### PR TITLE
fix(avroc): cross-platform PATH parsing for generator discovery

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,3 +61,7 @@ jobs:
         - name: Run example
           shell: bash
           run: avroc -go_out=example/gen -go_opt=package_name=avro -go_opt=encoding=single_object -json_out=example -pcf_out=example/pcf example/schema.avdl
+
+        - name: Verify example output is up to date
+          shell: bash
+          run: git diff --exit-code -- example

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,10 +46,13 @@ jobs:
         - name: Build example binaries
           shell: bash
           run: |
-            go build -o ./bin/avroc ./cmd/avroc
-            go build -o ./bin/avroc-gen-go ./cmd/avroc-gen-go
-            go build -o ./bin/avroc-gen-json ./cmd/avroc-gen-json
-            go build -o ./bin/avroc-gen-pcf ./cmd/avroc-gen-pcf
+            ext=""
+            if [ "${{ matrix.os }}" = "windows-latest" ]; then ext=".exe"; fi
+            go build -o "./bin/avroc${ext}" ./cmd/avroc
+            go build -o "./bin/avroc-gen-go${ext}" ./cmd/avroc-gen-go
+            go build -o "./bin/avroc-gen-json${ext}" ./cmd/avroc-gen-json
+            go build -o "./bin/avroc-gen-pcf${ext}" ./cmd/avroc-gen-pcf
+            ls -la ./bin
 
         - name: Add bin to PATH
           shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/build.yaml'
   pull_request:
     branches:
       - "main"
@@ -16,7 +17,11 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
         - name: Checkout
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -26,6 +31,7 @@ jobs:
             go-version-file: go.mod
 
         - name: Lint Go Code
+          if: matrix.os == 'ubuntu-latest'
           uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
           with:
             version: latest
@@ -36,3 +42,19 @@ jobs:
 
         - name: Test
           run: go test -race -cover ./...
+
+        - name: Build example binaries
+          shell: bash
+          run: |
+            go build -o ./bin/avroc ./cmd/avroc
+            go build -o ./bin/avroc-gen-go ./cmd/avroc-gen-go
+            go build -o ./bin/avroc-gen-json ./cmd/avroc-gen-json
+            go build -o ./bin/avroc-gen-pcf ./cmd/avroc-gen-pcf
+
+        - name: Add bin to PATH
+          shell: bash
+          run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+
+        - name: Run example
+          shell: bash
+          run: avroc -go_out=example/gen -go_opt=package_name=avro -go_opt=encoding=single_object -json_out=example -pcf_out=example/pcf example/schema.avdl

--- a/cmd/avroc-gen-go/main.go
+++ b/cmd/avroc-gen-go/main.go
@@ -27,7 +27,6 @@ func main() {
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),
-		Fs:   os.DirFS("/"),
 		Args: os.Args[1:],
 	})
 	os.Exit(code)

--- a/cmd/avroc-gen-json/main.go
+++ b/cmd/avroc-gen-json/main.go
@@ -27,7 +27,6 @@ func main() {
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),
-		Fs:   os.DirFS("/"),
 		Args: os.Args[1:],
 	})
 	os.Exit(code)

--- a/cmd/avroc-gen-pcf/main.go
+++ b/cmd/avroc-gen-pcf/main.go
@@ -27,7 +27,6 @@ func main() {
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),
-		Fs:   os.DirFS("/"),
 		Args: os.Args[1:],
 	})
 	os.Exit(code)

--- a/cmd/avroc/main.go
+++ b/cmd/avroc/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -27,8 +28,8 @@ func main() {
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),
-		Fs:   os.DirFS("/"),
-		Args: os.Args[1:],
+		OpenDir: func(dir string) fs.FS { return os.DirFS(dir) },
+		Args:    os.Args[1:],
 	})
 	os.Exit(code)
 }

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -16,6 +16,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -41,8 +42,8 @@ func Main(ctx context.Context, cli cli.Context) int {
 		return 1
 	}
 
-	paths := strings.Split(path, ":")
-	generators, err := lookupGenerators(ctx, cli.Log, cli.Fs, paths...)
+	paths := filepath.SplitList(path)
+	generators, err := lookupGenerators(ctx, cli.Log, cli.OpenDir, paths...)
 	if err != nil {
 		cli.Log.ErrorContext(ctx, "failed to lookup generators", slog.Any("error", err))
 		return 1
@@ -154,47 +155,33 @@ func Main(ctx context.Context, cli cli.Context) int {
 	return 0
 }
 
-func lookupGenerators(ctx context.Context, log *slog.Logger, root fs.FS, dirs ...string) (map[string]string, error) {
+func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string) fs.FS, dirs ...string) (map[string]string, error) {
 	generatorIndex := make(map[string]string)
 
 	for _, dir := range dirs {
-		dir = strings.TrimPrefix(dir, "/")
-
-		err := fs.WalkDir(root, dir, func(path string, d fs.DirEntry, err error) error {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil
-			}
-			if errors.Is(err, fs.ErrPermission) {
-				log.WarnContext(ctx, "skipping path due to permission error", slog.String("path", path), slog.Any("error", err))
-				if d != nil && d.IsDir() {
-					return fs.SkipDir
-				}
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-
-			name := d.Name()
-			if !strings.HasPrefix(name, "avroc-gen-") {
-				return nil
-			}
-
-			info, infoErr := d.Info()
-			if infoErr != nil {
-				return nil
-			}
-
-			mode := info.Mode()
-			if !mode.IsRegular() || mode&0o111 == 0 {
-				return nil
-			}
-
-			generatorIndex[name] = "/" + path
-			return nil
-		})
+		fsys := openDir(dir)
+		entries, err := fs.ReadDir(fsys, ".")
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if errors.Is(err, fs.ErrPermission) {
+			log.WarnContext(ctx, "skipping path due to permission error", slog.String("path", dir), slog.Any("error", err))
+			continue
+		}
 		if err != nil {
 			return nil, err
+		}
+
+		for _, entry := range entries {
+			name := entry.Name()
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				continue
+			}
+			if !isGeneratorExecutable(name, info.Mode()) {
+				continue
+			}
+			generatorIndex[generatorKey(name)] = filepath.Join(dir, name)
 		}
 	}
 

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -14,6 +14,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"maps"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -303,8 +304,16 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 		_ = cmd.Wait()
 	}()
 
+	// Use the passthrough resolver with a custom dialer rather than "unix://".
+	// gRPC's URL-based target parsing mishandles Windows absolute paths (the
+	// drive-letter colon is read as host:port); passthrough hands the address
+	// to the dialer verbatim so the socket path is never URL-parsed.
 	cc, err := grpc.NewClient(
-		"unix://"+socketPath,
+		"passthrough:///"+socketPath,
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", addr)
+		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -592,6 +593,12 @@ func (s *testGeneratorServer) Generate(_ context.Context, req *avrocpb.GenerateR
 }
 
 func TestGeneratorGenerate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// gRPC's unix:// resolver cannot parse Windows absolute socket paths
+		// (drive-letter colon is read as host:port). Tracked separately; see #49.
+		t.Skip("unix socket transport not supported on Windows")
+	}
+
 	t.Setenv("AVROC_TEST_GENERATOR", "1")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -588,12 +587,6 @@ func (s *testGeneratorServer) Generate(_ context.Context, req *avrocpb.GenerateR
 }
 
 func TestGeneratorGenerate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// gRPC's unix:// resolver cannot parse Windows absolute socket paths
-		// (drive-letter colon is read as host:port). Tracked separately; see #49.
-		t.Skip("unix socket transport not supported on Windows")
-	}
-
 	t.Setenv("AVROC_TEST_GENERATOR", "1")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -13,8 +13,8 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -272,13 +272,16 @@ func TestMapToProtoSchema_EnumNilDefault(t *testing.T) {
 }
 
 func TestLookupGenerators(t *testing.T) {
-	t.Run("finds executable generators", func(t *testing.T) {
+	discardLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := filepath.Join(string(filepath.Separator), "usr", "local", "bin")
+
+	t.Run("finds generator executables", func(t *testing.T) {
 		fsys := fstest.MapFS{
-			"usr/local/bin/avroc-gen-go": &fstest.MapFile{Mode: 0o755},
-			"usr/local/bin/other-tool":   &fstest.MapFile{Mode: 0o755},
+			generatorFixtureName("avroc-gen-go"): generatorFixtureFile(),
+			"other-tool":                         generatorFixtureFile(),
 		}
 
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "usr/local/bin")
+		got, err := lookupGenerators(context.Background(), discardLog, staticOpenDir(fsys), dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,18 +289,19 @@ func TestLookupGenerators(t *testing.T) {
 		if len(got) != 1 {
 			t.Fatalf("got %d generators, want 1", len(got))
 		}
-		if got["avroc-gen-go"] != "/usr/local/bin/avroc-gen-go" {
-			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], "/usr/local/bin/avroc-gen-go")
+		want := filepath.Join(dir, generatorFixtureName("avroc-gen-go"))
+		if got["avroc-gen-go"] != want {
+			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], want)
 		}
 	})
 
 	t.Run("multiple generators in same directory", func(t *testing.T) {
 		fsys := fstest.MapFS{
-			"bin/avroc-gen-go":   &fstest.MapFile{Mode: 0o755},
-			"bin/avroc-gen-java": &fstest.MapFile{Mode: 0o755},
+			generatorFixtureName("avroc-gen-go"):   generatorFixtureFile(),
+			generatorFixtureName("avroc-gen-java"): generatorFixtureFile(),
 		}
 
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "bin")
+		got, err := lookupGenerators(context.Background(), discardLog, staticOpenDir(fsys), dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,12 +312,19 @@ func TestLookupGenerators(t *testing.T) {
 	})
 
 	t.Run("multiple directories", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			"dir1/avroc-gen-go":   &fstest.MapFile{Mode: 0o755},
-			"dir2/avroc-gen-java": &fstest.MapFile{Mode: 0o755},
+		dir1 := filepath.Join(string(filepath.Separator), "dir1")
+		dir2 := filepath.Join(string(filepath.Separator), "dir2")
+		openDir := func(d string) fs.FS {
+			switch d {
+			case dir1:
+				return fstest.MapFS{generatorFixtureName("avroc-gen-go"): generatorFixtureFile()}
+			case dir2:
+				return fstest.MapFS{generatorFixtureName("avroc-gen-java"): generatorFixtureFile()}
+			}
+			return fstest.MapFS{}
 		}
 
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "dir1", "dir2")
+		got, err := lookupGenerators(context.Background(), discardLog, openDir, dir1, dir2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -321,27 +332,18 @@ func TestLookupGenerators(t *testing.T) {
 		if len(got) != 2 {
 			t.Fatalf("got %d generators, want 2", len(got))
 		}
-	})
-
-	t.Run("skips non-executable files", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			"bin/avroc-gen-go": &fstest.MapFile{Mode: 0o644},
+		if got["avroc-gen-go"] != filepath.Join(dir1, generatorFixtureName("avroc-gen-go")) {
+			t.Errorf("avroc-gen-go path = %q", got["avroc-gen-go"])
 		}
-
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "bin")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(got) != 0 {
-			t.Fatalf("got %d generators, want 0 (file not executable)", len(got))
+		if got["avroc-gen-java"] != filepath.Join(dir2, generatorFixtureName("avroc-gen-java")) {
+			t.Errorf("avroc-gen-java path = %q", got["avroc-gen-java"])
 		}
 	})
 
 	t.Run("nonexistent directory", func(t *testing.T) {
-		fsys := fstest.MapFS{}
+		openDir := func(string) fs.FS { return &errFS{err: fs.ErrNotExist} }
 
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "nonexistent")
+		got, err := lookupGenerators(context.Background(), discardLog, openDir, "nonexistent")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -352,11 +354,7 @@ func TestLookupGenerators(t *testing.T) {
 	})
 
 	t.Run("empty directory", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			"bin": &fstest.MapFile{Mode: 0o755 | os.ModeDir},
-		}
-
-		got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), fsys, "bin")
+		got, err := lookupGenerators(context.Background(), discardLog, staticOpenDir(fstest.MapFS{}), dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -367,17 +365,18 @@ func TestLookupGenerators(t *testing.T) {
 	})
 
 	t.Run("skips directory with permission error and continues", func(t *testing.T) {
-		fsys := &permErrorFS{
-			MapFS: fstest.MapFS{
-				"bin/avroc-gen-go": &fstest.MapFile{Mode: 0o755},
-			},
-			restrictedPath: "restricted",
+		restricted := filepath.Join(string(filepath.Separator), "restricted")
+		openDir := func(d string) fs.FS {
+			if d == restricted {
+				return &errFS{err: fs.ErrPermission}
+			}
+			return fstest.MapFS{generatorFixtureName("avroc-gen-go"): generatorFixtureFile()}
 		}
 
 		var logBuf bytes.Buffer
 		log := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-		got, err := lookupGenerators(context.Background(), log, fsys, "restricted", "bin")
+		got, err := lookupGenerators(context.Background(), log, openDir, restricted, dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -385,35 +384,31 @@ func TestLookupGenerators(t *testing.T) {
 		if len(got) != 1 {
 			t.Fatalf("got %d generators, want 1", len(got))
 		}
-		if got["avroc-gen-go"] != "/bin/avroc-gen-go" {
-			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], "/bin/avroc-gen-go")
+		want := filepath.Join(dir, generatorFixtureName("avroc-gen-go"))
+		if got["avroc-gen-go"] != want {
+			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], want)
 		}
-
 		if !bytes.Contains(logBuf.Bytes(), []byte("permission")) {
 			t.Errorf("expected warning log for permission error, got: %s", logBuf.String())
 		}
 	})
 }
 
-// permErrorFS wraps a fstest.MapFS and returns fs.ErrPermission when opening paths
-// that match or are nested under restrictedPath.
-type permErrorFS struct {
-	fstest.MapFS
-	restrictedPath string
+func staticOpenDir(fsys fs.FS) func(string) fs.FS {
+	return func(string) fs.FS { return fsys }
 }
 
-func (f *permErrorFS) Open(name string) (fs.File, error) {
-	if name == f.restrictedPath || strings.HasPrefix(name, f.restrictedPath+"/") {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrPermission}
-	}
-	return f.MapFS.Open(name)
+// errFS implements fs.FS and returns a fixed error for every operation.
+// Used to simulate real-filesystem failure modes (ErrNotExist, ErrPermission)
+// that MapFS cannot otherwise produce.
+type errFS struct{ err error }
+
+func (f *errFS) Open(name string) (fs.File, error) {
+	return nil, &fs.PathError{Op: "open", Path: name, Err: f.err}
 }
 
-func (f *permErrorFS) Stat(name string) (fs.FileInfo, error) {
-	if name == f.restrictedPath || strings.HasPrefix(name, f.restrictedPath+"/") {
-		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrPermission}
-	}
-	return f.MapFS.Stat(name)
+func (f *errFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return nil, &fs.PathError{Op: "read", Path: name, Err: f.err}
 }
 
 func TestPrintHelp(t *testing.T) {
@@ -542,8 +537,8 @@ func TestMain_NoIDLFiles(t *testing.T) {
 			}
 			return "", false
 		}),
-		Fs:   fstest.MapFS{},
-		Args: []string{},
+		OpenDir: staticOpenDir(fstest.MapFS{}),
+		Args:    []string{},
 	})
 
 	if code != 1 {

--- a/internal/avroc/avroc_unix.go
+++ b/internal/avroc/avroc_unix.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+//go:build !windows
+
+package avroc
+
+import (
+	"io/fs"
+	"strings"
+)
+
+func isGeneratorExecutable(name string, mode fs.FileMode) bool {
+	return strings.HasPrefix(name, "avroc-gen-") && mode.IsRegular() && mode&0o111 != 0
+}
+
+func generatorKey(name string) string {
+	return name
+}

--- a/internal/avroc/avroc_unix_test.go
+++ b/internal/avroc/avroc_unix_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+//go:build !windows
+
+package avroc
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"testing/fstest"
+)
+
+func generatorFixtureName(base string) string { return base }
+
+func generatorFixtureFile() *fstest.MapFile {
+	return &fstest.MapFile{Mode: 0o755}
+}
+
+func TestLookupGenerators_Unix_SkipsNonExecutable(t *testing.T) {
+	fsys := fstest.MapFS{
+		"avroc-gen-go": &fstest.MapFile{Mode: 0o644},
+	}
+
+	got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), staticOpenDir(fsys), "/bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("got %d generators, want 0 (file not executable)", len(got))
+	}
+}

--- a/internal/avroc/avroc_windows.go
+++ b/internal/avroc/avroc_windows.go
@@ -3,6 +3,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+//go:build windows
+
 package avroc
 
 import (
@@ -11,8 +13,8 @@ import (
 	"strings"
 )
 
-func isGeneratorExecutable(name string, _ fs.FileMode) bool {
-	return strings.HasPrefix(name, "avroc-gen-") && strings.EqualFold(filepath.Ext(name), ".exe")
+func isGeneratorExecutable(name string, mode fs.FileMode) bool {
+	return mode.IsRegular() && strings.HasPrefix(name, "avroc-gen-") && strings.EqualFold(filepath.Ext(name), ".exe")
 }
 
 func generatorKey(name string) string {

--- a/internal/avroc/avroc_windows.go
+++ b/internal/avroc/avroc_windows.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+func isGeneratorExecutable(name string, _ fs.FileMode) bool {
+	return strings.HasPrefix(name, "avroc-gen-") && strings.EqualFold(filepath.Ext(name), ".exe")
+}
+
+func generatorKey(name string) string {
+	return strings.TrimSuffix(name, filepath.Ext(name))
+}

--- a/internal/avroc/avroc_windows_test.go
+++ b/internal/avroc/avroc_windows_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+//go:build windows
+
+package avroc
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func generatorFixtureName(base string) string { return base + ".exe" }
+
+func generatorFixtureFile() *fstest.MapFile {
+	return &fstest.MapFile{}
+}
+
+func TestLookupGenerators_Windows_RequiresExeSuffix(t *testing.T) {
+	fsys := fstest.MapFS{
+		"avroc-gen-go":     &fstest.MapFile{},
+		"avroc-gen-go.exe": &fstest.MapFile{},
+	}
+
+	got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), staticOpenDir(fsys), `C:\bin`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d generators, want 1", len(got))
+	}
+	if want := filepath.Join(`C:\bin`, "avroc-gen-go.exe"); got["avroc-gen-go"] != want {
+		t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], want)
+	}
+}
+
+func TestLookupGenerators_Windows_CaseInsensitiveExt(t *testing.T) {
+	fsys := fstest.MapFS{
+		"avroc-gen-go.EXE": &fstest.MapFile{},
+	}
+
+	got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), staticOpenDir(fsys), `C:\bin`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d generators, want 1", len(got))
+	}
+	if _, ok := got["avroc-gen-go"]; !ok {
+		t.Errorf("expected key avroc-gen-go, got keys: %v", got)
+	}
+}
+
+func TestLookupGenerators_Windows_IgnoresExecBit(t *testing.T) {
+	// On Windows the 0o111 bit is meaningless; a .exe file with no mode
+	// bits set must still be discovered.
+	fsys := fstest.MapFS{
+		"avroc-gen-go.exe": &fstest.MapFile{Mode: 0},
+	}
+
+	got, err := lookupGenerators(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), staticOpenDir(fsys), `C:\bin`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d generators, want 1 (exec bit must be ignored)", len(got))
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,8 +21,8 @@ func (f EnvironmentFunc) LookupEnv(key string) (string, bool) {
 }
 
 type Context struct {
-	Log  *slog.Logger
-	Env  Environment
-	Fs   fs.FS
-	Args []string
+	Log     *slog.Logger
+	Env     Environment
+	OpenDir func(dir string) fs.FS
+	Args    []string
 }


### PR DESCRIPTION
## Summary
Closes #49.

- Replace hardcoded `strings.Split(path, ":")` with `filepath.SplitList` so the OS-native PATH separator is used.
- Replace the single-root `cli.Context.Fs = os.DirFS("/")` with a per-directory factory `cli.Context.OpenDir`, so discovery spans Windows drive letters.
- Drop recursive walk — PATH discovery is top-level (matches `protoc`); OS-specific predicates pick matching executables: `0o111` bit on Unix, `.exe` suffix (case-insensitive) on Windows with the suffix stripped from the map key.
- Switch gRPC plugin dial from `unix://` to the `passthrough:` resolver with a custom dialer. The prior target URL-parse rejected Windows absolute paths with `too many colons in address`; the dialer now calls `net.Dial("unix", addr)` directly.
- Expand the CI build job into an OS matrix (ubuntu, macos, windows) and run the example end-to-end on each.

## Test plan
- [x] ubuntu-latest CI: build + test + run example → green
- [x] macos-latest CI: build + test + run example → green
- [x] windows-latest CI: build + test + run example → green
- [x] New Windows-only unit tests cover `.exe` suffix requirement, case-insensitive matching, and exec-bit-independence
- [x] Existing Unix exec-bit-skip test preserved in a build-tagged `_unix_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)