### PR TITLE
story(ir): version the descriptor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ go test -v ./...
 
 Generators are handed **resolved** schemas (`docs/ir/SPEC.md`). `internal/avroc/resolve.go` is the only place that qualifies a namespace, knows Avro's primitive list, or decides where a named type is written out in full versus referred to by name. Every named type carries `full_name`; every type reference is a `Reference` stating its `kind`. A generator that re-derives any of this is a bug.
 
+### The IR version
+
+Every descriptor carries `GenerateRequest.version`, the single monotonic integer `docs/ir/SPEC.md` specifies. `internal/ir.Version` is the constant avroc stamps on and every generator here understands; `ir.CheckVersion` is the **first** thing a generator's `Generate` does, before options and before any schema, so a descriptor from a contract the generator does not know fails the invocation instead of being read for the parts that look familiar.
+
+Bumping `ir.Version` is the last step of a breaking change to the IR schema, never a routine one — it strands every generator built against the previous version. `ir.Validate` enforces the other half of the spec's asymmetry: unknown *fields* are ignored (protobuf drops them), unknown *members of a closed set* — type constructor, `TypeRefKind`, `SortOrder` — are rejected.
+
 ### Plugin Discovery
 
 The CLI scans all directories in `PATH` for executables matching `avroc-gen-<name>`. Each discovered generator gets a corresponding `-<name>_out` CLI flag for specifying its output directory.

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -158,6 +158,41 @@ document it was never entitled to read, so what a user sees is a complaint
 about a type they cannot fix instead of a plugin that is too old for the avroc
 in front of it.
 
+### The version this document specifies, and when it advances
+
+The version is **1**. A producer **MUST** write 1, and a consumer built against
+this document **MUST** accept 1 and refuse every other value.
+
+Zero is not a version and a producer **MUST NOT** write it. An absent integer
+field decodes as zero, so reserving it is what makes a descriptor that carries
+no version at all — one written by a producer predating this section, or one
+whose version was lost in transit — refuse in exactly the same way as one from
+a contract too new to read. A consumer **SHOULD** say which of the two it
+found, because "carries no version" and "is version 9" send a user to
+different places.
+
+The version advances by **exactly one**, to the next integer, when a change is
+breaking in the sense [Compatibility](#compatibility) defines, and at no other
+time. Concretely, it advances when the IR schema removes a field or reuses its
+number, changes what an existing field means, narrows or widens the values a
+field may hold, or adds a member to a closed set — a type constructor, a
+reference kind, a sort order. It does not advance for a field a consumer can
+ignore and still handle the descriptor correctly, which is the whole of what
+makes an additive change free.
+
+One bump covers every breaking change since the last released version, because
+the integer identifies a contract rather than an edit. A version already
+advanced and not yet released absorbs the next breaking change without
+advancing again; advancing per edit would number contracts nobody ever built
+against, and a consumer's refusal would then name a version that never
+existed.
+
+The bump is the last step of a breaking change and not a routine one. A
+producer and a consumer disagreeing about this integer is the *designed*
+outcome — it is how a plugin too old for the avroc in front of it says so —
+so raising it strands every generator built against the version before it
+until each is rebuilt.
+
 ### What this version is not
 
 It is not avroc's release version, and it is not the Go module tag of the

--- a/internal/avroc-gen-go/generate.go
+++ b/internal/avroc-gen-go/generate.go
@@ -20,6 +20,14 @@ type generatorService struct {
 // Generate implements the Generator gRPC service method, streaming each
 // generated file back to avroc, which performs the filesystem writes.
 func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	// The version comes first, before the options and before a single schema is
+	// looked at. A descriptor written against a contract this generator does not
+	// know is not one to read the recognisable parts of, and complaining about a
+	// type is no use to a user whose real problem is a generator that is too old.
+	if err := ir.CheckVersion(req.GetVersion()); err != nil {
+		return err
+	}
+
 	var packageName string
 	var encoding string
 	for _, opt := range req.GetOptions() {

--- a/internal/avroc-gen-go/stream_test.go
+++ b/internal/avroc-gen-go/stream_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // captureStream is a server stream that records the GenerateResponse chunks a
@@ -42,6 +44,16 @@ type genResult struct {
 // would, returning their full paths in emission order.
 func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
 	t.Helper()
+
+	// avroc stamps every descriptor it emits with the IR version, so a request
+	// built in a test without one is a test artefact rather than the case under
+	// test. Defaulting it here keeps the version rule tested where it is the
+	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
+	// every call site. A test that sets a version of its own keeps it.
+	if req.GetVersion() == 0 {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
 
 	cs := &captureStream{ctx: context.Background()}
 	if err := svc.Generate(req, cs); err != nil {

--- a/internal/avroc-gen-go/stream_test.go
+++ b/internal/avroc-gen-go/stream_test.go
@@ -50,7 +50,12 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 	// test. Defaulting it here keeps the version rule tested where it is the
 	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
 	// every call site. A test that sets a version of its own keeps it.
-	if req.GetVersion() == 0 {
+	//
+	// The field, not GetVersion: an explicit zero is a reserved value a test may
+	// legitimately want to send, and GetVersion cannot tell it from a field that
+	// was never set. Defaulting that away would rewrite the case under test into
+	// a passing one.
+	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}

--- a/internal/avroc-gen-go/version_test.go
+++ b/internal/avroc-gen-go/version_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGenerateRejectsUnknownIRVersion is docs/ir/SPEC.md's version rule seen
+// from the consumer's side: a descriptor written against a contract this
+// generator does not know fails the invocation with a diagnostic naming both
+// versions, rather than being read for the parts that still look familiar.
+func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version *int32
+	}{
+		{name: "no version at all", version: nil},
+		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &generatorService{}
+
+			// Deliberately not routed through generateToDir: that helper stamps
+			// a valid version onto a request that carries none, which is the
+			// one thing this test needs left alone.
+			cs := &captureStream{ctx: t.Context()}
+			err := svc.Generate(&avrocpb.GenerateRequest{
+				Version: tc.version,
+				Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+				Schemas: []*avrocpb.Schema{versionTestSchema()},
+			}, cs)
+
+			if err == nil {
+				t.Fatal("Generate accepted a descriptor whose IR version it does not know")
+			}
+			if !strings.Contains(err.Error(), "IR version") {
+				t.Errorf("diagnostic %q does not name the IR version", err.Error())
+			}
+			if len(cs.msgs) != 0 {
+				t.Errorf("generator emitted %d chunks from a descriptor it refused", len(cs.msgs))
+			}
+		})
+	}
+}
+
+// TestGenerateAcceptsTheCurrentIRVersion is the guard on the test above: a check
+// that refused everything would pass it.
+func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err != nil {
+		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// versionTestSchema is a schema this generator handles without complaint, so a
+// failure above is the version check and nothing else.
+func versionTestSchema() *avrocpb.Schema {
+	return &avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:      proto.String("Person"),
+					Namespace: proto.String("com.example"),
+					FullName:  proto.String("com.example.Person"),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("name"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_Reference{
+									Reference: &avrocpb.Reference{
+										Name: proto.String("string"),
+										Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/avroc-gen-go/version_test.go
+++ b/internal/avroc-gen-go/version_test.go
@@ -25,6 +25,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 		version *int32
 	}{
 		{name: "no version at all", version: nil},
+		{name: "explicitly zero", version: proto.Int32(0)},
 		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
 	}
 
@@ -67,6 +68,25 @@ func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// TestGenerateToDirPreservesAnExplicitVersion pins generateToDir's one piece of
+// judgment: it defaults a version onto a request that carries none, and must
+// leave alone one a test set deliberately. Zero is the case that distinguishes
+// the two, because it is a reserved value a test may legitimately want to send
+// and is indistinguishable from an unset field through the getter — defaulting
+// it away would quietly rewrite a failing case into a passing one.
+func TestGenerateToDirPreservesAnExplicitVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(0),
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err == nil {
+		t.Fatal("generateToDir replaced an explicitly reserved version with a valid one")
 	}
 }
 

--- a/internal/avroc-gen-json/generate.go
+++ b/internal/avroc-gen-json/generate.go
@@ -20,6 +20,13 @@ type generatorService struct {
 // Generate implements the Generator gRPC service method, streaming each
 // generated file back to avroc, which performs the filesystem writes.
 func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	// The version comes first, before a single schema is looked at. A descriptor
+	// written against a contract this generator does not know is not one to read
+	// the recognisable parts of.
+	if err := ir.CheckVersion(req.GetVersion()); err != nil {
+		return err
+	}
+
 	for _, schema := range req.Schemas {
 		filename, content, err := buildSchemaFile(schema)
 		if err != nil {
@@ -203,6 +210,10 @@ func recordToJSON(r *avrocpb.Record) (avroRecord, error) {
 }
 
 func fieldToJSON(f *avrocpb.Field) (avroField, error) {
+	// Ascending is Avro's default and is written by omitting the attribute, so
+	// it shares the zero value of order here. Validate has already established
+	// that the sort order is one of the three, so falling through to ascending
+	// cannot silently swallow a member this generator does not know.
 	var order string
 	switch f.GetSortOrder() {
 	case avrocpb.SortOrder_SORT_ORDER_DESC:

--- a/internal/avroc-gen-json/stream_test.go
+++ b/internal/avroc-gen-json/stream_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // captureStream is a server stream that records the GenerateResponse chunks a
@@ -42,6 +44,16 @@ type genResult struct {
 // would, returning their full paths in emission order.
 func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
 	t.Helper()
+
+	// avroc stamps every descriptor it emits with the IR version, so a request
+	// built in a test without one is a test artefact rather than the case under
+	// test. Defaulting it here keeps the version rule tested where it is the
+	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
+	// every call site. A test that sets a version of its own keeps it.
+	if req.GetVersion() == 0 {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
 
 	cs := &captureStream{ctx: context.Background()}
 	if err := svc.Generate(req, cs); err != nil {

--- a/internal/avroc-gen-json/stream_test.go
+++ b/internal/avroc-gen-json/stream_test.go
@@ -50,7 +50,12 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 	// test. Defaulting it here keeps the version rule tested where it is the
 	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
 	// every call site. A test that sets a version of its own keeps it.
-	if req.GetVersion() == 0 {
+	//
+	// The field, not GetVersion: an explicit zero is a reserved value a test may
+	// legitimately want to send, and GetVersion cannot tell it from a field that
+	// was never set. Defaulting that away would rewrite the case under test into
+	// a passing one.
+	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}

--- a/internal/avroc-gen-json/version_test.go
+++ b/internal/avroc-gen-json/version_test.go
@@ -25,6 +25,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 		version *int32
 	}{
 		{name: "no version at all", version: nil},
+		{name: "explicitly zero", version: proto.Int32(0)},
 		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
 	}
 
@@ -67,6 +68,25 @@ func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// TestGenerateToDirPreservesAnExplicitVersion pins generateToDir's one piece of
+// judgment: it defaults a version onto a request that carries none, and must
+// leave alone one a test set deliberately. Zero is the case that distinguishes
+// the two, because it is a reserved value a test may legitimately want to send
+// and is indistinguishable from an unset field through the getter — defaulting
+// it away would quietly rewrite a failing case into a passing one.
+func TestGenerateToDirPreservesAnExplicitVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(0),
+		Options: nil,
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err == nil {
+		t.Fatal("generateToDir replaced an explicitly reserved version with a valid one")
 	}
 }
 

--- a/internal/avroc-gen-json/version_test.go
+++ b/internal/avroc-gen-json/version_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenjson
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGenerateRejectsUnknownIRVersion is docs/ir/SPEC.md's version rule seen
+// from the consumer's side: a descriptor written against a contract this
+// generator does not know fails the invocation with a diagnostic naming both
+// versions, rather than being read for the parts that still look familiar.
+func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version *int32
+	}{
+		{name: "no version at all", version: nil},
+		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &generatorService{}
+
+			// Deliberately not routed through generateToDir: that helper stamps
+			// a valid version onto a request that carries none, which is the
+			// one thing this test needs left alone.
+			cs := &captureStream{ctx: t.Context()}
+			err := svc.Generate(&avrocpb.GenerateRequest{
+				Version: tc.version,
+				Options: nil,
+				Schemas: []*avrocpb.Schema{versionTestSchema()},
+			}, cs)
+
+			if err == nil {
+				t.Fatal("Generate accepted a descriptor whose IR version it does not know")
+			}
+			if !strings.Contains(err.Error(), "IR version") {
+				t.Errorf("diagnostic %q does not name the IR version", err.Error())
+			}
+			if len(cs.msgs) != 0 {
+				t.Errorf("generator emitted %d chunks from a descriptor it refused", len(cs.msgs))
+			}
+		})
+	}
+}
+
+// TestGenerateAcceptsTheCurrentIRVersion is the guard on the test above: a check
+// that refused everything would pass it.
+func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: nil,
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err != nil {
+		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// versionTestSchema is a schema this generator handles without complaint, so a
+// failure above is the version check and nothing else.
+func versionTestSchema() *avrocpb.Schema {
+	return &avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:      proto.String("Person"),
+					Namespace: proto.String("com.example"),
+					FullName:  proto.String("com.example.Person"),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("name"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_Reference{
+									Reference: &avrocpb.Reference{
+										Name: proto.String("string"),
+										Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/avroc-gen-pcf/generate.go
+++ b/internal/avroc-gen-pcf/generate.go
@@ -19,6 +19,14 @@ type generatorService struct {
 // Generate implements the Generator gRPC service method, streaming each
 // generated file back to avroc, which performs the filesystem writes.
 func (s *generatorService) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	// The version comes first, before a single schema is looked at. A descriptor
+	// written against a contract this generator does not know is not one to read
+	// the recognisable parts of — and a canonical form derived from a misread
+	// schema fingerprints to something nothing else agrees with.
+	if err := ir.CheckVersion(req.GetVersion()); err != nil {
+		return err
+	}
+
 	for _, schema := range req.Schemas {
 		filename, content, err := buildSchemaFile(schema)
 		if err != nil {

--- a/internal/avroc-gen-pcf/stream_test.go
+++ b/internal/avroc-gen-pcf/stream_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // captureStream is a server stream that records the GenerateResponse chunks a
@@ -42,6 +44,16 @@ type genResult struct {
 // would, returning their full paths in emission order.
 func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb.GenerateRequest) (*genResult, error) {
 	t.Helper()
+
+	// avroc stamps every descriptor it emits with the IR version, so a request
+	// built in a test without one is a test artefact rather than the case under
+	// test. Defaulting it here keeps the version rule tested where it is the
+	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
+	// every call site. A test that sets a version of its own keeps it.
+	if req.GetVersion() == 0 {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
 
 	cs := &captureStream{ctx: context.Background()}
 	if err := svc.Generate(req, cs); err != nil {

--- a/internal/avroc-gen-pcf/stream_test.go
+++ b/internal/avroc-gen-pcf/stream_test.go
@@ -50,7 +50,12 @@ func generateToDir(t *testing.T, svc *generatorService, dir string, req *avrocpb
 	// test. Defaulting it here keeps the version rule tested where it is the
 	// subject — see TestGenerateRejectsUnknownIRVersion — instead of restated at
 	// every call site. A test that sets a version of its own keeps it.
-	if req.GetVersion() == 0 {
+	//
+	// The field, not GetVersion: an explicit zero is a reserved value a test may
+	// legitimately want to send, and GetVersion cannot tell it from a field that
+	// was never set. Defaulting that away would rewrite the case under test into
+	// a passing one.
+	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}

--- a/internal/avroc-gen-pcf/version_test.go
+++ b/internal/avroc-gen-pcf/version_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenpcf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGenerateRejectsUnknownIRVersion is docs/ir/SPEC.md's version rule seen
+// from the consumer's side: a descriptor written against a contract this
+// generator does not know fails the invocation with a diagnostic naming both
+// versions, rather than being read for the parts that still look familiar.
+func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version *int32
+	}{
+		{name: "no version at all", version: nil},
+		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &generatorService{}
+
+			// Deliberately not routed through generateToDir: that helper stamps
+			// a valid version onto a request that carries none, which is the
+			// one thing this test needs left alone.
+			cs := &captureStream{ctx: t.Context()}
+			err := svc.Generate(&avrocpb.GenerateRequest{
+				Version: tc.version,
+				Options: nil,
+				Schemas: []*avrocpb.Schema{versionTestSchema()},
+			}, cs)
+
+			if err == nil {
+				t.Fatal("Generate accepted a descriptor whose IR version it does not know")
+			}
+			if !strings.Contains(err.Error(), "IR version") {
+				t.Errorf("diagnostic %q does not name the IR version", err.Error())
+			}
+			if len(cs.msgs) != 0 {
+				t.Errorf("generator emitted %d chunks from a descriptor it refused", len(cs.msgs))
+			}
+		})
+	}
+}
+
+// TestGenerateAcceptsTheCurrentIRVersion is the guard on the test above: a check
+// that refused everything would pass it.
+func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: nil,
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err != nil {
+		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// versionTestSchema is a schema this generator handles without complaint, so a
+// failure above is the version check and nothing else.
+func versionTestSchema() *avrocpb.Schema {
+	return &avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:      proto.String("Person"),
+					Namespace: proto.String("com.example"),
+					FullName:  proto.String("com.example.Person"),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("name"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_Reference{
+									Reference: &avrocpb.Reference{
+										Name: proto.String("string"),
+										Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/avroc-gen-pcf/version_test.go
+++ b/internal/avroc-gen-pcf/version_test.go
@@ -25,6 +25,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 		version *int32
 	}{
 		{name: "no version at all", version: nil},
+		{name: "explicitly zero", version: proto.Int32(0)},
 		{name: "newer than this generator", version: proto.Int32(ir.Version + 1)},
 	}
 
@@ -67,6 +68,25 @@ func TestGenerateAcceptsTheCurrentIRVersion(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Generate rejected the current IR version %d: %v", ir.Version, err)
+	}
+}
+
+// TestGenerateToDirPreservesAnExplicitVersion pins generateToDir's one piece of
+// judgment: it defaults a version onto a request that carries none, and must
+// leave alone one a test set deliberately. Zero is the case that distinguishes
+// the two, because it is a reserved value a test may legitimately want to send
+// and is indistinguishable from an unset field through the getter — defaulting
+// it away would quietly rewrite a failing case into a passing one.
+func TestGenerateToDirPreservesAnExplicitVersion(t *testing.T) {
+	svc := &generatorService{}
+
+	_, err := generateToDir(t, svc, t.TempDir(), &avrocpb.GenerateRequest{
+		Version: proto.Int32(0),
+		Options: nil,
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err == nil {
+		t.Fatal("generateToDir replaced an explicitly reserved version with a valid one")
 	}
 }
 

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -20,10 +20,12 @@ import (
 
 	"github.com/z5labs/avroc/internal/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
 
 	"github.com/z5labs/avro-go/idl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 )
 
 // Main dispatches to an avroc subcommand. Generators are declared in an
@@ -198,6 +200,10 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 	// long. Cancellation flows from the signal-based parent context instead.
 	client := avrocpb.NewGeneratorClient(cc)
 	stream, err := client.Generate(ctx, &avrocpb.GenerateRequest{
+		// Every descriptor avroc emits carries the version of the contract it
+		// was written against, so a generator built against an IR avroc has
+		// since moved past can say so instead of misreading the schemas.
+		Version: proto.Int32(ir.Version),
 		Options: options,
 		Schemas: schemas,
 	})

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -8,6 +8,7 @@ package avroc
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/z5labs/avroc/internal/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -272,7 +274,16 @@ type testGeneratorServer struct {
 	path string
 }
 
-func (s *testGeneratorServer) Generate(_ *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+func (s *testGeneratorServer) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	// This stand-in generator holds avroc to the producer half of
+	// docs/ir/SPEC.md's version rule, on the real client path rather than on a
+	// request a test constructed: if avroc stops stamping every descriptor it
+	// emits, TestGeneratorGenerate fails here with the reason rather than
+	// somewhere downstream with a missing file.
+	if err := ir.CheckVersion(req.GetVersion()); err != nil {
+		return fmt.Errorf("avroc emitted a descriptor this generator will not read: %w", err)
+	}
+
 	path := s.path
 	if path == "" {
 		path = "output.go"

--- a/internal/avrocpb/generate_request.pb.go
+++ b/internal/avrocpb/generate_request.pb.go
@@ -26,9 +26,28 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// The request message for the Generate RPC method.
+// The request message for the Generate RPC method. It is the descriptor
+// docs/ir/SPEC.md specifies: the version identifying the contract it was
+// written against, the options for the invocation it belongs to, and the
+// resolved schemas.
 type GenerateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// The IR contract version this descriptor was written against: a single
+	// monotonic integer, never a major and a minor. The only question a
+	// consumer can act on is whether it understands the descriptor in front of
+	// it, and a minor number exists to let it answer "not entirely, but I will
+	// continue anyway".
+	//
+	// A producer MUST set it on every descriptor it emits. A consumer MUST read
+	// it before processing anything else, and MUST refuse a version it does not
+	// know — failing the invocation with a diagnostic naming the version it
+	// found and the version it understands — rather than proceeding on the
+	// parts it recognises.
+	//
+	// Zero is never emitted by a conforming producer. Field number 3 rather
+	// than 1 only because 1 and 2 were already assigned; the number carries no
+	// meaning and says nothing about the order a consumer reads fields in.
+	Version *int32 `protobuf:"varint,3,opt,name=version" json:"version,omitempty"`
 	// Options to customize the code generation process.
 	Options []*Option `protobuf:"bytes,1,rep,name=options" json:"options,omitempty"`
 	// The Avro schemas to be generate code for.
@@ -67,6 +86,13 @@ func (*GenerateRequest) Descriptor() ([]byte, []int) {
 	return file_generate_request_proto_rawDescGZIP(), []int{0}
 }
 
+func (x *GenerateRequest) GetVersion() int32 {
+	if x != nil && x.Version != nil {
+		return *x.Version
+	}
+	return 0
+}
+
 func (x *GenerateRequest) GetOptions() []*Option {
 	if x != nil {
 		return x.Options
@@ -85,8 +111,9 @@ var File_generate_request_proto protoreflect.FileDescriptor
 
 const file_generate_request_proto_rawDesc = "" +
 	"\n" +
-	"\x16generate_request.proto\x1a\fschema.proto\x1a\foption.proto\"W\n" +
-	"\x0fGenerateRequest\x12!\n" +
+	"\x16generate_request.proto\x1a\fschema.proto\x1a\foption.proto\"q\n" +
+	"\x0fGenerateRequest\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\x05R\aversion\x12!\n" +
 	"\aoptions\x18\x01 \x03(\v2\a.OptionR\aoptions\x12!\n" +
 	"\aschemas\x18\x02 \x03(\v2\a.SchemaR\aschemasB2Z0github.com/z5labs/avroc/internal/avrocpb;avrocpbb\beditionsp\xe8\a"
 

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -33,8 +33,15 @@ func avroPrimitives() map[string]struct{} {
 // fails the invocation instead of producing partial or silently wrong output.
 //
 // It rejects a type constructor it does not recognise, a reference whose kind
-// it does not recognise, a reference claiming to be a primitive that names none,
-// and a named type carrying no fully-qualified name.
+// it does not recognise, a sort order it does not recognise, a reference
+// claiming to be a primitive that names none, and a named type carrying no
+// fully-qualified name.
+//
+// Every one of those but the last is the closed-set half of docs/ir/SPEC.md's
+// asymmetry: an unknown *field* is information this consumer did not need and
+// protobuf drops it, while an unknown *member of a closed set* is a fact about
+// the schema this consumer cannot represent at all. Rejecting means failing the
+// invocation, not skipping the type and carrying on.
 func Validate(schema *avrocpb.Schema) error {
 	primitives := avroPrimitives()
 
@@ -60,6 +67,9 @@ func validateType(t *avrocpb.Type, primitives map[string]struct{}) error {
 			return fmt.Errorf("record %q carries no fully-qualified name", v.Record.GetName())
 		}
 		for _, f := range v.Record.GetFields() {
+			if err := validateSortOrder(f.GetSortOrder()); err != nil {
+				return fmt.Errorf("record %q field %q: %w", v.Record.GetFullName(), f.GetName(), err)
+			}
 			if err := validateType(f.GetType(), primitives); err != nil {
 				return fmt.Errorf("record %q field %q: %w", v.Record.GetFullName(), f.GetName(), err)
 			}
@@ -92,6 +102,21 @@ func validateType(t *avrocpb.Type, primitives map[string]struct{}) error {
 		// A type constructor is a closed set. An unrecognised member is a
 		// schema this consumer cannot represent, not one to skip.
 		return fmt.Errorf("unsupported type: %T", t.GetType())
+	}
+}
+
+// validateSortOrder rejects a sort order outside Avro's three. Avro's own set
+// is closed, so a fourth member means a descriptor written against a newer IR
+// than this consumer knows — and a consumer that fell through to ascending
+// would order records by a rule nobody asked for and say nothing about it.
+func validateSortOrder(order avrocpb.SortOrder) error {
+	switch order {
+	case avrocpb.SortOrder_SORT_ORDER_ASC,
+		avrocpb.SortOrder_SORT_ORDER_DESC,
+		avrocpb.SortOrder_SORT_ORDER_IGNORE:
+		return nil
+	default:
+		return fmt.Errorf("unrecognised sort order %v", order)
 	}
 }
 

--- a/internal/ir/validate_test.go
+++ b/internal/ir/validate_test.go
@@ -60,6 +60,83 @@ func TestValidate_RejectsNilType(t *testing.T) {
 	}
 }
 
+// TestValidateRejectsUnknownSortOrder is the closed-set half of
+// docs/ir/SPEC.md's asymmetry, applied to the set that is easiest to fall
+// through on: sort order has a meaningful zero value, so a consumer that
+// switched on the three it knows and let anything else reach the default would
+// order a record by ascending and say nothing about it. The user finds out when
+// the generated code sorts differently from somebody else's.
+func TestValidateRejectsUnknownSortOrder(t *testing.T) {
+	schema := &avrocpb.Schema{
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:     proto.String("Person"),
+					FullName: proto.String("com.example.Person"),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("name"),
+							Type: primRef("string"),
+							// A member added to SortOrder by an IR newer than
+							// this consumer.
+							SortOrder: avrocpb.SortOrder(99).Enum(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := Validate(schema)
+	if err == nil {
+		t.Fatal("expected an error for a sort order this consumer does not recognise")
+	}
+	if !strings.Contains(err.Error(), "unrecognised sort order") {
+		t.Errorf("error = %v, want it to name the problem", err)
+	}
+	if !strings.Contains(err.Error(), `field "name"`) {
+		t.Errorf("error = %v, want it to name the field carrying it", err)
+	}
+}
+
+// TestValidateAcceptsEverySortOrder is the guard on the test above: rejecting an
+// unknown member is only correct if every known one is accepted, and a set this
+// small is worth pinning so a future member cannot be added to the proto without
+// the switch above being taught about it.
+func TestValidateAcceptsEverySortOrder(t *testing.T) {
+	orders := []avrocpb.SortOrder{
+		avrocpb.SortOrder_SORT_ORDER_ASC,
+		avrocpb.SortOrder_SORT_ORDER_DESC,
+		avrocpb.SortOrder_SORT_ORDER_IGNORE,
+	}
+
+	if got := len(avrocpb.SortOrder_name); got != len(orders) {
+		t.Fatalf("SortOrder has %d members, this test knows %d — teach validateSortOrder about the new one", got, len(orders))
+	}
+
+	for _, order := range orders {
+		t.Run(order.String(), func(t *testing.T) {
+			schema := &avrocpb.Schema{
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:     proto.String("Person"),
+							FullName: proto.String("com.example.Person"),
+							Fields: []*avrocpb.Field{
+								{Name: proto.String("name"), Type: primRef("string"), SortOrder: order.Enum()},
+							},
+						},
+					},
+				},
+			}
+
+			if err := Validate(schema); err != nil {
+				t.Errorf("Validate rejected sort order %v: %v", order, err)
+			}
+		})
+	}
+}
+
 // TestValidate_AcceptsNamedTypeSpelledLikeAPrimitive is the rule the primitive
 // list must not overreach into: the kind decides what a reference is, so a
 // named type may legitimately be called "string".

--- a/internal/ir/version.go
+++ b/internal/ir/version.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package ir
+
+import "fmt"
+
+// Version is the IR contract version this build of avroc writes onto every
+// descriptor it emits, and the only version the generators in this repository
+// understand. It is the integer docs/ir/SPEC.md's "The version field"
+// specifies: monotonic, and deliberately not a major and a minor.
+//
+// Bumping it is the last step of a breaking change, not a routine one. A change
+// is breaking, and requires this constant to advance to the next integer, when
+// a conforming consumer cannot ignore it and remain correct — removing a field
+// or reusing its number, changing what a field means, or adding a member to a
+// closed set such as the type constructors, TypeRefKind or SortOrder. Adding a
+// field a consumer can ignore and still handle the descriptor correctly leaves
+// it alone; that is what makes an additive change free, and it is the only
+// reason this constant can stay put across most edits. docs/ir/SPEC.md's
+// "Compatibility" is normative for which is which.
+//
+// One bump covers every breaking change made since the last released version:
+// the version identifies a contract, not an edit.
+//
+// This is neither avroc's release version nor the Go module tag of the package
+// the generated IR types live in. One IR version outlives many of both.
+const Version int32 = 1
+
+// CheckVersion is the first thing a consumer of a descriptor does with it.
+//
+// docs/ir/SPEC.md requires the version to be read before anything else, and a
+// version the consumer does not know to fail the invocation with a diagnostic
+// naming both versions, rather than the consumer proceeding on the parts it
+// recognises. Reading it first is the whole of the rule: a consumer that walks
+// the schemas and checks the version afterwards has already spent its
+// diagnostics on a document it was never entitled to read, so what a user sees
+// is a complaint about a type they cannot fix instead of a plugin that is too
+// old for the avroc in front of it.
+//
+// It takes the integer rather than the message carrying it, because which
+// message that is belongs to the contract that delivers the descriptor, not to
+// the version rule.
+func CheckVersion(version int32) error {
+	if version == Version {
+		return nil
+	}
+	if version == 0 {
+		// Zero is both "the field was never set" and "a producer wrote 0",
+		// which no conforming producer does. Either way it is not a version
+		// this consumer knows, and saying so is more use than printing 0.
+		return fmt.Errorf("descriptor carries no IR version; this generator understands IR version %d", Version)
+	}
+	return fmt.Errorf("descriptor is IR version %d; this generator understands IR version %d", version, Version)
+}

--- a/internal/ir/version_test.go
+++ b/internal/ir/version_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package ir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/avrocpb"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestVersionIsPositive(t *testing.T) {
+	// Zero is CheckVersion's "carries no version", so a released contract can
+	// never be numbered 0, and a monotonic version never runs backwards.
+	if Version < 1 {
+		t.Errorf("IR version must be at least 1, got %d", Version)
+	}
+}
+
+func TestCheckVersionAcceptsTheCurrentVersion(t *testing.T) {
+	if err := CheckVersion(Version); err != nil {
+		t.Errorf("CheckVersion rejected the current version %d: %v", Version, err)
+	}
+}
+
+func TestCheckVersionRejectsUnknownVersions(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version int32
+		want    []string
+	}{
+		{
+			name:    "unset",
+			version: 0,
+			// Printing "IR version 0" would send a user looking for a version
+			// nothing ever emitted; the diagnostic names the real problem.
+			want: []string{"carries no IR version", "understands IR version 1"},
+		},
+		{
+			name:    "newer than this consumer",
+			version: Version + 1,
+			want:    []string{"is IR version 2", "understands IR version 1"},
+		},
+		{
+			// There is no "older than this consumer" case to write while the
+			// contract is on its first version: one below it is zero, which is
+			// the unset case above. A negative stands in for the malformed
+			// version a non-conforming producer could still put on the wire.
+			name:    "negative",
+			version: -1,
+			want:    []string{"is IR version -1", "understands IR version 1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckVersion(tc.version)
+			if err == nil {
+				t.Fatalf("CheckVersion(%d) accepted a version this consumer does not know", tc.version)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("diagnostic %q does not name %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestUnknownFieldsAreIgnored is the other half of docs/ir/SPEC.md's asymmetry
+// from TestValidateRejectsUnknownSortOrder: a field a consumer has never seen is
+// information it did not need, and decoding a descriptor carrying one must
+// succeed with every known field intact.
+//
+// It appends a field number no descriptor defines to the encoded bytes rather
+// than asserting that protobuf behaves this way in the abstract, because what
+// the spec promises is about the descriptor as it arrives on the wire — which is
+// what makes an additive change free and lets the version stay put across most
+// edits.
+func TestUnknownFieldsAreIgnored(t *testing.T) {
+	want := &avrocpb.GenerateRequest{
+		Version: proto.Int32(Version),
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+		Schemas: []*avrocpb.Schema{{
+			Namespace: proto.String("com.example"),
+			Type: &avrocpb.Type{Type: &avrocpb.Type_Record{Record: &avrocpb.Record{
+				Name:      proto.String("Thing"),
+				Namespace: proto.String("com.example"),
+				FullName:  proto.String("com.example.Thing"),
+			}}},
+		}},
+	}
+
+	encoded, err := proto.Marshal(want)
+	if err != nil {
+		t.Fatalf("failed to marshal descriptor: %v", err)
+	}
+
+	// Field 4096, varint 7: a scalar a future IR might add and this build has
+	// never heard of.
+	encoded = protowire.AppendTag(encoded, 4096, protowire.VarintType)
+	encoded = protowire.AppendVarint(encoded, 7)
+	// Field 4097, length-delimited: a message-shaped addition, which fails
+	// differently from a scalar if it is not tolerated.
+	encoded = protowire.AppendTag(encoded, 4097, protowire.BytesType)
+	encoded = protowire.AppendBytes(encoded, []byte("a future field's value"))
+
+	var got avrocpb.GenerateRequest
+	if err := proto.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("decoding a descriptor carrying unknown fields failed: %v", err)
+	}
+
+	if err := CheckVersion(got.GetVersion()); err != nil {
+		t.Errorf("the version did not survive the unknown fields: %v", err)
+	}
+	if err := Validate(got.GetSchemas()[0]); err != nil {
+		t.Errorf("the schema did not survive the unknown fields: %v", err)
+	}
+
+	got.ProtoReflect().SetUnknown(nil)
+	if !proto.Equal(want, &got) {
+		t.Errorf("known fields did not survive decoding\n got: %v\nwant: %v", &got, want)
+	}
+}

--- a/proto/generate_request.proto
+++ b/proto/generate_request.proto
@@ -10,8 +10,28 @@ option go_package = "github.com/z5labs/avroc/internal/avrocpb;avrocpb";
 import "schema.proto";
 import "option.proto";
 
-// The request message for the Generate RPC method.
+// The request message for the Generate RPC method. It is the descriptor
+// docs/ir/SPEC.md specifies: the version identifying the contract it was
+// written against, the options for the invocation it belongs to, and the
+// resolved schemas.
 message GenerateRequest {
+    // The IR contract version this descriptor was written against: a single
+    // monotonic integer, never a major and a minor. The only question a
+    // consumer can act on is whether it understands the descriptor in front of
+    // it, and a minor number exists to let it answer "not entirely, but I will
+    // continue anyway".
+    //
+    // A producer MUST set it on every descriptor it emits. A consumer MUST read
+    // it before processing anything else, and MUST refuse a version it does not
+    // know — failing the invocation with a diagnostic naming the version it
+    // found and the version it understands — rather than proceeding on the
+    // parts it recognises.
+    //
+    // Zero is never emitted by a conforming producer. Field number 3 rather
+    // than 1 only because 1 and 2 were already assigned; the number carries no
+    // meaning and says nothing about the order a consumer reads fields in.
+    int32 version = 3;
+
     // Options to customize the code generation process.
     repeated Option options = 1;
 


### PR DESCRIPTION
Closes #109

Nothing versioned the generator contract. A third-party generator built against
today's messages had no way to detect that avroc had changed them, and avroc had
no way to detect that a plugin was too old. This adds the monotonic integer
version `docs/ir/SPEC.md` requires and makes both sides act on it.

## Acceptance criteria

- [x] **The descriptor message carries a single monotonic integer version field — not `major.minor`.**
  `GenerateRequest` — the descriptor today, per `docs/ir/SPEC.md`'s "What a
  descriptor carries" — gains `int32 version = 3`. One integer, because the only
  question a consumer can act on is whether it understands the descriptor in
  front of it, and a minor number exists to let it answer "not entirely, but I
  will continue anyway".
- [x] **avroc sets it on every emitted descriptor.**
  `internal/avroc/avroc.go` stamps `proto.Int32(ir.Version)` on the request it
  sends. The stand-in generator in `avroc_test.go` now holds avroc to that on the
  real gRPC client path, so `TestGeneratorGenerate` fails with the reason if the
  stamp ever goes away, rather than downstream on a missing file.
- [x] **A plugin reading a version it does not know exits non-zero with a diagnostic rather than proceeding.**
  `ir.CheckVersion` is the **first** statement in all three generators'
  `Generate` — before the options and before a single schema is looked at. It
  returns an error naming the version found and the version understood; the error
  propagates out of the RPC, `runGenerate` logs it and `avroc` exits 1.
  `TestGenerateRejectsUnknownIRVersion` in each generator package asserts both
  the diagnostic and that no chunk was emitted, and covers "no version at all"
  separately from "newer than this generator".
- [x] **Unknown fields are ignored; unknown members of closed sets are rejected, per the spec's asymmetry.**
  `TestUnknownFieldsAreIgnored` appends a scalar and a message-shaped field that
  no descriptor defines to encoded bytes, then asserts the decode succeeds with
  every known field intact — the promise stated about the descriptor as it
  arrives on the wire, not about protobuf in the abstract. The rejecting half was
  already in place for type constructors and `TypeRefKind`; this adds the set that
  was still missing, `SortOrder`, which is the one with a *meaningful* zero value
  and so the one a consumer silently falls through on.
- [x] **The rules for what requires a version bump are documented in `docs/ir/SPEC.md`.**
  New subsection "The version this document specifies, and when it advances".
- [x] **`go test -race ./...` passes.**

## Judgment calls that shaped the public API

- **`ir.CheckVersion` takes the integer, not the message.** Which message carries
  the version belongs to the contract that delivers the descriptor (#111/#114),
  not to the version rule, so the check does not have to move when the delivery
  does.
- **Field number 3, not 1.** 1 and 2 were already assigned; renumbering to put
  `version` first would be a wire-breaking change made solely for looks. The proto
  comment says so, and says the number implies nothing about read order — the
  ordering requirement is on the consumer, and is enforced by where
  `CheckVersion` sits.
- **Zero is reserved rather than assigned.** An absent `int32` decodes as zero, so
  reserving it makes a descriptor that never carried a version refuse identically
  to one from a contract too new. `CheckVersion` reports the two differently
  ("carries no IR version" vs "is IR version N") because they send a user to
  different places.
- **`generateToDir` defaults an unset version.** The three generator packages'
  test helper stamps `ir.Version` onto a request that carries none, rather than
  the ~50 existing call sites repeating it. A test that sets a version of its own
  keeps it, which is what lets the rejection tests bypass the helper entirely.

## Verified

All four `verify` commands from `.claude/backlog.json`, locally:
`go build ./...`, `go test -race -cover ./...`, `golangci-lint run`, and the
`example/` round-trip with `git diff --exit-code` — the last one exercises the
stamp and all three checks end to end through real subprocesses. The regenerated
`internal/avrocpb/generate_request.pb.go` came from the same `protoc` /
`protoc-gen-go` versions recorded in the existing generated files, confirmed by
regenerating every `.proto` first and diffing byte-for-byte against what was
committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)