### PR TITLE
story(avroc): declarative generator manifest + avroc init (#68)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,8 @@ jobs:
 
         - name: Run example
           shell: bash
-          run: avroc -go_out=example/gen -go_opt=package_name=avro -go_opt=encoding=single_object -json_out=example -pcf_out=example/pcf example/schema.avdl
+          working-directory: example
+          run: avroc generate
 
         - name: Verify example output is up to date
           shell: bash

--- a/README.md
+++ b/README.md
@@ -4,27 +4,29 @@ A modular code generator for messages and services defined in [Avro IDL](https:/
 
 ## Features
 
-- **Dynamic generator discovery** — avroc automatically discovers generator plugins on your `PATH` using the naming convention `avroc-gen-<name>`. No configuration file needed; just install a plugin and it is available immediately.
+- **Declarative manifest** — a project's generators and their configuration live in a checked-in `avroc.json` manifest, so generator selection and options are diffable, reviewable, and shared across a team and CI. `avroc init` scaffolds one to get started.
+- **Dynamic generator discovery** — avroc discovers generator plugins on your `PATH` using the naming convention `avroc-gen-<name>`; a manifest entry's `name` resolves to the matching `avroc-gen-<name>` executable.
 - **Type validation** — avroc resolves all type references in your Avro IDL schemas and reports errors for any undefined types before invoking generators.
 - **Value validation** — avroc validates field defaults and enum defaults against their declared types, catching mistakes (e.g. a `null` default on an `int` field) at generation time.
-- **Parallel generation** — all active generators run concurrently, so code generation scales with the number of plugins you use.
+- **Parallel generation** — all generators run concurrently, so code generation scales with the number of plugins you use.
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  avroc (CLI)                                         │
+│  avroc generate                                      │
 │                                                      │
-│  1. Scan PATH for avroc-gen-* executables            │
-│  2. Register -<name>_out / -<name>_opt flags         │
-│  3. Parse & validate Avro IDL files                  │
-│  4. For each active generator (concurrently):        │
+│  1. Read avroc.json manifest                         │
+│  2. Resolve each generator to avroc-gen-<name>       │
+│  3. Parse & validate the declared Avro IDL inputs    │
+│  4. For each generator (concurrently):               │
 │     a. Create a temporary Unix socket                │
 │     b. Launch avroc-gen-<name> subprocess            │
 │     c. Connect via gRPC (Generator service)          │
 │     d. Send GenerateRequest  ──────────────────────► │  avroc-gen-<name>
-│     e. Receive GenerateResponse ◄──────────────────  │  (gRPC server on
-└─────────────────────────────────────────────────────┘   Unix socket)
+│     e. Receive streamed GenerateResponse ◄─────────  │  (gRPC server on
+│     f. avroc writes the streamed files               │   Unix socket)
+└─────────────────────────────────────────────────────┘
 ```
 
 Generators communicate with `avroc` over a gRPC `Generator` service defined in [`proto/`](proto/). This means you can write a generator in **any language** that supports gRPC — just name the executable `avroc-gen-<name>` and put it on your `PATH`.
@@ -50,16 +52,47 @@ go install github.com/z5labs/avroc/cmd/avroc-gen-pcf@latest
 
 ## Usage
 
+avroc is driven by a project manifest (`avroc.json`) and exposes two commands:
+
 ```
-avroc [options] <idl files...>
+avroc init        # scaffold a starter avroc.json (never clobbers an existing one)
+avroc generate    # run the generators declared in avroc.json
 ```
 
-For each generator plugin discovered on `PATH`, avroc registers two flags:
+### Manifest (`avroc.json`)
 
-| Flag | Description |
-|---|---|
-| `-<name>_out <dir>` | Output directory for the `<name>` generator. Passing this flag activates the generator. |
-| `-<name>_opt <key>=<value>` | Generator option. Can be specified multiple times. |
+The manifest declares the input IDL files and the generators to run:
+
+```json
+{
+  "inputs": ["schema.avdl"],
+  "generators": [
+    {
+      "name": "go",
+      "source": "ghcr.io/z5labs/avroc-gen-go",
+      "version": "v0.1.0",
+      "out": "gen",
+      "options": { "package_name": "mypackage", "encoding": "single_object" }
+    },
+    { "name": "json", "out": "." },
+    { "name": "pcf", "out": "pcf" }
+  ]
+}
+```
+
+| Field | Scope | Description |
+|---|---|---|
+| `inputs` | top-level | IDL files shared by every generator. |
+| `name` | generator | Logical name; resolves to the `avroc-gen-<name>` executable on `PATH`. |
+| `source` | generator | OCI image reference. Recorded for the containerized-generator workflow; today generators are run from `PATH`. |
+| `version` | generator | OCI image tag. Recorded alongside `source`. |
+| `out` | generator | Output directory (relative to the manifest). |
+| `options` | generator | `key`/`value` generator options. |
+| `inputs` | generator | IDL files specific to this generator, merged with the top-level `inputs`. |
+
+> A generator whose `name` is not found on `PATH` is reported as an error. If such an entry
+> also names an OCI `source`, avroc explains that containerized execution is not yet
+> supported — that lands in a follow-on release.
 
 ### Example
 
@@ -86,21 +119,19 @@ record TestRecord {
 }
 ```
 
-Generate Go types, an Avro JSON schema file, and a Parsing Canonical Form file:
+Scaffold a manifest, edit it to declare the `go`, `json`, and `pcf` generators (as above),
+then generate:
 
 ```bash
-avroc \
-  -go_out=./gen \
-  -go_opt=package_name=mypackage \
-  -json_out=. \
-  -pcf_out=./pcf \
-  schema.avdl
+avroc init
+# edit avroc.json
+avroc generate
 ```
 
 This produces:
-- `./gen/test_record.go` — Go types with `MarshalAvroBinary` / `UnmarshalAvroBinary` methods
-- `./test_record.avsc` — Avro JSON schema
-- `./pcf/test_record.avsc` — Avro Parsing Canonical Form
+- `gen/test_record.go` — Go types with `MarshalAvroBinary` / `UnmarshalAvroBinary` methods
+- `test_record.avsc` — Avro JSON schema
+- `pcf/test_record.avsc` — Avro Parsing Canonical Form
 
 See the [`example/`](example/) directory for a working example.
 
@@ -146,6 +177,6 @@ No options required.
 1. Create an executable named `avroc-gen-<name>` and put it on your `PATH`.
 2. On startup, read the Unix socket path from `os.Args[1]`.
 3. Start a gRPC server on that socket and register your implementation of the `Generator` service (see [`proto/generator.proto`](proto/generator.proto)).
-4. Handle `GenerateRequest` messages (output directory, options, schemas) and return a `GenerateResponse` with the list of generated file paths.
+4. Handle a `GenerateRequest` (options + schemas) by **streaming** the generated files back: each `GenerateResponse` carries a relative `path`, a chunk of `content`, and a `last` flag. avroc reassembles the chunks and writes the files, so the generator never touches the filesystem.
 
 The protobuf definitions and generated Go stubs are in [`internal/avrocpb/`](internal/avrocpb/).

--- a/cmd/avroc/main.go
+++ b/cmd/avroc/main.go
@@ -28,8 +28,9 @@ func main() {
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),
-		OpenDir: func(dir string) fs.FS { return os.DirFS(dir) },
-		Args:    os.Args[1:],
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: ".",
+		Args:       os.Args[1:],
 	})
 	os.Exit(code)
 }

--- a/example/README.md
+++ b/example/README.md
@@ -6,20 +6,28 @@ This example demonstrates using `avroc` to generate code from an Avro IDL schema
 
 The `schema.avdl` file contains an example schema based on the [Apache Avro documentation](https://avro.apache.org/docs/1.12.0/idl-language/#schemaavdl).
 
+## Manifest
+
+The generators and their configuration are declared in [`avroc.json`](avroc.json): the
+shared input (`schema.avdl`) plus a `go`, `json`, and `pcf` generator, each with its output
+directory and options. `avroc init` scaffolds a starter manifest; this example ships a
+ready-made one.
+
 ## Generating Code
 
 To generate code from the schema:
 
 ```bash
-# Build avroc tools (from repo root)
-go build -o ./bin/avroc ./cmd/avroc
-go build -o ./bin/avroc-gen-go ./cmd/avroc-gen-go
-go build -o ./bin/avroc-gen-json ./cmd/avroc-gen-json
-go build -o ./bin/avroc-gen-pcf ./cmd/avroc-gen-pcf
+# Install the avroc tools (so they are discovered on PATH as avroc-gen-<name>)
+go install ./cmd/...
 
-# Generate Go types, JSON schema, and Parsing Canonical Form
-PATH="$PWD/bin:$PATH" ./bin/avroc -go_out=example/gen -go_opt=package_name=avro -go_opt=encoding=single_object -json_out=example -pcf_out=example/pcf example/schema.avdl
+# From this example directory, run the generators declared in avroc.json
+cd example
+avroc generate
 ```
+
+This reads `avroc.json` and produces Go types (`gen/`), an Avro JSON schema
+(`test_record.avsc`), and a Parsing Canonical Form file (`pcf/test_record.avsc`).
 
 ## Generated Output
 

--- a/example/avroc.json
+++ b/example/avroc.json
@@ -1,0 +1,23 @@
+{
+  "inputs": [
+    "schema.avdl"
+  ],
+  "generators": [
+    {
+      "name": "go",
+      "out": "gen",
+      "options": {
+        "encoding": "single_object",
+        "package_name": "avro"
+      }
+    },
+    {
+      "name": "json",
+      "out": "."
+    },
+    {
+      "name": "pcf",
+      "out": "pcf"
+    }
+  ]
+}

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -51,12 +51,14 @@ func Main(ctx context.Context, cli cli.Context) int {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: avroc <command>")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Commands:")
-	fmt.Fprintln(w, "  init       Scaffold an avroc.json manifest")
-	fmt.Fprintln(w, "  generate   Run the generators declared in avroc.json")
-	fmt.Fprintln(w, "  help       Show this help")
+	const usage = `Usage: avroc <command>
+
+Commands:
+  init       Scaffold an avroc.json manifest
+  generate   Run the generators declared in avroc.json
+  help       Show this help
+`
+	_, _ = io.WriteString(w, usage)
 }
 
 func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string) fs.FS, dirs ...string) (map[string]string, error) {

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -8,151 +8,55 @@ package avroc
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
-	"maps"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
 
-	"github.com/sourcegraph/conc/pool"
 	"github.com/z5labs/avro-go/idl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 )
 
+// Main dispatches to an avroc subcommand. Generators are declared in an
+// avroc.json manifest (see avroc init) and run with avroc generate.
 func Main(ctx context.Context, cli cli.Context) int {
-	path, ok := cli.Env.LookupEnv("PATH")
-	if !ok {
-		cli.Log.ErrorContext(
-			ctx,
-			"unable to lookup generators",
-			slog.Any("error", "PATH environment variable not set"),
-		)
+	if len(cli.Args) == 0 {
+		printUsage(os.Stderr)
 		return 1
 	}
 
-	paths := filepath.SplitList(path)
-	generators, err := lookupGenerators(ctx, cli.Log, cli.OpenDir, paths...)
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to lookup generators", slog.Any("error", err))
-		return 1
-	}
-
-	flags := flag.NewFlagSet("avroc", flag.ContinueOnError)
-	flags.Usage = func() {}
-
-	optFlags := make(map[string]*optionFlag)
-	for name := range generators {
-		generatorName := strings.TrimPrefix(name, "avroc-gen-")
-
-		flags.String(generatorName+"_out", "", fmt.Sprintf("Output directory for the %q generator", generatorName))
-
-		of := &optionFlag{}
-		optFlags[generatorName] = of
-		flags.Var(of, generatorName+"_opt", fmt.Sprintf("Options for the %q generator (key=value)", generatorName))
-	}
-
-	err = flags.Parse(cli.Args)
-	if errors.Is(err, flag.ErrHelp) {
-		err = printHelp(os.Stdout, slices.Collect(maps.Keys(generators))...)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to print help", slog.Any("error", err))
-			return 1
-		}
+	switch cmd := cli.Args[0]; cmd {
+	case "init":
+		return runInit(ctx, cli)
+	case "generate":
+		return runGenerate(ctx, cli)
+	case "help", "-h", "-help", "--help":
+		printUsage(os.Stdout)
 		return 0
-	}
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to parse flags", slog.Any("error", err))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", cmd)
+		printUsage(os.Stderr)
 		return 1
 	}
+}
 
-	args := flags.Args()
-	if len(args) == 0 {
-		cli.Log.ErrorContext(ctx, "no IDL files provided")
-		return 1
-	}
-
-	schemas := make([]*avrocpb.Schema, len(args))
-	for i, arg := range args {
-		f, err := parseIDL(arg)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to parse IDL file", slog.String("file", arg), slog.Any("error", err))
-			return 1
-		}
-		if f.Schema == nil {
-			cli.Log.ErrorContext(ctx, "IDL file does not contain a schema", slog.String("file", arg))
-			return 1
-		}
-
-		if err := validateSchema(f.Schema); err != nil {
-			cli.Log.ErrorContext(ctx, "schema validation failed", slog.String("file", arg), slog.Any("error", err))
-			return 1
-		}
-
-		schema, err := mapToProtoSchema(f.Schema)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to map IDL file to proto schema", slog.String("file", arg), slog.Any("error", err))
-			return 1
-		}
-
-		schemas[i] = schema
-	}
-
-	genPool := pool.New().WithContext(ctx)
-	flags.Visit(func(f *flag.Flag) {
-		if !strings.HasSuffix(f.Name, "_out") {
-			return
-		}
-
-		genPool.Go(func(ctx context.Context) error {
-			flagName := strings.TrimSuffix(f.Name, "_out")
-			generatorName := "avroc-gen-" + flagName
-
-			executablePath, ok := generators[generatorName]
-			if !ok {
-				cli.Log.ErrorContext(ctx, "no generator found for flag", slog.String("flag", f.Name))
-				return nil
-			}
-
-			output := f.Value.String()
-			if output == "" {
-				return fmt.Errorf("empty output directory for generator %q", generatorName)
-			}
-
-			var options []*avrocpb.Option
-			if of, ok := optFlags[flagName]; ok {
-				options = of.options()
-			}
-
-			g := generator{
-				log:            cli.Log,
-				env:            cli.Env,
-				name:           generatorName,
-				executablePath: executablePath,
-			}
-
-			return g.generate(ctx, output, options, schemas...)
-		})
-	})
-
-	err = genPool.Wait()
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to run generators", slog.Any("error", err))
-		return 1
-	}
-
-	return 0
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: avroc <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  init       Scaffold an avroc.json manifest")
+	fmt.Fprintln(w, "  generate   Run the generators declared in avroc.json")
+	fmt.Fprintln(w, "  help       Show this help")
 }
 
 func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string) fs.FS, dirs ...string) (map[string]string, error) {
@@ -186,74 +90,6 @@ func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string
 	}
 
 	return generatorIndex, nil
-}
-
-func printHelp(w io.Writer, generators ...string) error {
-	_, err := fmt.Fprintln(w, "Usage: avroc [options] <idl files>")
-	if err != nil {
-		return err
-	}
-
-	_, err = fmt.Fprintln(w, "Options:")
-	if err != nil {
-		return err
-	}
-
-	for _, gen := range generators {
-		name := strings.TrimPrefix(gen, "avroc-gen-")
-
-		_, err = fmt.Fprintf(w, "  -%s_out string\n", name)
-		if err != nil {
-			return err
-		}
-
-		_, err = fmt.Fprintf(w, "        Output directory for the %q generator\n", name)
-		if err != nil {
-			return err
-		}
-
-		_, err = fmt.Fprintf(w, "  -%s_opt key=value\n", name)
-		if err != nil {
-			return err
-		}
-
-		_, err = fmt.Fprintf(w, "        Options for the %q generator (can be specified multiple times)\n", name)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// optionFlag implements flag.Value to support repeated key=value flag usage.
-type optionFlag struct {
-	values []string
-}
-
-func (f *optionFlag) String() string {
-	return strings.Join(f.values, ",")
-}
-
-func (f *optionFlag) Set(value string) error {
-	if !strings.Contains(value, "=") {
-		return fmt.Errorf("option must be in key=value format: %q", value)
-	}
-	f.values = append(f.values, value)
-	return nil
-}
-
-func (f *optionFlag) options() []*avrocpb.Option {
-	opts := make([]*avrocpb.Option, len(f.values))
-	for i, v := range f.values {
-		// Cut is safe here; Set() already validated the "=" separator is present.
-		key, val, _ := strings.Cut(v, "=")
-		opts[i] = &avrocpb.Option{
-			Name:  proto.String(key),
-			Value: proto.String(val),
-		}
-	}
-	return opts
 }
 
 func parseIDL(path string) (_ *idl.File, err error) {

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -37,8 +37,14 @@ func Main(ctx context.Context, cli cli.Context) int {
 
 	switch cmd := cli.Args[0]; cmd {
 	case "init":
+		if code, ok := rejectExtraArgs(cmd, cli.Args[1:]); !ok {
+			return code
+		}
 		return runInit(ctx, cli)
 	case "generate":
+		if code, ok := rejectExtraArgs(cmd, cli.Args[1:]); !ok {
+			return code
+		}
 		return runGenerate(ctx, cli)
 	case "help", "-h", "-help", "--help":
 		printUsage(os.Stdout)
@@ -48,6 +54,19 @@ func Main(ctx context.Context, cli cli.Context) int {
 		printUsage(os.Stderr)
 		return 1
 	}
+}
+
+// rejectExtraArgs enforces that init and generate take no positional
+// arguments. The manifest is the sole source of inputs/generators, so a stray
+// argument — a typo or legacy flag-style usage like "avroc generate
+// schema.avdl" — should fail loudly instead of being silently ignored.
+func rejectExtraArgs(cmd string, extra []string) (int, bool) {
+	if len(extra) == 0 {
+		return 0, true
+	}
+	fmt.Fprintf(os.Stderr, "%s takes no arguments, got %v\n\n", cmd, extra)
+	printUsage(os.Stderr)
+	return 1, false
 }
 
 func printUsage(w io.Writer) {

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -410,139 +410,40 @@ func (f *errFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return nil, &fs.PathError{Op: "read", Path: name, Err: f.err}
 }
 
-func TestPrintHelp(t *testing.T) {
-	var buf bytes.Buffer
-	err := printHelp(&buf, "avroc-gen-go", "avroc-gen-java")
-	if err != nil {
-		t.Fatal(err)
+func TestMain_Dispatch(t *testing.T) {
+	newContext := func(args ...string) cli.Context {
+		return cli.Context{
+			Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Env:        cli.EnvironmentFunc(func(string) (string, bool) { return "", false }),
+			OpenDir:    staticOpenDir(fstest.MapFS{}),
+			WorkingDir: t.TempDir(),
+			Args:       args,
+		}
 	}
 
-	output := buf.String()
-	if !bytes.Contains([]byte(output), []byte("-go_out string")) {
-		t.Errorf("output missing -go_out flag:\n%s", output)
-	}
-	if !bytes.Contains([]byte(output), []byte("-java_out string")) {
-		t.Errorf("output missing -java_out flag:\n%s", output)
-	}
-	if !bytes.Contains([]byte(output), []byte("-go_opt key=value")) {
-		t.Errorf("output missing -go_opt flag:\n%s", output)
-	}
-	if !bytes.Contains([]byte(output), []byte("-java_opt key=value")) {
-		t.Errorf("output missing -java_opt flag:\n%s", output)
-	}
-	if !bytes.Contains([]byte(output), []byte("Usage: avroc")) {
-		t.Errorf("output missing usage line:\n%s", output)
-	}
-}
-
-func TestOptionFlag(t *testing.T) {
-	t.Run("single option", func(t *testing.T) {
-		of := &optionFlag{}
-		if err := of.Set("package_name=my_package"); err != nil {
-			t.Fatal(err)
-		}
-
-		opts := of.options()
-		if len(opts) != 1 {
-			t.Fatalf("got %d options, want 1", len(opts))
-		}
-		if opts[0].GetName() != "package_name" {
-			t.Errorf("option name = %q, want %q", opts[0].GetName(), "package_name")
-		}
-		if opts[0].GetValue() != "my_package" {
-			t.Errorf("option value = %q, want %q", opts[0].GetValue(), "my_package")
+	t.Run("no arguments is a usage error", func(t *testing.T) {
+		if code := Main(context.Background(), newContext()); code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
 		}
 	})
 
-	t.Run("multiple options", func(t *testing.T) {
-		of := &optionFlag{}
-		if err := of.Set("package_name=my_package"); err != nil {
-			t.Fatal(err)
-		}
-		if err := of.Set("other_opt=other_val"); err != nil {
-			t.Fatal(err)
-		}
-
-		opts := of.options()
-		if len(opts) != 2 {
-			t.Fatalf("got %d options, want 2", len(opts))
-		}
-		if opts[0].GetName() != "package_name" {
-			t.Errorf("option[0] name = %q, want %q", opts[0].GetName(), "package_name")
-		}
-		if opts[1].GetName() != "other_opt" {
-			t.Errorf("option[1] name = %q, want %q", opts[1].GetName(), "other_opt")
+	t.Run("unknown command is an error", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("bogus")); code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
 		}
 	})
 
-	t.Run("value with equals sign", func(t *testing.T) {
-		of := &optionFlag{}
-		if err := of.Set("key=val=ue"); err != nil {
-			t.Fatal(err)
-		}
-
-		opts := of.options()
-		if len(opts) != 1 {
-			t.Fatalf("got %d options, want 1", len(opts))
-		}
-		if opts[0].GetName() != "key" {
-			t.Errorf("option name = %q, want %q", opts[0].GetName(), "key")
-		}
-		if opts[0].GetValue() != "val=ue" {
-			t.Errorf("option value = %q, want %q", opts[0].GetValue(), "val=ue")
+	t.Run("help exits 0", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("help")); code != 0 {
+			t.Errorf("exit code = %d, want 0", code)
 		}
 	})
 
-	t.Run("invalid format", func(t *testing.T) {
-		of := &optionFlag{}
-		if err := of.Set("invalid"); err == nil {
-			t.Fatal("expected error for option without '='")
+	t.Run("init scaffolds and exits 0", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("init")); code != 0 {
+			t.Errorf("exit code = %d, want 0", code)
 		}
 	})
-
-	t.Run("string representation", func(t *testing.T) {
-		of := &optionFlag{}
-		if err := of.Set("a=b"); err != nil {
-			t.Fatal(err)
-		}
-		if err := of.Set("c=d"); err != nil {
-			t.Fatal(err)
-		}
-		if of.String() != "a=b,c=d" {
-			t.Errorf("String() = %q, want %q", of.String(), "a=b,c=d")
-		}
-	})
-}
-
-func TestMain_PathNotSet(t *testing.T) {
-	code := Main(context.Background(), cli.Context{
-		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
-			return "", false
-		}),
-	})
-
-	if code != 1 {
-		t.Errorf("exit code = %d, want 1", code)
-	}
-}
-
-func TestMain_NoIDLFiles(t *testing.T) {
-	code := Main(context.Background(), cli.Context{
-		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
-			if key == "PATH" {
-				return "/nonexistent", true
-			}
-			return "", false
-		}),
-		OpenDir: staticOpenDir(fstest.MapFS{}),
-		Args:    []string{},
-	})
-
-	if code != 1 {
-		t.Errorf("exit code = %d, want 1", code)
-	}
 }
 
 // TestHelperGenerator is a test function that doubles as a real generator subprocess.

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -444,6 +444,18 @@ func TestMain_Dispatch(t *testing.T) {
 			t.Errorf("exit code = %d, want 0", code)
 		}
 	})
+
+	t.Run("init rejects extra arguments", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("init", "schema.avdl")); code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
+		}
+	})
+
+	t.Run("generate rejects extra arguments", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("generate", "schema.avdl")); code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
+		}
+	})
 }
 
 // TestHelperGenerator is a test function that doubles as a real generator subprocess.

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -58,7 +58,6 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 
 	genPool := pool.New().WithContext(ctx)
 	for _, task := range tasks {
-		task := task // capture per goroutine
 		genPool.Go(func(ctx context.Context) error {
 			g := generator{
 				log:            cli.Log,

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -58,6 +58,7 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 
 	genPool := pool.New().WithContext(ctx)
 	for _, task := range tasks {
+		task := task // capture per goroutine
 		genPool.Go(func(ctx context.Context) error {
 			g := generator{
 				log:            cli.Log,
@@ -78,9 +79,11 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 }
 
 // planGenerators resolves every manifest generator into a runnable genTask. It
-// is a pure function of the manifest, the discovered generators, and the
-// working directory so it can be exercised without spawning subprocesses. Input
-// IDL files are parsed at most once even when shared across generators.
+// is derived entirely from the manifest, the discovered generators, and the
+// working directory — no generator subprocesses are spawned — so it can be
+// unit-tested in isolation. It does read and parse the declared input IDL files
+// from disk; each input is parsed at most once even when shared across
+// generators.
 func planGenerators(m *Manifest, generators map[string]string, workingDir string) ([]genTask, error) {
 	schemaCache := make(map[string]*avrocpb.Schema)
 

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+
+	"github.com/sourcegraph/conc/pool"
+)
+
+// genTask is a single resolved unit of work: one generator to run with its
+// output directory, options, and the schemas it should generate from.
+type genTask struct {
+	name           string // avroc-gen-<name>
+	executablePath string
+	output         string
+	options        []*avrocpb.Option
+	schemas        []*avrocpb.Schema
+}
+
+// runGenerate realizes the avroc.json manifest: it resolves each declared
+// generator against the PATH-discovered executables, parses the declared input
+// IDL files, and runs the generators concurrently, writing their streamed
+// output under each generator's output directory.
+func runGenerate(ctx context.Context, cli cli.Context) int {
+	path, ok := cli.Env.LookupEnv("PATH")
+	if !ok {
+		cli.Log.ErrorContext(ctx, "unable to lookup generators", slog.Any("error", "PATH environment variable not set"))
+		return 1
+	}
+
+	generators, err := lookupGenerators(ctx, cli.Log, cli.OpenDir, filepath.SplitList(path)...)
+	if err != nil {
+		cli.Log.ErrorContext(ctx, "failed to lookup generators", slog.Any("error", err))
+		return 1
+	}
+
+	manifest, err := loadManifest(cli, cli.WorkingDir)
+	if err != nil {
+		cli.Log.ErrorContext(ctx, "failed to load manifest", slog.Any("error", err))
+		return 1
+	}
+
+	tasks, err := planGenerators(manifest, generators, cli.WorkingDir)
+	if err != nil {
+		cli.Log.ErrorContext(ctx, "failed to plan generation", slog.Any("error", err))
+		return 1
+	}
+
+	genPool := pool.New().WithContext(ctx)
+	for _, task := range tasks {
+		genPool.Go(func(ctx context.Context) error {
+			g := generator{
+				log:            cli.Log,
+				env:            cli.Env,
+				name:           task.name,
+				executablePath: task.executablePath,
+			}
+			return g.generate(ctx, task.output, task.options, task.schemas...)
+		})
+	}
+
+	if err := genPool.Wait(); err != nil {
+		cli.Log.ErrorContext(ctx, "failed to run generators", slog.Any("error", err))
+		return 1
+	}
+
+	return 0
+}
+
+// planGenerators resolves every manifest generator into a runnable genTask. It
+// is a pure function of the manifest, the discovered generators, and the
+// working directory so it can be exercised without spawning subprocesses. Input
+// IDL files are parsed at most once even when shared across generators.
+func planGenerators(m *Manifest, generators map[string]string, workingDir string) ([]genTask, error) {
+	schemaCache := make(map[string]*avrocpb.Schema)
+
+	tasks := make([]genTask, 0, len(m.Generators))
+	for _, g := range m.Generators {
+		execName := "avroc-gen-" + g.Name
+		executablePath, ok := generators[execName]
+		if !ok {
+			if g.Source != "" {
+				return nil, fmt.Errorf("generator %q references OCI image %q but OCI execution is not yet supported (see #70); install %s on PATH to use it now", g.Name, g.Source, execName)
+			}
+			return nil, fmt.Errorf("no generator %q found on PATH", execName)
+		}
+
+		inputs := dedupInputs(m.Inputs, g.Inputs)
+		if len(inputs) == 0 {
+			return nil, fmt.Errorf("generator %q has no input IDL files", g.Name)
+		}
+
+		schemas := make([]*avrocpb.Schema, len(inputs))
+		for i, in := range inputs {
+			resolved := filepath.Join(workingDir, in)
+			schema, ok := schemaCache[resolved]
+			if !ok {
+				loaded, err := loadSchema(resolved)
+				if err != nil {
+					return nil, fmt.Errorf("generator %q input %q: %w", g.Name, in, err)
+				}
+				schemaCache[resolved] = loaded
+				schema = loaded
+			}
+			schemas[i] = schema
+		}
+
+		tasks = append(tasks, genTask{
+			name:           execName,
+			executablePath: executablePath,
+			output:         filepath.Join(workingDir, g.Out),
+			options:        g.options(),
+			schemas:        schemas,
+		})
+	}
+
+	return tasks, nil
+}
+
+// dedupInputs concatenates the shared and per-generator inputs, preserving the
+// first occurrence order and dropping duplicates.
+func dedupInputs(shared, own []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, in := range append(append([]string{}, shared...), own...) {
+		if _, ok := seen[in]; ok {
+			continue
+		}
+		seen[in] = struct{}{}
+		out = append(out, in)
+	}
+	return out
+}
+
+// loadSchema parses, validates, and maps a single IDL file to the protobuf
+// schema sent to a generator.
+func loadSchema(path string) (*avrocpb.Schema, error) {
+	f, err := parseIDL(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IDL file: %w", err)
+	}
+	if f.Schema == nil {
+		return nil, fmt.Errorf("IDL file does not contain a schema")
+	}
+	if err := validateSchema(f.Schema); err != nil {
+		return nil, fmt.Errorf("schema validation failed: %w", err)
+	}
+	return mapToProtoSchema(f.Schema)
+}

--- a/internal/avroc/generate_test.go
+++ b/internal/avroc/generate_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+const sampleIDL = `namespace com.example;
+schema User;
+record User {
+  string name;
+}
+`
+
+// writeIDL writes a sample IDL file under dir and returns its base name.
+func writeIDL(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(sampleIDL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+func TestPlanGenerators(t *testing.T) {
+	t.Run("resolves a local generator with composed, deduped inputs", func(t *testing.T) {
+		dir := t.TempDir()
+		shared := writeIDL(t, dir, "shared.avdl")
+		own := writeIDL(t, dir, "own.avdl")
+
+		m := &Manifest{
+			Inputs: []string{shared},
+			Generators: []GeneratorConfig{
+				{
+					Name:    "go",
+					Out:     "gen/go",
+					Options: map[string]string{"package_name": "models"},
+					// shared is repeated here; it must be deduped to one schema.
+					Inputs: []string{own, shared},
+				},
+			},
+		}
+		generators := map[string]string{"avroc-gen-go": "/fake/avroc-gen-go"}
+
+		tasks, err := planGenerators(m, generators, dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tasks) != 1 {
+			t.Fatalf("tasks = %d, want 1", len(tasks))
+		}
+
+		task := tasks[0]
+		if task.name != "avroc-gen-go" {
+			t.Errorf("name = %q, want avroc-gen-go", task.name)
+		}
+		if task.executablePath != "/fake/avroc-gen-go" {
+			t.Errorf("executablePath = %q", task.executablePath)
+		}
+		if want := filepath.Join(dir, "gen/go"); task.output != want {
+			t.Errorf("output = %q, want %q", task.output, want)
+		}
+		if len(task.options) != 1 || task.options[0].GetName() != "package_name" {
+			t.Errorf("options = %v", task.options)
+		}
+		// shared + own + shared(dup) => 2 schemas.
+		if len(task.schemas) != 2 {
+			t.Errorf("schemas = %d, want 2 (deduped)", len(task.schemas))
+		}
+	})
+
+	t.Run("parses a shared input once across generators", func(t *testing.T) {
+		dir := t.TempDir()
+		shared := writeIDL(t, dir, "shared.avdl")
+
+		m := &Manifest{
+			Inputs: []string{shared},
+			Generators: []GeneratorConfig{
+				{Name: "go", Out: "gen/go"},
+				{Name: "json", Out: "gen/json"},
+			},
+		}
+		generators := map[string]string{
+			"avroc-gen-go":   "/fake/avroc-gen-go",
+			"avroc-gen-json": "/fake/avroc-gen-json",
+		}
+
+		tasks, err := planGenerators(m, generators, dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tasks) != 2 {
+			t.Fatalf("tasks = %d, want 2", len(tasks))
+		}
+		// The cache must hand both generators the very same schema value.
+		if tasks[0].schemas[0] != tasks[1].schemas[0] {
+			t.Error("shared input was parsed more than once (schema not cached)")
+		}
+	})
+
+	t.Run("errors when an OCI-only generator is not on PATH", func(t *testing.T) {
+		m := &Manifest{
+			Generators: []GeneratorConfig{
+				{Name: "rust", Source: "ghcr.io/z5labs/avroc-gen-rust", Out: "gen", Inputs: []string{"x.avdl"}},
+			},
+		}
+
+		_, err := planGenerators(m, map[string]string{}, t.TempDir())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "#70") {
+			t.Errorf("error should mention #70, got: %v", err)
+		}
+	})
+
+	t.Run("errors when a generator is not on PATH and has no source", func(t *testing.T) {
+		m := &Manifest{
+			Generators: []GeneratorConfig{
+				{Name: "go", Out: "gen", Inputs: []string{"x.avdl"}},
+			},
+		}
+
+		_, err := planGenerators(m, map[string]string{}, t.TempDir())
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "avroc-gen-go") {
+			t.Errorf("error should name the missing generator, got: %v", err)
+		}
+	})
+
+	t.Run("errors when a generator has no inputs", func(t *testing.T) {
+		m := &Manifest{
+			Generators: []GeneratorConfig{{Name: "go", Out: "gen"}},
+		}
+		generators := map[string]string{"avroc-gen-go": "/fake/avroc-gen-go"}
+
+		if _, err := planGenerators(m, generators, t.TempDir()); err == nil {
+			t.Fatal("expected an error for missing inputs, got nil")
+		}
+	})
+}
+
+func TestRunGenerate_MissingManifest(t *testing.T) {
+	ctx := cli.Context{
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			if key == "PATH" {
+				return "/nonexistent", true
+			}
+			return "", false
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: t.TempDir(), // empty dir: no avroc.json
+	}
+
+	if code := runGenerate(context.Background(), ctx); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestRunGenerate_PathNotSet(t *testing.T) {
+	ctx := cli.Context{
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env:     cli.EnvironmentFunc(func(string) (string, bool) { return "", false }),
+		OpenDir: staticOpenDir(fstest.MapFS{}),
+	}
+
+	if code := runGenerate(context.Background(), ctx); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}

--- a/internal/avroc/init.go
+++ b/internal/avroc/init.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+// runInit scaffolds a starter avroc.json under the working directory. It never
+// clobbers an existing manifest: if one is present it reports that and exits 0.
+func runInit(ctx context.Context, cli cli.Context) int {
+	if _, err := fs.Stat(cli.OpenDir(cli.WorkingDir), manifestFilename); err == nil {
+		fmt.Fprintf(os.Stdout, "%s already exists; not overwriting\n", manifestFilename)
+		return 0
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		cli.Log.ErrorContext(ctx, "failed to check for existing manifest", slog.Any("error", err))
+		return 1
+	}
+
+	data, err := marshalManifest(scaffoldManifest())
+	if err != nil {
+		cli.Log.ErrorContext(ctx, "failed to render manifest", slog.Any("error", err))
+		return 1
+	}
+
+	dst := filepath.Join(cli.WorkingDir, manifestFilename)
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		cli.Log.ErrorContext(ctx, "failed to write manifest", slog.String("path", dst), slog.Any("error", err))
+		return 1
+	}
+
+	fmt.Fprintf(os.Stdout, "created %s\n", manifestFilename)
+	return 0
+}
+
+// scaffoldManifest is the starter manifest avroc init writes: a single Go
+// generator over one example input, ready for the user to edit.
+func scaffoldManifest() *Manifest {
+	return &Manifest{
+		Inputs: []string{"schema.avdl"},
+		Generators: []GeneratorConfig{
+			{
+				Name:    "go",
+				Source:  "ghcr.io/z5labs/avroc-gen-go",
+				Version: "v0.1.0",
+				Out:     "gen",
+				Options: map[string]string{"package_name": "models"},
+			},
+		},
+	}
+}

--- a/internal/avroc/init.go
+++ b/internal/avroc/init.go
@@ -21,7 +21,7 @@ import (
 // clobbers an existing manifest: if one is present it reports that and exits 0.
 func runInit(ctx context.Context, cli cli.Context) int {
 	if _, err := fs.Stat(cli.OpenDir(cli.WorkingDir), manifestFilename); err == nil {
-		fmt.Fprintf(os.Stdout, "%s already exists; not overwriting\n", manifestFilename)
+		_, _ = fmt.Fprintf(os.Stdout, "%s already exists; not overwriting\n", manifestFilename)
 		return 0
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		cli.Log.ErrorContext(ctx, "failed to check for existing manifest", slog.Any("error", err))
@@ -40,7 +40,7 @@ func runInit(ctx context.Context, cli cli.Context) int {
 		return 1
 	}
 
-	fmt.Fprintf(os.Stdout, "created %s\n", manifestFilename)
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", manifestFilename)
 	return 0
 }
 

--- a/internal/avroc/init_test.go
+++ b/internal/avroc/init_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+func initContext(workingDir string) cli.Context {
+	return cli.Context{
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: workingDir,
+	}
+}
+
+func TestRunInit(t *testing.T) {
+	t.Run("scaffolds a valid manifest", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if code := runInit(context.Background(), initContext(dir)); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+
+		// The scaffold must be a manifest the loader accepts.
+		m, err := loadManifest(initContext(dir), dir)
+		if err != nil {
+			t.Fatalf("scaffolded manifest does not load: %v", err)
+		}
+		if len(m.Generators) != 1 || m.Generators[0].Name != "go" {
+			t.Errorf("scaffolded manifest = %+v", m)
+		}
+	})
+
+	t.Run("does not clobber an existing manifest", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, manifestFilename)
+
+		existing := []byte(`{"generators":[{"name":"custom","out":"x"}]}`)
+		if err := os.WriteFile(path, existing, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if code := runInit(context.Background(), initContext(dir)); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(existing) {
+			t.Errorf("existing manifest was modified:\n%s", got)
+		}
+	})
+}

--- a/internal/avroc/manifest.go
+++ b/internal/avroc/manifest.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"maps"
+	"slices"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// manifestFilename is the fixed name of the declarative project manifest avroc
+// init scaffolds and avroc generate reads.
+const manifestFilename = "avroc.json"
+
+// Manifest is the declarative description of which generators a project uses
+// and how they are configured. It is the checked-in, reviewable record that
+// avroc generate realizes.
+type Manifest struct {
+	// Inputs are IDL files shared by every generator. Each generator's
+	// effective input set is these plus its own Inputs.
+	Inputs     []string          `json:"inputs,omitempty"`
+	Generators []GeneratorConfig `json:"generators"`
+}
+
+// GeneratorConfig describes a single generator entry in the manifest.
+type GeneratorConfig struct {
+	// Name is the logical generator name, i.e. the <name> in avroc-gen-<name>.
+	Name string `json:"name"`
+	// Source is the OCI image reference (e.g. ghcr.io/z5labs/avroc-gen-go). It
+	// is recorded here and consumed by the acquisition/execution work (#69/#70);
+	// avroc generate today resolves generators from PATH.
+	Source string `json:"source,omitempty"`
+	// Version is the OCI image tag. Recorded for #69/#70.
+	Version string `json:"version,omitempty"`
+	// Out is the output directory for this generator.
+	Out string `json:"out"`
+	// Options is the declarative form of the -<name>_opt key=value flags.
+	Options map[string]string `json:"options,omitempty"`
+	// Inputs are IDL files specific to this generator, merged with the
+	// top-level Manifest.Inputs.
+	Inputs []string `json:"inputs,omitempty"`
+}
+
+// options converts the manifest option map into the protobuf Option slice the
+// Generator service expects. Entries are sorted by key so the request (and the
+// resulting generation) is deterministic.
+func (g GeneratorConfig) options() []*avrocpb.Option {
+	keys := slices.Sorted(maps.Keys(g.Options))
+	opts := make([]*avrocpb.Option, 0, len(keys))
+	for _, k := range keys {
+		opts = append(opts, &avrocpb.Option{
+			Name:  proto.String(k),
+			Value: proto.String(g.Options[k]),
+		})
+	}
+	return opts
+}
+
+// loadManifest reads and validates the manifest located at manifestFilename
+// under workingDir. Unknown JSON fields are rejected so typos surface as errors
+// rather than being silently ignored.
+func loadManifest(cli cli.Context, workingDir string) (*Manifest, error) {
+	data, err := fs.ReadFile(cli.OpenDir(workingDir), manifestFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var m Manifest
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", manifestFilename, err)
+	}
+
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (m *Manifest) validate() error {
+	if len(m.Generators) == 0 {
+		return fmt.Errorf("%s declares no generators", manifestFilename)
+	}
+	for i, g := range m.Generators {
+		if g.Name == "" {
+			return fmt.Errorf("generator at index %d is missing a name", i)
+		}
+		if g.Out == "" {
+			return fmt.Errorf("generator %q is missing an output directory (out)", g.Name)
+		}
+	}
+	return nil
+}
+
+// marshalManifest renders a manifest as the canonical JSON avroc init writes:
+// two-space indentation and a trailing newline.
+func marshalManifest(m *Manifest) ([]byte, error) {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}

--- a/internal/avroc/manifest.go
+++ b/internal/avroc/manifest.go
@@ -8,7 +8,9 @@ package avroc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"slices"
@@ -82,6 +84,13 @@ func loadManifest(cli cli.Context, workingDir string) (*Manifest, error) {
 	var m Manifest
 	if err := dec.Decode(&m); err != nil {
 		return nil, fmt.Errorf("failed to parse %s: %w", manifestFilename, err)
+	}
+
+	// Decode stops after the first JSON value; reject any trailing content so a
+	// malformed or accidentally concatenated manifest surfaces as an error
+	// instead of being silently ignored.
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("unexpected trailing data after JSON object in %s", manifestFilename)
 	}
 
 	if err := m.validate(); err != nil {

--- a/internal/avroc/manifest.go
+++ b/internal/avroc/manifest.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/fs"
 	"maps"
+	"path/filepath"
 	"slices"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
@@ -103,12 +104,25 @@ func (m *Manifest) validate() error {
 	if len(m.Generators) == 0 {
 		return fmt.Errorf("%s declares no generators", manifestFilename)
 	}
+	for _, in := range m.Inputs {
+		if !filepath.IsLocal(in) {
+			return fmt.Errorf("input %q must be a relative path within the project (no absolute paths or %q traversal)", in, "..")
+		}
+	}
 	for i, g := range m.Generators {
 		if g.Name == "" {
 			return fmt.Errorf("generator at index %d is missing a name", i)
 		}
 		if g.Out == "" {
 			return fmt.Errorf("generator %q is missing an output directory (out)", g.Name)
+		}
+		if !filepath.IsLocal(g.Out) {
+			return fmt.Errorf("generator %q output %q must be a relative path within the project (no absolute paths or %q traversal)", g.Name, g.Out, "..")
+		}
+		for _, in := range g.Inputs {
+			if !filepath.IsLocal(in) {
+				return fmt.Errorf("generator %q input %q must be a relative path within the project (no absolute paths or %q traversal)", g.Name, in, "..")
+			}
 		}
 	}
 	return nil

--- a/internal/avroc/manifest_test.go
+++ b/internal/avroc/manifest_test.go
@@ -105,6 +105,15 @@ func TestLoadManifest(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects trailing content after the manifest object", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "go", "out": "gen"}]}{"generators": []}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for trailing content, got nil")
+		}
+	})
+
 	t.Run("reports a missing manifest file", func(t *testing.T) {
 		if _, err := loadManifest(manifestContext(fstest.MapFS{}), "."); err == nil {
 			t.Fatal("expected error for missing manifest, got nil")

--- a/internal/avroc/manifest_test.go
+++ b/internal/avroc/manifest_test.go
@@ -114,6 +114,51 @@ func TestLoadManifest(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects an absolute output directory", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "go", "out": "/etc"}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for absolute out, got nil")
+		}
+	})
+
+	t.Run("rejects an output directory that escapes the project", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "go", "out": "../escape"}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for traversing out, got nil")
+		}
+	})
+
+	t.Run("rejects an input that escapes the project", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"inputs": ["../secret.avdl"], "generators": [{"name": "go", "out": "gen"}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for traversing input, got nil")
+		}
+	})
+
+	t.Run("rejects a per-generator input that escapes the project", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "go", "out": "gen", "inputs": ["/abs/schema.avdl"]}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for absolute per-generator input, got nil")
+		}
+	})
+
+	t.Run("accepts \".\" as an output directory", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "json", "out": "."}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err != nil {
+			t.Fatalf("unexpected error for out=\".\": %v", err)
+		}
+	})
+
 	t.Run("reports a missing manifest file", func(t *testing.T) {
 		if _, err := loadManifest(manifestContext(fstest.MapFS{}), "."); err == nil {
 			t.Fatal("expected error for missing manifest, got nil")

--- a/internal/avroc/manifest_test.go
+++ b/internal/avroc/manifest_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"io"
+	"io/fs"
+	"log/slog"
+	"testing"
+	"testing/fstest"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+func manifestContext(fsys fs.FS) cli.Context {
+	return cli.Context{
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OpenDir:    staticOpenDir(fsys),
+		WorkingDir: ".",
+	}
+}
+
+func TestLoadManifest(t *testing.T) {
+	t.Run("parses a valid manifest", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{
+				"inputs": ["schemas/user.avdl"],
+				"generators": [
+					{
+						"name": "go",
+						"source": "ghcr.io/z5labs/avroc-gen-go",
+						"version": "v0.1.0",
+						"out": "gen/go",
+						"options": {"package_name": "models"},
+						"inputs": ["schemas/extra.avdl"]
+					}
+				]
+			}`)},
+		}
+
+		m, err := loadManifest(manifestContext(fsys), ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(m.Inputs) != 1 || m.Inputs[0] != "schemas/user.avdl" {
+			t.Errorf("inputs = %v, want [schemas/user.avdl]", m.Inputs)
+		}
+		if len(m.Generators) != 1 {
+			t.Fatalf("generators count = %d, want 1", len(m.Generators))
+		}
+		g := m.Generators[0]
+		if g.Name != "go" || g.Out != "gen/go" {
+			t.Errorf("generator = %+v, want name=go out=gen/go", g)
+		}
+		if g.Source != "ghcr.io/z5labs/avroc-gen-go" || g.Version != "v0.1.0" {
+			t.Errorf("source/version = %q/%q", g.Source, g.Version)
+		}
+		if g.Options["package_name"] != "models" {
+			t.Errorf("options = %v", g.Options)
+		}
+		if len(g.Inputs) != 1 || g.Inputs[0] != "schemas/extra.avdl" {
+			t.Errorf("per-generator inputs = %v", g.Inputs)
+		}
+	})
+
+	t.Run("rejects unknown fields", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{
+				"generators": [{"name": "go", "out": "gen", "typo": true}]
+			}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for unknown field, got nil")
+		}
+	})
+
+	t.Run("rejects a manifest with no generators", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": []}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for empty generators, got nil")
+		}
+	})
+
+	t.Run("rejects a generator missing name", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"out": "gen"}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for missing name, got nil")
+		}
+	})
+
+	t.Run("rejects a generator missing out", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			manifestFilename: &fstest.MapFile{Data: []byte(`{"generators": [{"name": "go"}]}`)},
+		}
+		if _, err := loadManifest(manifestContext(fsys), "."); err == nil {
+			t.Fatal("expected error for missing out, got nil")
+		}
+	})
+
+	t.Run("reports a missing manifest file", func(t *testing.T) {
+		if _, err := loadManifest(manifestContext(fstest.MapFS{}), "."); err == nil {
+			t.Fatal("expected error for missing manifest, got nil")
+		}
+	})
+}
+
+func TestGeneratorConfigOptions(t *testing.T) {
+	g := GeneratorConfig{
+		Options: map[string]string{
+			"encoding":     "single_object",
+			"package_name": "models",
+		},
+	}
+
+	opts := g.options()
+	if len(opts) != 2 {
+		t.Fatalf("options count = %d, want 2", len(opts))
+	}
+	// Sorted by key: "encoding" before "package_name".
+	if opts[0].GetName() != "encoding" || opts[0].GetValue() != "single_object" {
+		t.Errorf("opts[0] = %q=%q", opts[0].GetName(), opts[0].GetValue())
+	}
+	if opts[1].GetName() != "package_name" || opts[1].GetValue() != "models" {
+		t.Errorf("opts[1] = %q=%q", opts[1].GetName(), opts[1].GetValue())
+	}
+}
+
+func TestMarshalManifest(t *testing.T) {
+	m := &Manifest{
+		Inputs: []string{"schemas/user.avdl"},
+		Generators: []GeneratorConfig{
+			{Name: "go", Out: "gen/go", Options: map[string]string{"package_name": "models"}},
+		},
+	}
+
+	data, err := marshalManifest(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Error("expected a trailing newline")
+	}
+
+	// The rendered manifest must round-trip back through the loader.
+	fsys := fstest.MapFS{manifestFilename: &fstest.MapFile{Data: data}}
+	got, err := loadManifest(manifestContext(fsys), ".")
+	if err != nil {
+		t.Fatalf("rendered manifest did not round-trip: %v", err)
+	}
+	if len(got.Generators) != 1 || got.Generators[0].Name != "go" {
+		t.Errorf("round-tripped manifest = %+v", got)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,5 +24,8 @@ type Context struct {
 	Log     *slog.Logger
 	Env     Environment
 	OpenDir func(dir string) fs.FS
-	Args    []string
+	// WorkingDir is the directory avroc reads the manifest from and resolves
+	// relative manifest paths (inputs, output dirs) against.
+	WorkingDir string
+	Args       []string
 }


### PR DESCRIPTION
## Summary

Closes #68. Introduces a checked-in `avroc.json` manifest that declares which generators a project uses and how they are configured, plus `avroc init` to scaffold it and `avroc generate` to realize it. This is the Terraform/Dagger-style workflow that the OCI follow-ons (#69 acquisition + lockfile, #70 container execution) build on.

avroc moves from a flag-only CLI (`avroc -<name>_out … <idl files>`) to a **subcommands-only** surface (`avroc init` / `avroc generate` / `avroc help`).

## Manifest (`avroc.json`)

```json
{
  "inputs": ["schema.avdl"],
  "generators": [
    { "name": "go", "source": "ghcr.io/z5labs/avroc-gen-go", "version": "v0.1.0",
      "out": "gen", "options": { "package_name": "models", "encoding": "single_object" } },
    { "name": "json", "out": "." },
    { "name": "pcf", "out": "pcf" }
  ]
}
```

- **Format:** JSON (`encoding/json`, no new dependency; brace-based, Dagger-style).
- `source`/`version` are **recorded** for the containerized-generator workflow but not yet consumed — today generators run from `PATH`. A manifest entry whose generator isn't on `PATH` reports a clear error; if it also names an OCI `source`, the error explains containerized execution is not yet supported (see #70).

## Changes

- `internal/avroc/manifest.go` — schema, loader (rejects unknown fields), validation, sorted `options()`, canonical marshal.
- `internal/avroc/init.go` — `avroc init`; idempotent no-op (exit 0) if a manifest already exists.
- `internal/avroc/generate.go` — `runGenerate` + pure, unit-tested `planGenerators`: resolves `avroc-gen-<name>`, composes/dedupes inputs (shared input parsed once), runs generators concurrently over the existing streaming `Generator` contract.
- `internal/avroc/avroc.go` — `Main` is now a subcommand dispatcher; retired `optionFlag` / `printHelp` / the bare flag path.
- `internal/cli/cli.go` — added `WorkingDir` (manifest read + relative-path resolution seam).
- Docs: `README.md` and `example/` updated to the manifest workflow; added `example/avroc.json`.

## Acceptance criteria

- [x] Manifest format defined + documented (name, source, version, out, options, inputs).
- [x] `avroc init` scaffolds a starter manifest and does not clobber an existing one.
- [x] `avroc generate` runs declared generators (output dir + options + inputs) with behavior equivalent to the old `-<name>_out` / `-<name>_opt` flags.
- [x] Existing `PATH`-discovered local generators continue to work.
- [x] `go build ./...` and `go test ./...` pass.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass.
- End-to-end with freshly `go install`ed generators: `avroc init` (incl. no-clobber), `avroc generate`, and `avroc help` all work. Generated `gen/kind.go`, `test_record.avsc`, and `pcf/test_record.avsc` are **byte-for-byte identical** to the committed `example/` outputs (parity with the old flags). The OCI-only path emits the `#70` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)