### PR TITLE
story(docs): adopt spec conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A modular code generator for messages and services defined in [Avro IDL](https://avro.apache.org/docs/current/idl-language/).
 
+## Specs
+
+Three interfaces are built against from outside this repository, so each is
+specified rather than merely implemented:
+
+- [The resolved IR](docs/ir/SPEC.md) — what every generator plugin consumes, in
+  any language.
+- [The generator plugin CLI contract](docs/plugin/SPEC.md) — what
+  `avroc-gen-<name>` has to implement.
+- [The container base-image contract](docs/container/SPEC.md) — what a
+  Dockerfile building `FROM` the published image may rely on.
+
+[docs/CONVENTIONS.md](docs/CONVENTIONS.md) defines the conformance language all
+three use, and what else they have in common.
+
 ## Features
 
 - **Declarative manifest** — a project's generators and their configuration live in a checked-in `avroc.json` manifest, so generator selection and options are diffable, reviewable, and shared across a team and CI. `avroc init` scaffolds one to get started.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,179 @@
+# Spec conventions
+
+Three of avroc's interfaces are things other people build against rather than
+things it is free to change: the resolved IR, the generator plugin CLI contract,
+and the container base-image contract. Each is harder to change than the code
+behind it, so each gets a `SPEC.md` under this directory. They are linked from
+the [README](../README.md), which is the only list of them — a second list here
+would be a second answer to what the specs are, and two answers drift.
+
+This document is what those specs agree on. It exists because the alternative is
+three documents that each invent a shape and each define **MUST** in their own
+wording, so that having read one teaches you nothing about how to read the next.
+
+The model throughout is [cpybkc's `docs/CONVENTIONS.md`][cpybkc] — the sibling
+project this one adopted its plugin and distribution model from. Where a
+convention below has no stated reason, the reason is that cpybkc does it that
+way, and agreement between the two repositories is worth more than a local
+improvement.
+
+[cpybkc]: https://github.com/Zaba505/cpybkc/blob/main/docs/CONVENTIONS.md
+
+## What belongs here
+
+A document under `docs/` specifies an interface a third party builds against.
+That is the whole test, and it excludes more than it admits:
+
+- **Implementation gets no spec.** The stage that parses Avro IDL and resolves
+  its type references into IR has as its correctness criterion that its output
+  satisfies `ir/SPEC.md`. A second document describing how it computes that
+  would drift from the code the first time an optimisation landed, and nobody
+  outside this repository builds against it.
+- **Test infrastructure documents itself where it lives.** The `example/`
+  round-trip is a corpus plus the command that regenerates it, checked by
+  `git diff --exit-code`. It is documented with the corpus.
+- **Conveniences over a contract are not contracts.** The Dagger module that
+  runs avroc for a caller wraps the container contract; what it needs to say is
+  said by its module comment and `dagger call --help`.
+
+Something that fails the test and still needs writing down goes in a package
+comment, in `CONTRIBUTING.md`, or in a comment in the file it is about. All
+three are places this repository already keeps its reasoning.
+
+## Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+interface a document specifies and on the code implementing it. Everything else
+is descriptive. A requirement written in a spec is not a suggestion a downstream
+story may weigh against ergonomics.
+
+Those four, and no others. There is no **SHOULD NOT**, no **SHALL**, no
+**REQUIRED**/**RECOMMENDED**/**OPTIONAL**, and no citation of RFC 2119 or RFC
+8174. Citing 2119 would import eight keywords and 8174's rule about lowercase
+uses in order to define the four that have been needed and four that have not,
+and a keyword nobody has used is a keyword nobody has agreed the meaning of.
+
+Keywords are **always bolded**, never bare. A document that separates a
+normative `MUST` from an ordinary "must" by capitalisation alone depends on the
+reader noticing capitalisation, and stops working the moment a sentence is
+quoted into an issue or a review comment.
+
+A spec restates this by reference and never by rewording, in a
+`### Conformance language` subsection of its overview. What that sentence
+repeats is *which words are normative*, so a reader never has to leave the
+document to learn what to watch for. What is defined once, here, and never
+repeated is what they mean, that there is no fifth, and that they are bolded:
+
+```markdown
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on
+⟨what the document specifies⟩, interpreted as described in
+[CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+```
+
+## The shape of a spec
+
+In this order:
+
+1. `# Title`.
+2. `## Overview`, opening by disclaiming the neighbouring specs' territory and
+   closing with the formula — *X questions belong there; Y questions belong
+   here.* A spec that never says what it is not about leaves the gap between two
+   documents to be discovered by whoever falls into it.
+3. `### Scope`, a short paragraph of what is in, ending with a pointer to `Out
+   of Scope` rather than a list of exclusions. The exclusions are long and carry
+   reasons; they do not belong in front matter.
+4. `### Governing sources`, below.
+5. `### Conformance language`, the reference sentence above.
+6. The normative body, one `##` per topic.
+7. `## Out of Scope`, near the back and before any appendix. One `###` per
+   non-trivial exclusion, each with an explicit `Reason:` paragraph, then a
+   catch-all `### Also out of scope` list for the cheap ones. An exclusion
+   without a reason gets re-proposed every six months.
+8. `## Appendix: Mapping to Stories`, below. Other appendices — test vectors, a
+   cross-reference table — go before it as the document needs them.
+
+Subsection titles that carry an argument are welcome throughout. *protobuf is a
+schema language, not a service* and *The nested tree is kept* are load-bearing
+headings rather than decoration: a heading that states its conclusion is a
+heading somebody can find again.
+
+### Governing sources
+
+A bulleted list. Each entry names the source in bold and its title in italics,
+then says in prose what it is normative *for* and why it is needed, with a bare
+autolink where the source has a URL:
+
+> - **Apache Avro 1.12.0**, *Specification* — the normative definition of
+>   schema declaration, naming and the binary encoding. It fixes the schema
+>   model and the wire format, and says nothing about how a code generator
+>   represents either, which is why the rest of this list is needed.
+>   <https://avro.apache.org/docs/1.12.0/specification/>
+
+Prose rather than a table, because the useful part is the "normative for what",
+and that does not fit in a cell.
+
+The list is followed by a blockquote saying what happens when the sources
+disagree:
+
+> **Ambiguity:** where the sources differ this document does **not** choose a
+> winner; it records the fork as a setting and states who takes which side.
+
+A spec whose sources cannot conflict says that instead, in one line. Silence is
+not an option: an adopter who hits a contradiction needs to know whether they
+have found a bug in the spec or a fork the spec declined to resolve on purpose.
+
+### Traceability
+
+Two mechanisms:
+
+- **Inline `(#NN)` citations** closing a normative statement, naming the stories
+  the requirement lands on.
+- **`## Appendix: Mapping to Stories`**, a `| Section | Implemented by |` table
+  of anchor links against issue numbers.
+
+There are no bracketed requirement identifiers — no `[IR-1]`, no `[PLUGIN-7]`.
+They read as rigour and are not: a number is stable only until the requirement
+is split, and nothing checks that one is used exactly once.
+
+The table is the authoritative half. It also carries rows for stories that
+produced **no** section — a removal, a build change, a published artifact —
+mapped to what they did instead, so that the appendix answers "where did #NN
+land" as well as "who implements this section". A section and its row move
+together, in one change; a filled section whose row still says nothing is half a
+change.
+
+### What a spec does not carry
+
+**No version number, no date, no status badge, no changelog.** Git is the
+history and the Mapping to Stories table is the status; a hand-maintained `Last
+updated:` line is a claim that goes stale in silence. The IR's own version field
+is a different thing — a field in the protobuf, specified by `ir/SPEC.md`, which
+versions the interface rather than the document.
+
+**No reference by line number, to any file, ever.** Cite a section by name and
+link its anchor. A line number into a thousand-line document rots the moment
+either file is edited.
+
+**Lines wrapped at 80 columns**, tables exempted because there is nowhere to
+break them. Specs are reviewed as diffs, and a paragraph on a single line turns
+a one-word change into an unreadable hunk.
+
+## Stubs
+
+A spec that has been given its shape but not its content carries a `> **Stub.**`
+blockquote directly under the title, naming the story that writes it, and one
+HTML comment per empty heading naming what belongs there. The story that fills
+the document deletes the blockquote and the comments as it goes.
+
+A stub contains **no conformance keyword** outside its own conformance-language
+sentence. A stub is the outline nobody argued about; a normative claim in one is
+a requirement nobody reviewed.
+
+## `CLAUDE.md`
+
+A spec is paired with a `CLAUDE.md` in the same directory carrying what an
+implementer needs to know that is not a requirement on the interface. A spec
+directory here gains one once there is an implementation to guide, and not
+before — written against a stub it would be guidance about nothing.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -68,7 +68,11 @@ published avroc image and on images derived from it, interpreted as described in
 
 <!-- One ### per non-trivial exclusion, each with an explicit Reason:
      paragraph — the build machinery, the registry location, and the plugin CLI
-     conventions — then a catch-all ### Also out of scope list. -->
+     conventions — each above this catch-all as it is decided. -->
+
+### Also out of scope
+
+<!-- The list for exclusions too cheap to earn a heading of their own. -->
 
 ## Appendix: Mapping to Stories
 

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -1,0 +1,77 @@
+# The container base-image contract
+
+> **Stub.** This document has its shape and not its content.
+> [#107](https://github.com/z5labs/avroc/issues/107) writes it, and deletes this
+> blockquote and the comments below as it goes.
+
+## Overview
+
+<!-- What a Dockerfile building FROM the published avroc image may rely on, and
+     why the image is a public contract rather than a convenient way to ship a
+     binary. Disclaim the neighbours — what a plugin does once invoked belongs
+     to plugin/SPEC.md, and what it is invoked with belongs to ir/SPEC.md. Close
+     with the formula: X questions belong there; Y questions belong here. -->
+
+### Scope
+
+<!-- A short paragraph of what is in, ending with a pointer to Out of Scope
+     rather than a list of exclusions. -->
+
+### Governing sources
+
+<!-- Bulleted, prose, bare autolinks: the OCI Image Format Specification, the
+     Dockerfile reference, and this repository's plugin/SPEC.md for what lands
+     in the plugin directory. Followed by the ambiguity blockquote. -->
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+published avroc image and on images derived from it, interpreted as described in
+[CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+
+## The plugin directory
+
+<!-- The one stable path on PATH that a derived image copies a generator into,
+     with its stability guarantee stated alongside it rather than
+     separately. -->
+
+## The entrypoint
+
+<!-- The avroc CLI, and what a derived image must not do to it. -->
+
+## The user
+
+<!-- A stable non-root UID: why it is pinned rather than allocated, what it
+     means for ownership of the plugin and output directories, and guidance on
+     --user $(id -u):$(id -g) for writing files a caller can read. -->
+
+## No shell
+
+<!-- Stated plainly, with the consequence: extension is COPY-only and no RUN
+     works in a derived stage. -->
+
+## Tags
+
+<!-- Which exist, and what pinning one promises across a rebuild. -->
+
+## Worked example
+
+<!-- A multi-stage Dockerfile that builds a custom plugin and copies it in,
+     runnable as written. -->
+
+## Compatibility guarantees
+
+<!-- What is covered, what is explicitly implementation detail, and how a
+     covered thing would change if it had to. -->
+
+## Out of Scope
+
+<!-- One ### per non-trivial exclusion, each with an explicit Reason:
+     paragraph — the build machinery, the registry location, and the plugin CLI
+     conventions — then a catch-all ### Also out of scope list. -->
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+| --- | --- |
+| _Document shape and stub_ | [#103](https://github.com/z5labs/avroc/issues/103) |

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -60,7 +60,11 @@ in [CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
 ## Out of Scope
 
 <!-- One ### per non-trivial exclusion, each with an explicit Reason:
-     paragraph, then a catch-all ### Also out of scope list. -->
+     paragraph, added above this catch-all as the exclusion is decided. -->
+
+### Also out of scope
+
+<!-- The list for exclusions too cheap to earn a heading of their own. -->
 
 ## Appendix: Mapping to Stories
 

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1,0 +1,69 @@
+# The resolved IR
+
+> **Stub.** This document has its shape and not its content.
+> [#105](https://github.com/z5labs/avroc/issues/105) writes it, and deletes this
+> blockquote and the comments below as it goes.
+
+## Overview
+
+<!-- What the IR is: the value every generator plugin consumes, in any
+     language. Disclaim the neighbours — how a plugin is invoked with it
+     belongs to plugin/SPEC.md, and where the executable holding it comes from
+     belongs to container/SPEC.md. Close with the formula: X questions belong
+     there; Y questions belong here. -->
+
+### Scope
+
+<!-- A short paragraph of what is in, ending with a pointer to Out of Scope
+     rather than a list of exclusions. -->
+
+### Governing sources
+
+<!-- Bulleted, prose, bare autolinks: the Avro specification, the protobuf
+     proto3 language guide, and descriptor.proto. Each entry says what it is
+     normative for and why it is needed. Followed by the ambiguity
+     blockquote. -->
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+resolved IR and on the code producing and consuming it, interpreted as described
+in [CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+
+## protobuf is a schema language, not a service
+
+<!-- No service definition, no server, no port, no lifecycle. Include the
+     argument, because a reader arriving from protoc expects a service. -->
+
+## The version field
+
+<!-- The field itself, and the rule that a consumer reads it before processing
+     anything and refuses a version it does not know. -->
+
+## Compatibility
+
+<!-- The asymmetry: unknown fields are ignored, unknown members of closed sets
+     are rejected. Say which sets are closed. -->
+
+## What *resolved* means
+
+<!-- Every named-type reference carries a fully-qualified name; a generator does
+     not build its own symbol table and does not re-derive namespace
+     qualification. -->
+
+## The nested tree is kept
+
+<!-- Why avroc does not flatten into a node set the way cpybkc does: an Avro
+     schema is a tree, cpybkc's compiled automaton is a graph, and flattening
+     here would add indirection to buy nothing. -->
+
+## Out of Scope
+
+<!-- One ### per non-trivial exclusion, each with an explicit Reason:
+     paragraph, then a catch-all ### Also out of scope list. -->
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+| --- | --- |
+| _Document shape and stub_ | [#103](https://github.com/z5labs/avroc/issues/103) |

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -68,7 +68,12 @@ generator plugin and on the code invoking one, interpreted as described in
      paragraph — no transport, no plugin registry, no lockfile, no resolution
      protocol — and the reproducibility non-guarantee for PATH-supplied plugins:
      a plugin arrives on PATH by whatever means put it there, and the container
-     is the reproducible path. Then a catch-all ### Also out of scope list. -->
+     is the reproducible path. Each goes above this catch-all as it is
+     decided. -->
+
+### Also out of scope
+
+<!-- The list for exclusions too cheap to earn a heading of their own. -->
 
 ## Appendix: Mapping to Stories
 

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -1,0 +1,77 @@
+# The generator plugin CLI contract
+
+> **Stub.** This document has its shape and not its content.
+> [#106](https://github.com/z5labs/avroc/issues/106) writes it, and deletes this
+> blockquote and the comments below as it goes.
+
+## Overview
+
+<!-- What `avroc-gen-<name>` has to implement: an executable avroc finds on
+     PATH, runs, and waits for. Disclaim the neighbours — what the descriptor
+     contains belongs to ir/SPEC.md, and where the executable comes from in a
+     container belongs to container/SPEC.md. Close with the formula: X questions
+     belong there; Y questions belong here. -->
+
+### Scope
+
+<!-- A short paragraph of what is in, ending with a pointer to Out of Scope
+     rather than a list of exclusions. -->
+
+### Governing sources
+
+<!-- Bulleted, prose, bare autolinks: POSIX utility argument syntax, the
+     reproducible-builds SOURCE_DATE_EPOCH definition, and this repository's
+     ir/SPEC.md for the value being passed. Followed by the ambiguity
+     blockquote. -->
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on a
+generator plugin and on the code invoking one, interpreted as described in
+[CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+
+## Discovery
+
+<!-- The avroc-gen-<name> naming convention and its resolution against PATH,
+     consistent with the host-platform decision in #104. -->
+
+## Invocation
+
+<!-- --descriptor <path> with - for stdin, --out <dir>, repeated --opt k=v.
+     Record why a path is the default rather than stdin: it makes the bytes a
+     plugin receives reproducible, and lets an author re-run a failing
+     invocation by hand. -->
+
+## The output directory
+
+<!-- What a plugin may assume about the directory it is handed, and that
+     merging, collision detection and stale-file pruning are avroc's
+     responsibility rather than the plugin's. -->
+
+## Exit codes and diagnostics
+
+<!-- What zero and non-zero mean, and the stderr format avroc parses. -->
+
+## Determinism
+
+<!-- Identical descriptor and options produce byte-identical output: no embedded
+     timestamps, hostnames or map-iteration order. Cite SOURCE_DATE_EPOCH. -->
+
+## Capability negotiation
+
+<!-- The --plugin-info handshake by which a plugin declares what it supports
+     before being handed work. -->
+
+## Out of Scope
+
+<!-- One ### per non-trivial exclusion, each with an explicit Reason:
+     paragraph — no transport, no plugin registry, no lockfile, no resolution
+     protocol — and the reproducibility non-guarantee for PATH-supplied plugins:
+     a plugin arrives on PATH by whatever means put it there, and the container
+     is the reproducible path. Then a catch-all ### Also out of scope list. -->
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+| --- | --- |
+| _Document shape and stub_ | [#103](https://github.com/z5labs/avroc/issues/103) |


### PR DESCRIPTION
Closes #103

avroc is about to grow three specifications — the resolved IR (#105), the generator plugin CLI contract (#106) and the container base-image contract (#107) — each describing an interface a third party builds against. This adds `docs/CONVENTIONS.md`, what those three agree on, modelled on [cpybkc's `docs/CONVENTIONS.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/CONVENTIONS.md).

## Acceptance criteria

- [x] `docs/CONVENTIONS.md` exists and defines the conformance language: **MUST**, **MUST NOT**, **SHOULD** and **MAY**, always bolded, no RFC 2119 citation, and no fifth keyword.
- [x] The shape of a spec is fixed: Title → Overview → Scope → Governing sources → Conformance language → normative body → Out of Scope → Appendix: Mapping to Stories.
- [x] `Out of Scope` requires one `###` per non-trivial exclusion, each with an explicit `Reason:` paragraph, plus a catch-all `### Also out of scope` list for the cheap ones.
- [x] Traceability is defined as two mechanisms: inline `(#NN)` citations and a `| Section | Implemented by |` table. No bracketed requirement identifiers.
- [x] Documented that a spec carries no version number, no date, no status badge and no changelog, and never references another file by line number.
- [x] Lines wrap at 80 columns; tables are exempt. Enforced on every file added here.
- [x] The stub convention is documented: a `> **Stub.**` blockquote naming the story that fills it, one HTML comment per empty heading, and no conformance keyword outside the conformance-language sentence.
- [x] `README.md` gains a spec index, and is the only list of specs in the repository.

## Judgment calls

**The three specs are stubbed, not just indexed.** The last criterion puts a spec index in `README.md`, but #105–#107 have not landed, so an index alone would ship three dead links on `main` for the length of the phase. `docs/ir/SPEC.md`, `docs/plugin/SPEC.md` and `docs/container/SPEC.md` are therefore added as stubs in exactly the form this document defines — the `> **Stub.**` blockquote naming the story that fills each one, one HTML comment per empty heading drawn from that story's acceptance criteria, the conformance-language sentence quoted by reference, and no conformance keyword anywhere else. That makes the convention's own worked example the first thing to use it, and leaves #105–#107 an outline to fill rather than a file to create.

**Three specs, not cpybkc's four.** cpybkc specifies a file layout format as well; avroc has no analogue, so the count and the wording follow avroc's own interfaces throughout.

**The model is cited as cpybkc rather than as an upstream spec.** cpybkc names cobol-go's `codec/SPEC.md` as the document it imitates. avroc's equivalent claim is that it imitates cpybkc, so the "where a convention has no stated reason, the reason is that cpybkc does it that way" clause points there — agreement between the two repositories being the point.

**Illustrative examples are avroc's, not cpybkc's.** The `Governing sources` entry shows the Avro specification, and the load-bearing-heading examples are ones #105 will actually write, so the guidance reads against this repository's material.

**`## CLAUDE.md` is kept from the model** even though no criterion asks for it: it answers when a spec directory gains one, which is a question #105–#107 each reach.

## Verification

All four commands in `.claude/backlog.json` `verify` pass locally:

- `go build ./...`
- `go test -race -cover ./...`
- `golangci-lint run` — 0 issues. It first reported two `staticcheck` findings against `../issue-8/internal/avrocpb/generator_grpc.pb.go`, a file in a worktree that no longer exists; that is a stale lint cache, not a defect, and `golangci-lint cache clean` clears it.
- the `example/` round-trip, ending in `git diff --exit-code -- example`

Docs-only otherwise: no Go, proto or workflow file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)