### PR TITLE
story(generator): stream generated files back to avroc (location-transparent plugin contract)

### DIFF
--- a/internal/avroc-gen-go/generate.go
+++ b/internal/avroc-gen-go/generate.go
@@ -6,11 +6,8 @@
 package avrocgengo
 
 import (
-	"context"
 	"fmt"
 	"go/format"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
@@ -20,18 +17,9 @@ type generatorService struct {
 	avrocpb.UnimplementedGeneratorServer
 }
 
-// Generate implements the Generator gRPC service method.
-func (s *generatorService) Generate(ctx context.Context, req *avrocpb.GenerateRequest) (*avrocpb.GenerateResponse, error) {
-	outputDir := req.GetOutputDirectory()
-	if outputDir == "" {
-		return nil, fmt.Errorf("output directory is required")
-	}
-
-	// Ensure output directory exists
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-
+// Generate implements the Generator gRPC service method, streaming each
+// generated file back to avroc, which performs the filesystem writes.
+func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
 	var packageName string
 	var encoding string
 	for _, opt := range req.GetOptions() {
@@ -43,31 +31,57 @@ func (s *generatorService) Generate(ctx context.Context, req *avrocpb.GenerateRe
 		}
 	}
 	if packageName == "" {
-		return nil, fmt.Errorf("package_name option is required")
+		return fmt.Errorf("package_name option is required")
 	}
 
 	singleObject := encoding == "single_object"
 	if encoding != "" && !singleObject {
-		return nil, fmt.Errorf("unsupported encoding option: %q (supported: single_object)", encoding)
+		return fmt.Errorf("unsupported encoding option: %q (supported: single_object)", encoding)
 	}
-
-	var outputFiles []string
 
 	for _, schema := range req.Schemas {
-		filename, err := generateSchemaFile(outputDir, packageName, schema, singleObject)
+		filename, content, err := buildSchemaFile(packageName, schema, singleObject)
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate schema: %w", err)
+			return fmt.Errorf("failed to generate schema: %w", err)
 		}
-		outputFiles = append(outputFiles, filename)
+		if err := sendFile(stream, filename, content); err != nil {
+			return err
+		}
 	}
 
-	return &avrocpb.GenerateResponse{
-		OutputFiles: outputFiles,
-	}, nil
+	return nil
 }
 
-// generateSchemaFile generates a Go file for a single schema.
-func generateSchemaFile(outputDir string, packageName string, schema *avrocpb.Schema, singleObject bool) (string, error) {
+// maxChunkSize bounds each streamed GenerateResponse so messages stay well
+// under gRPC's 4MB default MaxRecvMsgSize.
+const maxChunkSize = 1 << 20 // 1 MiB
+
+// sendFile streams content to avroc as one or more chunks sharing path, with
+// last set on the final chunk. Empty content emits a single terminating chunk.
+func sendFile(stream avrocpb.Generator_GenerateServer, path string, content []byte) error {
+	for {
+		n := min(len(content), maxChunkSize)
+		chunk := content[:n]
+		content = content[n:]
+		last := len(content) == 0
+
+		err := stream.Send(&avrocpb.GenerateResponse{
+			Path:    &path,
+			Content: chunk,
+			Last:    &last,
+		})
+		if err != nil {
+			return err
+		}
+		if last {
+			return nil
+		}
+	}
+}
+
+// buildSchemaFile generates the Go source for a single schema, returning its
+// relative filename and formatted content.
+func buildSchemaFile(packageName string, schema *avrocpb.Schema, singleObject bool) (string, []byte, error) {
 	// Compute fingerprint before code generation if single-object encoding is requested.
 	var fp [8]byte
 	if singleObject {
@@ -79,20 +93,14 @@ func generateSchemaFile(outputDir string, packageName string, schema *avrocpb.Sc
 
 	// Determine the filename from the schema
 	filename := schemaFilename(schema)
-	outputPath := filepath.Join(outputDir, filename)
 
 	// Format the code using go/format
 	formatted, err := format.Source([]byte(code))
 	if err != nil {
-		return "", fmt.Errorf("failed to format generated code for %s: %w", outputPath, err)
+		return "", nil, fmt.Errorf("failed to format generated code for %s: %w", filename, err)
 	}
 
-	// Write the file
-	if err := os.WriteFile(outputPath, formatted, 0o644); err != nil {
-		return "", fmt.Errorf("failed to write file %s: %w", outputPath, err)
-	}
-
-	return outputPath, nil
+	return filename, formatted, nil
 }
 
 // schemaFilename determines the output filename for a schema.

--- a/internal/avroc-gen-go/generate_test.go
+++ b/internal/avroc-gen-go/generate_test.go
@@ -6,11 +6,9 @@
 package avrocgengo
 
 import (
-	"context"
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,10 +57,9 @@ func TestGenerate_Record(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -119,10 +116,9 @@ func TestGenerate_Enum(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -174,10 +170,9 @@ func TestGenerate_Fixed(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -236,10 +231,9 @@ func TestGenerate_Union(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -305,10 +299,9 @@ func TestGenerate_Array(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -364,10 +357,9 @@ func TestGenerate_Map(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -432,10 +424,9 @@ func TestGenerate_MultipleTypes(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -462,17 +453,6 @@ func TestGenerate_MultipleTypes(t *testing.T) {
 		if !strings.Contains(code, exp) {
 			t.Errorf("expected generated code to contain %q, got:\n%s", exp, code)
 		}
-	}
-}
-
-func TestGenerate_EmptyOutputDirectory(t *testing.T) {
-	svc := &generatorService{}
-	_, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(""),
-		Schemas:         []*avrocpb.Schema{},
-	})
-	if err == nil {
-		t.Fatal("expected error for empty output directory")
 	}
 }
 
@@ -528,48 +508,6 @@ func TestSchemaFilename(t *testing.T) {
 	}
 }
 
-func TestGenerate_CreatesOutputDirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	outputDir := filepath.Join(tmpDir, "nested", "output")
-
-	schema := &avrocpb.Schema{
-		Type: &avrocpb.Type{
-			Type: &avrocpb.Type_Record{
-				Record: &avrocpb.Record{
-					Name: proto.String("Test"),
-					Fields: []*avrocpb.Field{
-						{
-							Name: proto.String("value"),
-							Type: &avrocpb.Type{
-								Type: &avrocpb.Type_Ident{Ident: &avrocpb.Ident{Value: proto.String("string")}},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(outputDir),
-		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
-	})
-	if err != nil {
-		t.Fatalf("Generate failed: %v", err)
-	}
-
-	if len(resp.OutputFiles) != 1 {
-		t.Fatalf("expected 1 output file, got %d", len(resp.OutputFiles))
-	}
-
-	// Verify the file exists
-	if _, err := os.Stat(resp.OutputFiles[0]); os.IsNotExist(err) {
-		t.Errorf("output file does not exist: %s", resp.OutputFiles[0])
-	}
-}
-
 func TestGenerate_PackageNameOption(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -593,8 +531,7 @@ func TestGenerate_PackageNameOption(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{
 			{
 				Name:  proto.String("package_name"),
@@ -651,9 +588,8 @@ func TestGenerate_MissingPackageName(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	_, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	_, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err == nil {
 		t.Fatal("expected error when package_name option is not set")
@@ -689,8 +625,7 @@ func TestGenerate_SingleObjectEncoding(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{
 			{Name: proto.String("package_name"), Value: proto.String("avro")},
 			{Name: proto.String("encoding"), Value: proto.String("single_object")},
@@ -785,10 +720,9 @@ func TestGenerate_WithoutEncodingOption_NoFingerprint(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -828,8 +762,7 @@ func TestGenerate_InvalidEncodingOption(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	_, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	_, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{
 			{Name: proto.String("package_name"), Value: proto.String("avro")},
 			{Name: proto.String("encoding"), Value: proto.String("invalid_value")},

--- a/internal/avroc-gen-go/marshal_test.go
+++ b/internal/avroc-gen-go/marshal_test.go
@@ -6,7 +6,6 @@
 package avrocgengo
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -44,10 +43,9 @@ func TestMarshal_Record(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -95,10 +93,9 @@ func TestMarshal_Fixed(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -145,10 +142,9 @@ func TestMarshal_Enum(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -207,10 +203,9 @@ func TestMarshal_Union(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -278,10 +273,9 @@ func TestMarshal_ArrayField(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -341,10 +335,9 @@ func TestMarshal_MapField(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -425,10 +418,9 @@ func TestMarshal_NestedRecord(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -517,10 +509,9 @@ func TestMarshal_AllPrimitiveTypes(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -569,10 +560,9 @@ func TestMarshal_EmptyRecord(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)

--- a/internal/avroc-gen-go/stream_test.go
+++ b/internal/avroc-gen-go/stream_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+
+	"google.golang.org/grpc"
+)
+
+// captureStream is a server stream that records the GenerateResponse chunks a
+// generator sends, for use in tests.
+type captureStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	msgs []*avrocpb.GenerateResponse
+}
+
+func (c *captureStream) Send(m *avrocpb.GenerateResponse) error {
+	c.msgs = append(c.msgs, m)
+	return nil
+}
+
+func (c *captureStream) Context() context.Context { return c.ctx }
+
+// genResult mirrors the file paths a generation produced, matching the shape
+// the tests previously asserted against.
+type genResult struct {
+	OutputFiles []string
+}
+
+// generateToDir runs svc.Generate against a capture stream, reassembles the
+// streamed chunks per path, and writes the files under dir exactly as avroc
+// would, returning their full paths in emission order.
+func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
+	t.Helper()
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := svc.Generate(req, cs); err != nil {
+		return nil, err
+	}
+
+	contents := make(map[string][]byte)
+	var order []string
+	for _, m := range cs.msgs {
+		p := m.GetPath()
+		if _, ok := contents[p]; !ok {
+			order = append(order, p)
+		}
+		contents[p] = append(contents[p], m.GetContent()...)
+	}
+
+	res := &genResult{}
+	for _, p := range order {
+		full := filepath.Join(dir, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(full, contents[p], 0o644); err != nil {
+			return nil, err
+		}
+		res.OutputFiles = append(res.OutputFiles, full)
+	}
+
+	return res, nil
+}

--- a/internal/avroc-gen-go/stream_test.go
+++ b/internal/avroc-gen-go/stream_test.go
@@ -50,12 +50,26 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 
 	contents := make(map[string][]byte)
 	var order []string
+	done := make(map[string]bool)
 	for _, m := range cs.msgs {
 		p := m.GetPath()
+		// Enforce the streaming contract: last=true terminates a file, and no
+		// further chunks may reference that path afterwards.
+		if done[p] {
+			t.Fatalf("generator sent a chunk for path %q after it was terminated with last=true", p)
+		}
 		if _, ok := contents[p]; !ok {
 			order = append(order, p)
 		}
 		contents[p] = append(contents[p], m.GetContent()...)
+		if m.GetLast() {
+			done[p] = true
+		}
+	}
+	for _, p := range order {
+		if !done[p] {
+			t.Fatalf("generator never terminated path %q with last=true", p)
+		}
 	}
 
 	res := &genResult{}

--- a/internal/avroc-gen-go/unmarshal_test.go
+++ b/internal/avroc-gen-go/unmarshal_test.go
@@ -6,7 +6,6 @@
 package avrocgengo
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -44,10 +43,9 @@ func TestUnmarshal_Record(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -94,10 +92,9 @@ func TestUnmarshal_Fixed(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -144,10 +141,9 @@ func TestUnmarshal_Enum(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -206,10 +202,9 @@ func TestUnmarshal_Union(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -280,10 +275,9 @@ func TestUnmarshal_ArrayField(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -343,10 +337,9 @@ func TestUnmarshal_MapField(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -425,10 +418,9 @@ func TestUnmarshal_NestedRecord(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -515,10 +507,9 @@ func TestUnmarshal_AllPrimitiveTypes(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -566,10 +557,9 @@ func TestUnmarshal_EmptyRecord(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Options:         []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)

--- a/internal/avroc-gen-json/generate.go
+++ b/internal/avroc-gen-json/generate.go
@@ -6,11 +6,8 @@
 package avrocgenjson
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
@@ -20,50 +17,60 @@ type generatorService struct {
 	avrocpb.UnimplementedGeneratorServer
 }
 
-// Generate implements the Generator gRPC service method.
-func (s *generatorService) Generate(ctx context.Context, req *avrocpb.GenerateRequest) (*avrocpb.GenerateResponse, error) {
-	outputDir := req.GetOutputDirectory()
-	if outputDir == "" {
-		return nil, fmt.Errorf("output directory is required")
-	}
-
-	// Ensure output directory exists
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	var outputFiles []string
-
+// Generate implements the Generator gRPC service method, streaming each
+// generated file back to avroc, which performs the filesystem writes.
+func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
 	for _, schema := range req.Schemas {
-		filename, err := generateSchemaFile(outputDir, schema)
+		filename, content, err := buildSchemaFile(schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate schema: %w", err)
+			return fmt.Errorf("failed to generate schema: %w", err)
 		}
-		outputFiles = append(outputFiles, filename)
+		if err := sendFile(stream, filename, content); err != nil {
+			return err
+		}
 	}
 
-	return &avrocpb.GenerateResponse{
-		OutputFiles: outputFiles,
-	}, nil
+	return nil
 }
 
-// generateSchemaFile generates an Avro JSON schema file for a single schema.
-func generateSchemaFile(outputDir string, schema *avrocpb.Schema) (string, error) {
+// buildSchemaFile generates the Avro JSON schema for a single schema, returning
+// its relative filename and content.
+func buildSchemaFile(schema *avrocpb.Schema) (string, []byte, error) {
 	jsonSchema := schemaToJSON(schema)
 
 	data, err := json.MarshalIndent(jsonSchema, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal JSON schema: %w", err)
+		return "", nil, fmt.Errorf("failed to marshal JSON schema: %w", err)
 	}
 
-	filename := schemaFilename(schema)
-	outputPath := filepath.Join(outputDir, filename)
+	return schemaFilename(schema), append(data, '\n'), nil
+}
 
-	if err := os.WriteFile(outputPath, append(data, '\n'), 0o644); err != nil {
-		return "", fmt.Errorf("failed to write file %s: %w", outputPath, err)
+// maxChunkSize bounds each streamed GenerateResponse so messages stay well
+// under gRPC's 4MB default MaxRecvMsgSize.
+const maxChunkSize = 1 << 20 // 1 MiB
+
+// sendFile streams content to avroc as one or more chunks sharing path, with
+// last set on the final chunk. Empty content emits a single terminating chunk.
+func sendFile(stream avrocpb.Generator_GenerateServer, path string, content []byte) error {
+	for {
+		n := min(len(content), maxChunkSize)
+		chunk := content[:n]
+		content = content[n:]
+		last := len(content) == 0
+
+		err := stream.Send(&avrocpb.GenerateResponse{
+			Path:    &path,
+			Content: chunk,
+			Last:    &last,
+		})
+		if err != nil {
+			return err
+		}
+		if last {
+			return nil
+		}
 	}
-
-	return outputPath, nil
 }
 
 // schemaConverter holds state for converting a protobuf Schema to Avro JSON,

--- a/internal/avroc-gen-json/generate_test.go
+++ b/internal/avroc-gen-json/generate_test.go
@@ -6,7 +6,6 @@
 package avrocgenjson
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -54,9 +53,8 @@ func TestGenerate_Record(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -133,9 +131,8 @@ func TestGenerate_Enum(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -199,9 +196,8 @@ func TestGenerate_EnumWithDefault(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -241,9 +237,8 @@ func TestGenerate_Fixed(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -307,9 +302,8 @@ func TestGenerate_Union(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -374,9 +368,8 @@ func TestGenerate_Array(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -436,9 +429,8 @@ func TestGenerate_Map(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -471,58 +463,6 @@ func TestGenerate_Map(t *testing.T) {
 	}
 }
 
-func TestGenerate_EmptyOutputDirectory(t *testing.T) {
-	svc := &generatorService{}
-	_, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(""),
-		Schemas:         []*avrocpb.Schema{},
-	})
-	if err == nil {
-		t.Fatal("expected error for empty output directory")
-	}
-}
-
-func TestGenerate_CreatesOutputDirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	outputDir := filepath.Join(tmpDir, "nested", "output")
-
-	schema := &avrocpb.Schema{
-		Type: &avrocpb.Type{
-			Type: &avrocpb.Type_Record{
-				Record: &avrocpb.Record{
-					Name: proto.String("Test"),
-					Fields: []*avrocpb.Field{
-						{
-							Name: proto.String("value"),
-							Type: &avrocpb.Type{
-								Type: &avrocpb.Type_Ident{Ident: &avrocpb.Ident{Value: proto.String("string")}},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(outputDir),
-		Schemas:         []*avrocpb.Schema{schema},
-	})
-	if err != nil {
-		t.Fatalf("Generate failed: %v", err)
-	}
-
-	if len(resp.OutputFiles) != 1 {
-		t.Fatalf("expected 1 output file, got %d", len(resp.OutputFiles))
-	}
-
-	// Verify the file exists
-	if _, err := os.Stat(resp.OutputFiles[0]); os.IsNotExist(err) {
-		t.Errorf("output file does not exist: %s", resp.OutputFiles[0])
-	}
-}
-
 func TestGenerate_RecordWithAliases(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -547,9 +487,8 @@ func TestGenerate_RecordWithAliases(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -652,9 +591,8 @@ func TestGenerate_RecordWithNamespaceInheritance(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -700,9 +638,8 @@ func TestGenerate_RecordWithOwnNamespace(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -799,9 +736,8 @@ func TestGenerate_IdentMainTypeResolvesFromTypes(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)

--- a/internal/avroc-gen-json/stream_test.go
+++ b/internal/avroc-gen-json/stream_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenjson
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+
+	"google.golang.org/grpc"
+)
+
+// captureStream is a server stream that records the GenerateResponse chunks a
+// generator sends, for use in tests.
+type captureStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	msgs []*avrocpb.GenerateResponse
+}
+
+func (c *captureStream) Send(m *avrocpb.GenerateResponse) error {
+	c.msgs = append(c.msgs, m)
+	return nil
+}
+
+func (c *captureStream) Context() context.Context { return c.ctx }
+
+// genResult mirrors the file paths a generation produced, matching the shape
+// the tests previously asserted against.
+type genResult struct {
+	OutputFiles []string
+}
+
+// generateToDir runs svc.Generate against a capture stream, reassembles the
+// streamed chunks per path, and writes the files under dir exactly as avroc
+// would, returning their full paths in emission order.
+func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
+	t.Helper()
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := svc.Generate(req, cs); err != nil {
+		return nil, err
+	}
+
+	contents := make(map[string][]byte)
+	var order []string
+	for _, m := range cs.msgs {
+		p := m.GetPath()
+		if _, ok := contents[p]; !ok {
+			order = append(order, p)
+		}
+		contents[p] = append(contents[p], m.GetContent()...)
+	}
+
+	res := &genResult{}
+	for _, p := range order {
+		full := filepath.Join(dir, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(full, contents[p], 0o644); err != nil {
+			return nil, err
+		}
+		res.OutputFiles = append(res.OutputFiles, full)
+	}
+
+	return res, nil
+}

--- a/internal/avroc-gen-json/stream_test.go
+++ b/internal/avroc-gen-json/stream_test.go
@@ -50,12 +50,26 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 
 	contents := make(map[string][]byte)
 	var order []string
+	done := make(map[string]bool)
 	for _, m := range cs.msgs {
 		p := m.GetPath()
+		// Enforce the streaming contract: last=true terminates a file, and no
+		// further chunks may reference that path afterwards.
+		if done[p] {
+			t.Fatalf("generator sent a chunk for path %q after it was terminated with last=true", p)
+		}
 		if _, ok := contents[p]; !ok {
 			order = append(order, p)
 		}
 		contents[p] = append(contents[p], m.GetContent()...)
+		if m.GetLast() {
+			done[p] = true
+		}
+	}
+	for _, p := range order {
+		if !done[p] {
+			t.Fatalf("generator never terminated path %q with last=true", p)
+		}
 	}
 
 	res := &genResult{}

--- a/internal/avroc-gen-pcf/generate.go
+++ b/internal/avroc-gen-pcf/generate.go
@@ -6,67 +6,75 @@
 package avrocgenpcf
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/z5labs/avroc/internal/avrocpb"
 	"github.com/z5labs/avro-go/canonical"
+	"github.com/z5labs/avroc/internal/avrocpb"
 )
 
 type generatorService struct {
 	avrocpb.UnimplementedGeneratorServer
 }
 
-// Generate implements the Generator gRPC service method.
-func (s *generatorService) Generate(ctx context.Context, req *avrocpb.GenerateRequest) (*avrocpb.GenerateResponse, error) {
-	outputDir := req.GetOutputDirectory()
-	if outputDir == "" {
-		return nil, fmt.Errorf("output directory is required")
-	}
-
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	var outputFiles []string
-
+// Generate implements the Generator gRPC service method, streaming each
+// generated file back to avroc, which performs the filesystem writes.
+func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
 	for _, schema := range req.Schemas {
-		filename, err := generateSchemaFile(outputDir, schema)
+		filename, content, err := buildSchemaFile(schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate schema: %w", err)
+			return fmt.Errorf("failed to generate schema: %w", err)
 		}
-		outputFiles = append(outputFiles, filename)
+		if err := sendFile(stream, filename, content); err != nil {
+			return err
+		}
 	}
 
-	return &avrocpb.GenerateResponse{
-		OutputFiles: outputFiles,
-	}, nil
+	return nil
 }
 
-// generateSchemaFile generates an Avro Parsing Canonical Form file for a single schema.
-func generateSchemaFile(outputDir string, schema *avrocpb.Schema) (string, error) {
+// buildSchemaFile generates the Avro Parsing Canonical Form for a single schema,
+// returning its relative filename and content.
+func buildSchemaFile(schema *avrocpb.Schema) (string, []byte, error) {
 	cs, err := schemaToCanonical(schema)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert schema to canonical form: %w", err)
+		return "", nil, fmt.Errorf("failed to convert schema to canonical form: %w", err)
 	}
 
 	data, err := json.Marshal(cs)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal canonical schema: %w", err)
+		return "", nil, fmt.Errorf("failed to marshal canonical schema: %w", err)
 	}
 
-	filename := schemaFilename(schema)
-	outputPath := filepath.Join(outputDir, filename)
+	return schemaFilename(schema), data, nil
+}
 
-	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
-		return "", fmt.Errorf("failed to write file %s: %w", outputPath, err)
+// maxChunkSize bounds each streamed GenerateResponse so messages stay well
+// under gRPC's 4MB default MaxRecvMsgSize.
+const maxChunkSize = 1 << 20 // 1 MiB
+
+// sendFile streams content to avroc as one or more chunks sharing path, with
+// last set on the final chunk. Empty content emits a single terminating chunk.
+func sendFile(stream avrocpb.Generator_GenerateServer, path string, content []byte) error {
+	for {
+		n := min(len(content), maxChunkSize)
+		chunk := content[:n]
+		content = content[n:]
+		last := len(content) == 0
+
+		err := stream.Send(&avrocpb.GenerateResponse{
+			Path:    &path,
+			Content: chunk,
+			Last:    &last,
+		})
+		if err != nil {
+			return err
+		}
+		if last {
+			return nil
+		}
 	}
-
-	return outputPath, nil
 }
 
 // canonicalConverter converts protobuf schema types to the Avro Parsing Canonical Form.

--- a/internal/avroc-gen-pcf/generate_test.go
+++ b/internal/avroc-gen-pcf/generate_test.go
@@ -6,7 +6,6 @@
 package avrocgenpcf
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -44,9 +43,8 @@ func TestGenerate_Record(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -153,9 +151,8 @@ func TestGenerate_RecordWithNamedTypes(t *testing.T) {
 	}
 
 	svc := &generatorService{}
-	resp, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(tmpDir),
-		Schemas:         []*avrocpb.Schema{schema},
+	resp, err := generateToDir(t, svc, tmpDir, &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{schema},
 	})
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -235,17 +232,6 @@ func TestGenerate_RecordWithNamedTypes(t *testing.T) {
 	// MD5 was already defined, so it should be a reference string
 	if nullableHashTypes[1] != "org.apache.avro.test.MD5" {
 		t.Errorf("expected second union type=org.apache.avro.test.MD5, got %v", nullableHashTypes[1])
-	}
-}
-
-func TestGenerate_EmptyOutputDir(t *testing.T) {
-	svc := &generatorService{}
-	_, err := svc.Generate(context.Background(), &avrocpb.GenerateRequest{
-		OutputDirectory: proto.String(""),
-		Schemas:         []*avrocpb.Schema{},
-	})
-	if err == nil {
-		t.Fatal("expected error for empty output directory")
 	}
 }
 

--- a/internal/avroc-gen-pcf/stream_test.go
+++ b/internal/avroc-gen-pcf/stream_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenpcf
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+
+	"google.golang.org/grpc"
+)
+
+// captureStream is a server stream that records the GenerateResponse chunks a
+// generator sends, for use in tests.
+type captureStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	msgs []*avrocpb.GenerateResponse
+}
+
+func (c *captureStream) Send(m *avrocpb.GenerateResponse) error {
+	c.msgs = append(c.msgs, m)
+	return nil
+}
+
+func (c *captureStream) Context() context.Context { return c.ctx }
+
+// genResult mirrors the file paths a generation produced, matching the shape
+// the tests previously asserted against.
+type genResult struct {
+	OutputFiles []string
+}
+
+// generateToDir runs svc.Generate against a capture stream, reassembles the
+// streamed chunks per path, and writes the files under dir exactly as avroc
+// would, returning their full paths in emission order.
+func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
+	t.Helper()
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := svc.Generate(req, cs); err != nil {
+		return nil, err
+	}
+
+	contents := make(map[string][]byte)
+	var order []string
+	for _, m := range cs.msgs {
+		p := m.GetPath()
+		if _, ok := contents[p]; !ok {
+			order = append(order, p)
+		}
+		contents[p] = append(contents[p], m.GetContent()...)
+	}
+
+	res := &genResult{}
+	for _, p := range order {
+		full := filepath.Join(dir, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(full, contents[p], 0o644); err != nil {
+			return nil, err
+		}
+		res.OutputFiles = append(res.OutputFiles, full)
+	}
+
+	return res, nil
+}

--- a/internal/avroc-gen-pcf/stream_test.go
+++ b/internal/avroc-gen-pcf/stream_test.go
@@ -50,12 +50,26 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 
 	contents := make(map[string][]byte)
 	var order []string
+	done := make(map[string]bool)
 	for _, m := range cs.msgs {
 		p := m.GetPath()
+		// Enforce the streaming contract: last=true terminates a file, and no
+		// further chunks may reference that path afterwards.
+		if done[p] {
+			t.Fatalf("generator sent a chunk for path %q after it was terminated with last=true", p)
+		}
 		if _, ok := contents[p]; !ok {
 			order = append(order, p)
 		}
 		contents[p] = append(contents[p], m.GetContent()...)
+		if m.GetLast() {
+			done[p] = true
+		}
+	}
+	for _, p := range order {
+		if !done[p] {
+			t.Fatalf("generator never terminated path %q with last=true", p)
+		}
 	}
 
 	res := &genResult{}

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -345,17 +345,37 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 	return nil
 }
 
-// writeStream consumes the generator's server stream, reassembling each file
-// from its ordered chunks and writing it under output. Each path is validated
-// to stay within output before anything is written. It returns the OS-native
-// paths of the files written.
+// writeStream consumes the generator's server stream, writing each file's
+// ordered chunks directly to disk under output rather than buffering whole
+// files in memory. A path is validated to stay within output and its file is
+// created on the first chunk, so an unsafe or buggy generator cannot force
+// avroc to buffer arbitrary content before being rejected. A file is only
+// considered written once a chunk with last=true terminates it; the stream
+// ending with files still open, or any chunk arriving after a file's
+// terminating chunk, is reported as an error. It returns the OS-native paths
+// of the files written.
 func (g generator) writeStream(output string, stream avrocpb.Generator_GenerateClient) ([]string, error) {
-	pending := make(map[string][]byte)
+	open := make(map[string]*os.File)
+	finalized := make(map[string]struct{})
 	var written []string
+
+	// On any early return, discard files that never received their terminating
+	// chunk so partial/corrupt output is not left behind in the output tree.
+	defer func() {
+		for path, f := range open {
+			name := f.Name()
+			_ = f.Close()
+			_ = os.Remove(name)
+			delete(open, path)
+		}
+	}()
 
 	for {
 		msg, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
+			if len(open) > 0 {
+				return written, fmt.Errorf("generator %q closed the stream with %d unterminated file(s)", g.name, len(open))
+			}
 			return written, nil
 		}
 		if err != nil {
@@ -363,26 +383,41 @@ func (g generator) writeStream(output string, stream avrocpb.Generator_GenerateC
 		}
 
 		path := msg.GetPath()
-		pending[path] = append(pending[path], msg.GetContent()...)
+		if _, done := finalized[path]; done {
+			return written, fmt.Errorf("generator %q sent a chunk for already-completed file %q", g.name, path)
+		}
+
+		f, ok := open[path]
+		if !ok {
+			dst, err := safeOutputPath(output, path)
+			if err != nil {
+				return written, fmt.Errorf("generator %q returned unsafe path %q: %w", g.name, path, err)
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return written, fmt.Errorf("failed to create output directory for %q: %w", dst, err)
+			}
+			f, err = os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+			if err != nil {
+				return written, fmt.Errorf("failed to create file %q: %w", dst, err)
+			}
+			open[path] = f
+		}
+
+		if _, err := f.Write(msg.GetContent()); err != nil {
+			return written, fmt.Errorf("failed to write file %q: %w", f.Name(), err)
+		}
+
 		if !msg.GetLast() {
 			continue
 		}
 
-		content := pending[path]
-		delete(pending, path)
-
-		dst, err := safeOutputPath(output, path)
-		if err != nil {
-			return written, fmt.Errorf("generator %q returned unsafe path %q: %w", g.name, path, err)
+		name := f.Name()
+		delete(open, path)
+		finalized[path] = struct{}{}
+		if err := f.Close(); err != nil {
+			return written, fmt.Errorf("failed to close file %q: %w", name, err)
 		}
-
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return written, fmt.Errorf("failed to create output directory for %q: %w", dst, err)
-		}
-		if err := os.WriteFile(dst, content, 0o644); err != nil {
-			return written, fmt.Errorf("failed to write file %q: %w", dst, err)
-		}
-		written = append(written, dst)
+		written = append(written, name)
 	}
 }
 

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
@@ -324,22 +323,67 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 		err = errors.Join(err, cc.Close())
 	}()
 
-	rpcCtx, rpcCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer rpcCancel()
-
+	// No overall RPC timeout: a large streamed generation can legitimately run
+	// long. Cancellation flows from the signal-based parent context instead.
 	client := avrocpb.NewGeneratorClient(cc)
-	resp, err := client.Generate(rpcCtx, &avrocpb.GenerateRequest{
-		OutputDirectory: &output,
-		Options:         options,
-		Schemas:         schemas,
+	stream, err := client.Generate(ctx, &avrocpb.GenerateRequest{
+		Options: options,
+		Schemas: schemas,
 	})
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to generate code", slog.String("generator", g.name), slog.Any("error", err))
 		return err
 	}
 
-	g.log.InfoContext(ctx, "generated output", slog.String("generator", g.name), slog.Any("output_files", resp.GetOutputFiles()))
+	outputFiles, err := g.writeStream(output, stream)
+	if err != nil {
+		g.log.ErrorContext(ctx, "failed to write generated output", slog.String("generator", g.name), slog.Any("error", err))
+		return err
+	}
+
+	g.log.InfoContext(ctx, "generated output", slog.String("generator", g.name), slog.Any("output_files", outputFiles))
 	return nil
+}
+
+// writeStream consumes the generator's server stream, reassembling each file
+// from its ordered chunks and writing it under output. Each path is validated
+// to stay within output before anything is written. It returns the OS-native
+// paths of the files written.
+func (g generator) writeStream(output string, stream avrocpb.Generator_GenerateClient) ([]string, error) {
+	pending := make(map[string][]byte)
+	var written []string
+
+	for {
+		msg, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return written, nil
+		}
+		if err != nil {
+			return written, err
+		}
+
+		path := msg.GetPath()
+		pending[path] = append(pending[path], msg.GetContent()...)
+		if !msg.GetLast() {
+			continue
+		}
+
+		content := pending[path]
+		delete(pending, path)
+
+		dst, err := safeOutputPath(output, path)
+		if err != nil {
+			return written, fmt.Errorf("generator %q returned unsafe path %q: %w", g.name, path, err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return written, fmt.Errorf("failed to create output directory for %q: %w", dst, err)
+		}
+		if err := os.WriteFile(dst, content, 0o644); err != nil {
+			return written, fmt.Errorf("failed to write file %q: %w", dst, err)
+		}
+		written = append(written, dst)
+	}
 }
 
 func (g generator) startGenerator(ctx context.Context, socket string) (*exec.Cmd, error) {

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -715,6 +715,39 @@ func TestWriteStream(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("errors when the stream ends with an unterminated file", func(t *testing.T) {
+		root := t.TempDir()
+		path := "pkg/person.go"
+		last := func(b bool) *bool { return &b }
+		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
+			{Path: &path, Content: []byte("package pkg\n"), Last: last(false)},
+			// No terminating chunk: the stream just ends.
+		}}
+
+		if _, err := g.writeStream(root, stream); err == nil {
+			t.Fatal("expected error for unterminated file, got nil")
+		}
+
+		// The partial file must not be left behind in the output tree.
+		if _, err := os.Stat(filepath.Join(root, "pkg", "person.go")); !os.IsNotExist(err) {
+			t.Errorf("partial file was not discarded: %v", err)
+		}
+	})
+
+	t.Run("errors when a chunk follows a terminated file", func(t *testing.T) {
+		root := t.TempDir()
+		path := "person.go"
+		last := func(b bool) *bool { return &b }
+		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
+			{Path: &path, Content: []byte("package pkg\n"), Last: last(true)},
+			{Path: &path, Content: []byte("// extra\n"), Last: last(true)},
+		}}
+
+		if _, err := g.writeStream(root, stream); err == nil {
+			t.Fatal("expected error for chunk after termination, got nil")
+		}
+	})
 }
 
 func TestGeneratorGenerate_RejectsUnsafePath(t *testing.T) {

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -561,7 +561,7 @@ func TestHelperGenerator(t *testing.T) {
 	}
 
 	srv := grpc.NewServer(grpc.Creds(insecure.NewCredentials()))
-	avrocpb.RegisterGeneratorServer(srv, &testGeneratorServer{})
+	avrocpb.RegisterGeneratorServer(srv, &testGeneratorServer{path: os.Getenv("AVROC_TEST_GEN_PATH")})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -578,12 +578,20 @@ func TestHelperGenerator(t *testing.T) {
 
 type testGeneratorServer struct {
 	avrocpb.UnimplementedGeneratorServer
+	path string
 }
 
-func (s *testGeneratorServer) Generate(_ context.Context, req *avrocpb.GenerateRequest) (*avrocpb.GenerateResponse, error) {
-	return &avrocpb.GenerateResponse{
-		OutputFiles: []string{req.GetOutputDirectory() + "/output.go"},
-	}, nil
+func (s *testGeneratorServer) Generate(_ *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	path := s.path
+	if path == "" {
+		path = "output.go"
+	}
+	last := true
+	return stream.Send(&avrocpb.GenerateResponse{
+		Path:    &path,
+		Content: []byte("package main\n"),
+		Last:    &last,
+	})
 }
 
 func TestGeneratorGenerate(t *testing.T) {
@@ -629,6 +637,121 @@ func TestGeneratorGenerate(t *testing.T) {
 	err := g.generate(ctx, outputDir, nil, schema)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// avroc, not the generator, performs the write. Confirm the streamed file
+	// landed under the output directory.
+	written := filepath.Join(outputDir, "output.go")
+	if _, err := os.Stat(written); err != nil {
+		t.Errorf("expected generated file at %q: %v", written, err)
+	}
+}
+
+// fakeClientStream replays a fixed sequence of GenerateResponse messages,
+// implementing avrocpb.Generator_GenerateClient for writeStream tests.
+type fakeClientStream struct {
+	grpc.ClientStream
+	msgs []*avrocpb.GenerateResponse
+	i    int
+}
+
+func (f *fakeClientStream) Recv() (*avrocpb.GenerateResponse, error) {
+	if f.i >= len(f.msgs) {
+		return nil, io.EOF
+	}
+	m := f.msgs[f.i]
+	f.i++
+	return m, nil
+}
+
+func TestWriteStream(t *testing.T) {
+	g := generator{
+		log:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		name: "avroc-gen-test",
+	}
+
+	t.Run("writes reassembled file under output root", func(t *testing.T) {
+		root := t.TempDir()
+		path := "pkg/person.go"
+		last := func(b bool) *bool { return &b }
+		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
+			{Path: &path, Content: []byte("package pkg\n"), Last: last(false)},
+			{Path: &path, Content: []byte("// trailer\n"), Last: last(true)},
+		}}
+
+		written, err := g.writeStream(root, stream)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(written) != 1 {
+			t.Fatalf("expected 1 written file, got %d", len(written))
+		}
+
+		got, err := os.ReadFile(filepath.Join(root, "pkg", "person.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "package pkg\n// trailer\n"; string(got) != want {
+			t.Errorf("content = %q, want %q", string(got), want)
+		}
+	})
+
+	t.Run("rejects paths that escape the output root", func(t *testing.T) {
+		for _, bad := range []string{"../escape.go", "/etc/evil.go", "a/../../escape.go"} {
+			root := t.TempDir()
+			path := bad
+			last := true
+			stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
+				{Path: &path, Content: []byte("package x\n"), Last: &last},
+			}}
+
+			if _, err := g.writeStream(root, stream); err == nil {
+				t.Errorf("path %q: expected error, got nil", bad)
+			}
+
+			// Nothing must be written next to the output root.
+			if _, err := os.Stat(filepath.Join(filepath.Dir(root), "escape.go")); !os.IsNotExist(err) {
+				t.Errorf("path %q: file escaped the output root", bad)
+			}
+		}
+	})
+}
+
+func TestGeneratorGenerate_RejectsUnsafePath(t *testing.T) {
+	t.Setenv("AVROC_TEST_GENERATOR", "1")
+	t.Setenv("AVROC_TEST_GEN_PATH", "../escape.go")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	g := generator{
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			if key == "AVROC_GENERATOR_ARGS" {
+				return "-test.run=TestHelperGenerator --", true
+			}
+			return "", false
+		}),
+		name:           "avroc-gen-test",
+		executablePath: os.Args[0],
+	}
+
+	schema := &avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{Name: proto.String("User")},
+			},
+		},
+	}
+
+	outputDir := t.TempDir()
+	if err := g.generate(ctx, outputDir, nil, schema); err == nil {
+		t.Fatal("expected error for generator returning an escaping path")
+	}
+
+	if _, err := os.Stat(filepath.Join(filepath.Dir(outputDir), "escape.go")); !os.IsNotExist(err) {
+		t.Errorf("file escaped the output root")
 	}
 }
 

--- a/internal/avroc/validate.go
+++ b/internal/avroc/validate.go
@@ -8,9 +8,46 @@ package avroc
 import (
 	"errors"
 	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/z5labs/avro-go/idl"
 )
+
+// safeOutputPath resolves a generator-supplied relative path against the output
+// root, rejecting anything that is absolute or escapes the root. The supplied
+// path uses forward slashes regardless of OS. It returns the OS-native absolute
+// path to write to.
+func safeOutputPath(root, p string) (string, error) {
+	if p == "" {
+		return "", errors.New("path is empty")
+	}
+	if path.IsAbs(p) {
+		return "", fmt.Errorf("path %q is absolute", p)
+	}
+
+	osPath := filepath.FromSlash(p)
+	if filepath.IsAbs(osPath) || filepath.VolumeName(osPath) != "" {
+		return "", fmt.Errorf("path %q is absolute", p)
+	}
+
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+
+	full := filepath.Join(rootAbs, osPath)
+	rel, err := filepath.Rel(rootAbs, full)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes the output directory", p)
+	}
+
+	return full, nil
+}
 
 func validateSchema(schema *idl.Schema) error {
 	primitives := map[string]struct{}{

--- a/internal/avroc/validate_test.go
+++ b/internal/avroc/validate_test.go
@@ -6,11 +6,38 @@
 package avroc
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/z5labs/avro-go/idl"
 )
+
+func TestSafeOutputPath(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "out")
+
+	t.Run("accepts relative paths", func(t *testing.T) {
+		for _, p := range []string{"person.go", "pkg/person.go", "a/b/c.avsc"} {
+			got, err := safeOutputPath(root, p)
+			if err != nil {
+				t.Errorf("path %q: unexpected error: %v", p, err)
+				continue
+			}
+			want := filepath.Join(root, filepath.FromSlash(p))
+			if got != want {
+				t.Errorf("path %q: got %q, want %q", p, got, want)
+			}
+		}
+	})
+
+	t.Run("rejects unsafe paths", func(t *testing.T) {
+		for _, p := range []string{"", "../escape.go", "a/../../escape.go", "/etc/passwd"} {
+			if _, err := safeOutputPath(root, p); err == nil {
+				t.Errorf("path %q: expected error, got nil", p)
+			}
+		}
+	})
+}
 
 func TestValidateSchema_PrimitiveIdents(t *testing.T) {
 	schema := &idl.Schema{

--- a/internal/avroc/validate_test.go
+++ b/internal/avroc/validate_test.go
@@ -16,6 +16,15 @@ import (
 func TestSafeOutputPath(t *testing.T) {
 	root := filepath.Join(string(filepath.Separator), "out")
 
+	// safeOutputPath returns an absolute path (it resolves root via
+	// filepath.Abs). Compute the expected value from the same absolute root so
+	// the assertion is OS-independent: on Windows a rooted-but-volume-less path
+	// like "\out" gains the current drive letter ("C:\out") once made absolute.
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("failed to resolve absolute root: %v", err)
+	}
+
 	t.Run("accepts relative paths", func(t *testing.T) {
 		for _, p := range []string{"person.go", "pkg/person.go", "a/b/c.avsc"} {
 			got, err := safeOutputPath(root, p)
@@ -23,7 +32,7 @@ func TestSafeOutputPath(t *testing.T) {
 				t.Errorf("path %q: unexpected error: %v", p, err)
 				continue
 			}
-			want := filepath.Join(root, filepath.FromSlash(p))
+			want := filepath.Join(rootAbs, filepath.FromSlash(p))
 			if got != want {
 				t.Errorf("path %q: got %q, want %q", p, got, want)
 			}

--- a/internal/avrocpb/generate_request.pb.go
+++ b/internal/avrocpb/generate_request.pb.go
@@ -29,12 +29,10 @@ const (
 // The request message for the Generate RPC method.
 type GenerateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The directory where the generated code should be placed.
-	OutputDirectory *string `protobuf:"bytes,1,opt,name=output_directory,json=outputDirectory" json:"output_directory,omitempty"`
 	// Options to customize the code generation process.
-	Options []*Option `protobuf:"bytes,2,rep,name=options" json:"options,omitempty"`
+	Options []*Option `protobuf:"bytes,1,rep,name=options" json:"options,omitempty"`
 	// The Avro schemas to be generate code for.
-	Schemas       []*Schema `protobuf:"bytes,3,rep,name=schemas" json:"schemas,omitempty"`
+	Schemas       []*Schema `protobuf:"bytes,2,rep,name=schemas" json:"schemas,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -69,13 +67,6 @@ func (*GenerateRequest) Descriptor() ([]byte, []int) {
 	return file_generate_request_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *GenerateRequest) GetOutputDirectory() string {
-	if x != nil && x.OutputDirectory != nil {
-		return *x.OutputDirectory
-	}
-	return ""
-}
-
 func (x *GenerateRequest) GetOptions() []*Option {
 	if x != nil {
 		return x.Options
@@ -94,11 +85,10 @@ var File_generate_request_proto protoreflect.FileDescriptor
 
 const file_generate_request_proto_rawDesc = "" +
 	"\n" +
-	"\x16generate_request.proto\x1a\fschema.proto\x1a\foption.proto\"\x82\x01\n" +
-	"\x0fGenerateRequest\x12)\n" +
-	"\x10output_directory\x18\x01 \x01(\tR\x0foutputDirectory\x12!\n" +
-	"\aoptions\x18\x02 \x03(\v2\a.OptionR\aoptions\x12!\n" +
-	"\aschemas\x18\x03 \x03(\v2\a.SchemaR\aschemasB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
+	"\x16generate_request.proto\x1a\fschema.proto\x1a\foption.proto\"W\n" +
+	"\x0fGenerateRequest\x12!\n" +
+	"\aoptions\x18\x01 \x03(\v2\a.OptionR\aoptions\x12!\n" +
+	"\aschemas\x18\x02 \x03(\v2\a.SchemaR\aschemasB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
 
 var (
 	file_generate_request_proto_rawDescOnce sync.Once

--- a/internal/avrocpb/generate_response.pb.go
+++ b/internal/avrocpb/generate_response.pb.go
@@ -26,11 +26,21 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// The response message for the Generate RPC method.
+// One streamed chunk of generated output. A file is the ordered concatenation
+// of all chunks sharing the same `path`, terminated by the chunk whose `last`
+// is true.
 type GenerateResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The list of generated output files.
-	OutputFiles   []string `protobuf:"bytes,1,rep,name=output_files,json=outputFiles" json:"output_files,omitempty"`
+	// Path of the generated file, relative to the output root, using forward
+	// slashes regardless of OS. avroc joins this onto the -<name>_out directory
+	// and MUST reject absolute paths or any path that escapes the output root
+	// (e.g. containing "..").
+	Path *string `protobuf:"bytes,1,opt,name=path" json:"path,omitempty"`
+	// A chunk of the file's content. Each message is kept comfortably under the
+	// 4MB default MaxRecvMsgSize so the limit never needs raising.
+	Content []byte `protobuf:"bytes,2,opt,name=content" json:"content,omitempty"`
+	// True on the final chunk for `path`.
+	Last          *bool `protobuf:"varint,3,opt,name=last" json:"last,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -65,20 +75,36 @@ func (*GenerateResponse) Descriptor() ([]byte, []int) {
 	return file_generate_response_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *GenerateResponse) GetOutputFiles() []string {
+func (x *GenerateResponse) GetPath() string {
+	if x != nil && x.Path != nil {
+		return *x.Path
+	}
+	return ""
+}
+
+func (x *GenerateResponse) GetContent() []byte {
 	if x != nil {
-		return x.OutputFiles
+		return x.Content
 	}
 	return nil
+}
+
+func (x *GenerateResponse) GetLast() bool {
+	if x != nil && x.Last != nil {
+		return *x.Last
+	}
+	return false
 }
 
 var File_generate_response_proto protoreflect.FileDescriptor
 
 const file_generate_response_proto_rawDesc = "" +
 	"\n" +
-	"\x17generate_response.proto\"5\n" +
-	"\x10GenerateResponse\x12!\n" +
-	"\foutput_files\x18\x01 \x03(\tR\voutputFilesB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
+	"\x17generate_response.proto\"T\n" +
+	"\x10GenerateResponse\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
+	"\acontent\x18\x02 \x01(\fR\acontent\x12\x12\n" +
+	"\x04last\x18\x03 \x01(\bR\x04lastB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
 
 var (
 	file_generate_response_proto_rawDescOnce sync.Once

--- a/internal/avrocpb/generator.pb.go
+++ b/internal/avrocpb/generator.pb.go
@@ -29,9 +29,9 @@ var File_generator_proto protoreflect.FileDescriptor
 
 const file_generator_proto_rawDesc = "" +
 	"\n" +
-	"\x0fgenerator.proto\x1a\x16generate_request.proto\x1a\x17generate_response.proto2<\n" +
-	"\tGenerator\x12/\n" +
-	"\bGenerate\x12\x10.GenerateRequest\x1a\x11.GenerateResponseB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
+	"\x0fgenerator.proto\x1a\x16generate_request.proto\x1a\x17generate_response.proto2>\n" +
+	"\tGenerator\x121\n" +
+	"\bGenerate\x12\x10.GenerateRequest\x1a\x11.GenerateResponse0\x01B2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
 
 var file_generator_proto_goTypes = []any{
 	(*GenerateRequest)(nil),  // 0: GenerateRequest

--- a/internal/avrocpb/generator_grpc.pb.go
+++ b/internal/avrocpb/generator_grpc.pb.go
@@ -33,8 +33,8 @@ const (
 //
 // The Generator service defines the RPC method for generating code from Avro schemas.
 type GeneratorClient interface {
-	// The Generate method takes a GenerateRequest and returns a GenerateResponse.
-	Generate(ctx context.Context, in *GenerateRequest, opts ...grpc.CallOption) (*GenerateResponse, error)
+	// Generate streams generated files back to avroc, which writes them.
+	Generate(ctx context.Context, in *GenerateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GenerateResponse], error)
 }
 
 type generatorClient struct {
@@ -45,15 +45,24 @@ func NewGeneratorClient(cc grpc.ClientConnInterface) GeneratorClient {
 	return &generatorClient{cc}
 }
 
-func (c *generatorClient) Generate(ctx context.Context, in *GenerateRequest, opts ...grpc.CallOption) (*GenerateResponse, error) {
+func (c *generatorClient) Generate(ctx context.Context, in *GenerateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GenerateResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GenerateResponse)
-	err := c.cc.Invoke(ctx, Generator_Generate_FullMethodName, in, out, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Generator_ServiceDesc.Streams[0], Generator_Generate_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	x := &grpc.GenericClientStream[GenerateRequest, GenerateResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Generator_GenerateClient = grpc.ServerStreamingClient[GenerateResponse]
 
 // GeneratorServer is the server API for Generator service.
 // All implementations must embed UnimplementedGeneratorServer
@@ -61,8 +70,8 @@ func (c *generatorClient) Generate(ctx context.Context, in *GenerateRequest, opt
 //
 // The Generator service defines the RPC method for generating code from Avro schemas.
 type GeneratorServer interface {
-	// The Generate method takes a GenerateRequest and returns a GenerateResponse.
-	Generate(context.Context, *GenerateRequest) (*GenerateResponse, error)
+	// Generate streams generated files back to avroc, which writes them.
+	Generate(*GenerateRequest, grpc.ServerStreamingServer[GenerateResponse]) error
 	mustEmbedUnimplementedGeneratorServer()
 }
 
@@ -73,8 +82,8 @@ type GeneratorServer interface {
 // pointer dereference when methods are called.
 type UnimplementedGeneratorServer struct{}
 
-func (UnimplementedGeneratorServer) Generate(context.Context, *GenerateRequest) (*GenerateResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Generate not implemented")
+func (UnimplementedGeneratorServer) Generate(*GenerateRequest, grpc.ServerStreamingServer[GenerateResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method Generate not implemented")
 }
 func (UnimplementedGeneratorServer) mustEmbedUnimplementedGeneratorServer() {}
 func (UnimplementedGeneratorServer) testEmbeddedByValue()                   {}
@@ -97,23 +106,16 @@ func RegisterGeneratorServer(s grpc.ServiceRegistrar, srv GeneratorServer) {
 	s.RegisterService(&Generator_ServiceDesc, srv)
 }
 
-func _Generator_Generate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GenerateRequest)
-	if err := dec(in); err != nil {
-		return nil, err
+func _Generator_Generate_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(GenerateRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
 	}
-	if interceptor == nil {
-		return srv.(GeneratorServer).Generate(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: Generator_Generate_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(GeneratorServer).Generate(ctx, req.(*GenerateRequest))
-	}
-	return interceptor(ctx, in, info, handler)
+	return srv.(GeneratorServer).Generate(m, &grpc.GenericServerStream[GenerateRequest, GenerateResponse]{ServerStream: stream})
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Generator_GenerateServer = grpc.ServerStreamingServer[GenerateResponse]
 
 // Generator_ServiceDesc is the grpc.ServiceDesc for Generator service.
 // It's only intended for direct use with grpc.RegisterService,
@@ -121,12 +123,13 @@ func _Generator_Generate_Handler(srv interface{}, ctx context.Context, dec func(
 var Generator_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "Generator",
 	HandlerType: (*GeneratorServer)(nil),
-	Methods: []grpc.MethodDesc{
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
 		{
-			MethodName: "Generate",
-			Handler:    _Generator_Generate_Handler,
+			StreamName:    "Generate",
+			Handler:       _Generator_Generate_Handler,
+			ServerStreams: true,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
 	Metadata: "generator.proto",
 }

--- a/proto/generate_request.proto
+++ b/proto/generate_request.proto
@@ -12,12 +12,9 @@ import "option.proto";
 
 // The request message for the Generate RPC method.
 message GenerateRequest {
-    // The directory where the generated code should be placed.
-    string output_directory = 1;
-
     // Options to customize the code generation process.
-    repeated Option options = 2;
+    repeated Option options = 1;
 
     // The Avro schemas to be generate code for.
-    repeated Schema schemas = 3;
+    repeated Schema schemas = 2;
 }

--- a/proto/generate_response.proto
+++ b/proto/generate_response.proto
@@ -7,8 +7,20 @@ edition = "2023";
 
 option go_package = "github.com/z5labs/avroc/internal/avrocpb;avrocpb";
 
-// The response message for the Generate RPC method.
+// One streamed chunk of generated output. A file is the ordered concatenation
+// of all chunks sharing the same `path`, terminated by the chunk whose `last`
+// is true.
 message GenerateResponse {
-    // The list of generated output files.
-    repeated string output_files = 1;
+    // Path of the generated file, relative to the output root, using forward
+    // slashes regardless of OS. avroc joins this onto the -<name>_out directory
+    // and MUST reject absolute paths or any path that escapes the output root
+    // (e.g. containing "..").
+    string path = 1;
+
+    // A chunk of the file's content. Each message is kept comfortably under the
+    // 4MB default MaxRecvMsgSize so the limit never needs raising.
+    bytes content = 2;
+
+    // True on the final chunk for `path`.
+    bool last = 3;
 }

--- a/proto/generator.proto
+++ b/proto/generator.proto
@@ -12,6 +12,6 @@ import "generate_response.proto";
 
 // The Generator service defines the RPC method for generating code from Avro schemas.
 service Generator {
-    // The Generate method takes a GenerateRequest and returns a GenerateResponse.
-    rpc Generate (GenerateRequest) returns (GenerateResponse);
+    // Generate streams generated files back to avroc, which writes them.
+    rpc Generate (GenerateRequest) returns (stream GenerateResponse);
 }


### PR DESCRIPTION
Closes #67.

Refactors the `Generator` plugin contract to **Design A (location-transparent generators)**: generators become pure functions (schemas in, file **contents** out) and **avroc performs every filesystem write**. `Generate` is now server-streaming so large outputs stay under gRPC's 4MB default without raising the limit.

## Contract (`proto/` + regenerated `internal/avrocpb/`)
- `GenerateRequest`: removed `output_directory`; renumbered `options=1`, `schemas=2`.
- `GenerateResponse`: now a streamed chunk `{ path, content, last }`.
- `Generate (GenerateRequest) returns (stream GenerateResponse)`.

## avroc orchestrator
- Consumes the stream, reassembles per `path`, creates parent dirs, and writes under `-<name>_out`.
- New `safeOutputPath` rejects absolute paths, Windows volumes, and any `..` escape.
- **Dropped the fixed 30s RPC cap** — cancellation flows from the signal-based parent context.

## Generators (go / json / pcf)
- Stream output in ≤1 MiB chunks via `sendFile`; none import `os.WriteFile`/`os.MkdirAll` for output.
- Content/format logic unchanged → example output is **byte-identical**.

## Tests
- Capture-stream helpers replace on-disk assertions.
- Path-traversal rejection tests at `safeOutputPath`, `writeStream`, and end-to-end levels.

## Verification
- `go build ./...`, `go test -race ./...`, `golangci-lint run` — all pass.
- Round-trip (CI gate): regenerated `example/`; `git diff --exit-code -- example` is clean.

Blocks #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)