### PR TITLE
story(ir): emit the descriptor as a file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,29 @@ Every descriptor carries `GenerateRequest.version`, the single monotonic integer
 
 Bumping `ir.Version` is the last step of a breaking change to the IR schema, never a routine one — it strands every generator built against the previous version. `ir.Validate` enforces the other half of the spec's asymmetry: unknown *fields* are ignored (protobuf drops them), unknown *members of a closed set* — type constructor, `TypeRefKind`, `SortOrder` — are rejected.
 
+### The descriptor file
+
+Every generator invocation gets one descriptor file: the `GenerateRequest` — IR
+version, that generator's options, its resolved schemas — encoded by
+`ir.MarshalDescriptor` and written by `internal/avroc.writeDescriptor` into a
+directory created for that invocation alone, read-only, complete before the
+generator starts and removed once it has exited. `docs/plugin/SPEC.md`'s
+"Location and lifetime" is normative; nothing may derive meaning from the path.
+
+The descriptor value is built once and then both written and sent, so the file is
+the value the generator received rather than a second encoding that could drift
+from it. Passing it as `--descriptor` is #114's; until then the same value still
+travels over the gRPC service #124 removes.
+
+**The bytes are deterministic**: two runs over unchanged inputs produce
+byte-identical descriptors, because generated output is a thing a project commits
+and a descriptor that varied would make every regeneration a diff. Every repeated
+field is ordered by the producer before it reaches the encoding — manifest
+options sort by key, schemas follow the manifest's input order — and
+`ir.MarshalDescriptor` marshals deterministically. An unordered collection
+reaching the encoder in Go's map iteration order is the way this gets broken, and
+it breaks intermittently.
+
 ### Plugin Discovery
 
 The CLI scans all directories in `PATH` for executables matching `avroc-gen-<name>`. Each discovered generator gets a corresponding `-<name>_out` CLI flag for specifying its output directory.

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -119,6 +119,16 @@ both strings, in an order a producer **MUST** make deterministic so that
 identical inputs produce identical bytes. What any particular name means is the
 generator's, and is [out of scope](#generator-option-meanings).
 
+The whole descriptor carries that requirement, not only its options: two runs
+over unchanged inputs **MUST** produce byte-identical descriptors (#111). It is
+the same promise [`plugin/SPEC.md`](../plugin/SPEC.md)'s determinism section
+makes of a generator's output, one step earlier in the pipeline, and it is needed
+one step earlier because a plugin cannot be deterministic about an input that is
+not — a descriptor that varied would make every regeneration a diff whatever the
+plugins did with it. Every repeated field therefore carries a producer-chosen
+order, and a producer **MUST NOT** let an unordered collection reach the encoding
+in the order it happened to iterate.
+
 A schema is a tree of types, and every type is exactly one member of a closed
 set: the type constructors Avro declares — record, enum, fixed, array, map and
 union — plus a reference, which names either an Avro primitive or a named type

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -210,8 +210,39 @@ both would have to sniff which one it had been handed.
 A plugin **MUST** read the descriptor and **MUST NOT** write to it, rename it,
 or delete it. It **MUST NOT** derive anything from the file's name or its
 directory — the path is a temporary location avroc chose, not a place a plugin
-may hang meaning on. avroc **MAY** delete the file as soon as the plugin exits,
-so a plugin **MUST NOT** retain the path for later use.
+may hang meaning on. The file is gone once the plugin exits, as [Location and
+lifetime](#location-and-lifetime) requires, so a plugin **MUST NOT** retain the
+path for later use.
+
+#### Location and lifetime
+
+avroc **MUST** write the descriptor into a directory it creates for that one
+invocation and nothing else, and **MUST NOT** share a descriptor file between two
+generators, or between two runs. One file per invocation is what makes the bytes
+attributable: a descriptor on disk belongs to exactly one generator and one run,
+and cannot have been overwritten by whichever invocation happened to finish last.
+
+The file **MUST** be written in full and closed before the generator is started.
+A plugin therefore never observes a partial descriptor, and needs no protocol —
+no lock, no sentinel, no retry — to find out whether the bytes it can see are all
+of them.
+
+avroc **MUST** remove the file, and the directory holding it, once the generator
+has exited, whether it exited zero or not. That is the whole of the file's
+lifetime. A plugin that wants the descriptor to outlive the invocation **MUST**
+copy the bytes, and **MUST NOT** expect the path to resolve to anything
+afterwards; what it will find there instead is unspecified, because avroc creates
+the next invocation's directory by the same means.
+
+avroc **SHOULD** create the file read-only. The prohibition above is on the
+plugin and a mode bit does not enforce it — a plugin running as the user that
+created the file can change the mode back — but it turns the accidental case, a
+plugin opening the path for writing, into an error where the mistake is rather
+than into a descriptor quietly different from the one avroc wrote.
+
+Nothing here is a promise about the *path*. The directory avroc picks, the name
+it gives the file and the suffix on that name are all implementation, and a
+plugin reading any of them has broken the rule above rather than found a feature.
 
 `--descriptor -` means the descriptor arrives on standard input, and a plugin
 **MUST** accept it. avroc itself always passes a path, which is the point: a
@@ -581,6 +612,7 @@ model is that avroc has no opinion about the code that comes out.
 | [Host platform](#host-platform) | [#104](https://github.com/z5labs/avroc/issues/104) |
 | [Discovery](#discovery) | [#114](https://github.com/z5labs/avroc/issues/114) |
 | [Invocation](#invocation) | [#114](https://github.com/z5labs/avroc/issues/114), [#115](https://github.com/z5labs/avroc/issues/115) |
+| [The descriptor](#the-descriptor), [Location and lifetime](#location-and-lifetime) | [#111](https://github.com/z5labs/avroc/issues/111), [#114](https://github.com/z5labs/avroc/issues/114) |
 | [The output directory](#the-output-directory) | [#117](https://github.com/z5labs/avroc/issues/117), [#118](https://github.com/z5labs/avroc/issues/118), [#119](https://github.com/z5labs/avroc/issues/119) |
 | [Exit codes and diagnostics](#exit-codes-and-diagnostics) | [#115](https://github.com/z5labs/avroc/issues/115) |
 | [Determinism](#determinism) | [#120](https://github.com/z5labs/avroc/issues/120) |

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -20,12 +20,10 @@ import (
 
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
-	"github.com/z5labs/avroc/internal/ir"
 
 	"github.com/z5labs/avro-go/idl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/proto"
 )
 
 // Main dispatches to an avroc subcommand. Generators are declared in an
@@ -149,6 +147,33 @@ type generator struct {
 }
 
 func (g generator) generate(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (err error) {
+	desc := newDescriptor(options, schemas)
+
+	// One descriptor file per generator invocation, in a directory created for
+	// that invocation and nothing else, removed once the generator has exited.
+	// docs/plugin/SPEC.md's "Location and lifetime" is normative for all three,
+	// and this defer is registered first so that it unwinds last — after the
+	// generator process has been waited on, never while it may still be reading.
+	descriptorDir, err := os.MkdirTemp("", g.name+"-descriptor-*")
+	if err != nil {
+		g.log.ErrorContext(ctx, "failed to create descriptor directory", slog.String("generator", g.name), slog.Any("error", err))
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(descriptorDir))
+	}()
+
+	descriptorPath, err := writeDescriptor(descriptorDir, desc)
+	if err != nil {
+		g.log.ErrorContext(ctx, "failed to write descriptor", slog.String("generator", g.name), slog.Any("error", err))
+		return err
+	}
+	// The path is logged and not yet passed: the argument vector that hands it
+	// to the generator is #114's, and until then the same descriptor value
+	// travels over the gRPC service #124 removes. Logging it is what makes the
+	// file findable while it exists.
+	g.log.DebugContext(ctx, "wrote descriptor", slog.String("generator", g.name), slog.String("descriptor", descriptorPath))
+
 	socketFile, err := os.CreateTemp("", g.name+"-*.sock")
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to create temporary socket file", slog.String("generator", g.name), slog.Any("error", err))
@@ -199,14 +224,7 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 	// No overall RPC timeout: a large streamed generation can legitimately run
 	// long. Cancellation flows from the signal-based parent context instead.
 	client := avrocpb.NewGeneratorClient(cc)
-	stream, err := client.Generate(ctx, &avrocpb.GenerateRequest{
-		// Every descriptor avroc emits carries the version of the contract it
-		// was written against, so a generator built against an IR avroc has
-		// since moved past can say so instead of misreading the schemas.
-		Version: proto.Int32(ir.Version),
-		Options: options,
-		Schemas: schemas,
-	})
+	stream, err := client.Generate(ctx, desc)
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to generate code", slog.String("generator", g.name), slog.Any("error", err))
 		return err

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -274,6 +274,43 @@ type testGeneratorServer struct {
 	path string
 }
 
+// testDescriptorGlob matches the descriptor files avroc writes for the
+// stand-in generator these tests drive. It leans on the generator's name being
+// part of the per-invocation directory, so a leftover from some other test —
+// or from another package's temporary files — is not mistaken for this one's.
+const testDescriptorGlob = "avroc-gen-test-descriptor-*/" + descriptorFilename
+
+// findDescriptorMatching reports whether a descriptor file holding exactly req
+// is readable right now. A leftover from an earlier crashed run may sit beside
+// it, so the test is "at least one decodes and equals req" rather than "exactly
+// one file exists": a stale file cannot make this pass, and cannot make it fail
+// either.
+func findDescriptorMatching(req *avrocpb.GenerateRequest) error {
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), testDescriptorGlob))
+	if err != nil {
+		return fmt.Errorf("failed to search for the descriptor file: %w", err)
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("no descriptor file under %q while the generator is running", os.TempDir())
+	}
+
+	for _, m := range matches {
+		b, err := os.ReadFile(m)
+		if err != nil {
+			return fmt.Errorf("failed to read descriptor %q: %w", m, err)
+		}
+		var onDisk avrocpb.GenerateRequest
+		if err := proto.Unmarshal(b, &onDisk); err != nil {
+			return fmt.Errorf("descriptor %q does not decode: %w", m, err)
+		}
+		if proto.Equal(&onDisk, req) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("none of the %d descriptor file(s) on disk match what this generator received", len(matches))
+}
+
 func (s *testGeneratorServer) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
 	// This stand-in generator holds avroc to the producer half of
 	// docs/ir/SPEC.md's version rule, on the real client path rather than on a
@@ -282,6 +319,15 @@ func (s *testGeneratorServer) Generate(req *avrocpb.GenerateRequest, stream avro
 	// somewhere downstream with a missing file.
 	if err := ir.CheckVersion(req.GetVersion()); err != nil {
 		return fmt.Errorf("avroc emitted a descriptor this generator will not read: %w", err)
+	}
+
+	// And to the other half docs/plugin/SPEC.md adds: while a generator is
+	// running, a complete descriptor carrying exactly what it received is on
+	// disk. Checked from inside the subprocess because that is the only vantage
+	// point from which "before the generator started, and not yet deleted" is
+	// observable at all.
+	if err := findDescriptorMatching(req); err != nil {
+		return err
 	}
 
 	path := s.path
@@ -338,6 +384,12 @@ func TestGeneratorGenerate(t *testing.T) {
 		},
 	}
 
+	// The descriptor's lifetime ends when the generator exits, so the set of
+	// descriptor directories on disk must not grow across an invocation. Taken
+	// before rather than asserted as "none afterwards", because a crashed
+	// earlier run may have left one and that is not this test's failure.
+	before := descriptorDirs(t)
+
 	outputDir := t.TempDir()
 	err := g.generate(ctx, outputDir, nil, schema)
 	if err != nil {
@@ -350,6 +402,28 @@ func TestGeneratorGenerate(t *testing.T) {
 	if _, err := os.Stat(written); err != nil {
 		t.Errorf("expected generated file at %q: %v", written, err)
 	}
+
+	for dir := range descriptorDirs(t) {
+		if _, ok := before[dir]; !ok {
+			t.Errorf("descriptor directory %q survived the invocation that created it", dir)
+		}
+	}
+}
+
+// descriptorDirs is the set of per-invocation descriptor directories currently
+// on disk for the stand-in generator.
+func descriptorDirs(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "avroc-gen-test-descriptor-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		dirs[m] = struct{}{}
+	}
+	return dirs
 }
 
 // fakeClientStream replays a fixed sequence of GenerateResponse messages,

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -285,6 +285,14 @@ const testDescriptorGlob = "avroc-gen-test-descriptor-*/" + descriptorFilename
 // it, so the test is "at least one decodes and equals req" rather than "exactly
 // one file exists": a stale file cannot make this pass, and cannot make it fail
 // either.
+//
+// Making good on the second half is why a match that cannot be read or decoded
+// is skipped rather than returned as an error. A file that vanished between the
+// glob and the read, or that some earlier run left half-written, is not evidence
+// about the descriptor this invocation wrote — but it would sit ahead of it in
+// the glob's sorted order often enough to make the failure look real. The last
+// such error is kept only to be quoted when nothing matched, so a genuinely
+// unreadable descriptor still says why rather than reporting a bare miss.
 func findDescriptorMatching(req *avrocpb.GenerateRequest) error {
 	matches, err := filepath.Glob(filepath.Join(os.TempDir(), testDescriptorGlob))
 	if err != nil {
@@ -294,20 +302,26 @@ func findDescriptorMatching(req *avrocpb.GenerateRequest) error {
 		return fmt.Errorf("no descriptor file under %q while the generator is running", os.TempDir())
 	}
 
+	var skipped error
 	for _, m := range matches {
 		b, err := os.ReadFile(m)
 		if err != nil {
-			return fmt.Errorf("failed to read descriptor %q: %w", m, err)
+			skipped = fmt.Errorf("failed to read descriptor %q: %w", m, err)
+			continue
 		}
 		var onDisk avrocpb.GenerateRequest
 		if err := proto.Unmarshal(b, &onDisk); err != nil {
-			return fmt.Errorf("descriptor %q does not decode: %w", m, err)
+			skipped = fmt.Errorf("descriptor %q does not decode: %w", m, err)
+			continue
 		}
 		if proto.Equal(&onDisk, req) {
 			return nil
 		}
 	}
 
+	if skipped != nil {
+		return fmt.Errorf("none of the %d descriptor file(s) on disk match what this generator received; last unusable one: %w", len(matches), skipped)
+	}
 	return fmt.Errorf("none of the %d descriptor file(s) on disk match what this generator received", len(matches))
 }
 

--- a/internal/avroc/descriptor.go
+++ b/internal/avroc/descriptor.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// descriptorFilename is the name avroc gives the descriptor inside the private
+// directory it creates for one generator invocation.
+//
+// Fixed rather than randomised, because the directory already is: no two
+// invocations share one, so there is nothing left for the file's name to
+// disambiguate. docs/plugin/SPEC.md forbids a plugin deriving anything from
+// either the name or the directory, so this constant is a convenience for the
+// person reading a log line or saving the bytes, and no part of the contract.
+//
+// The .binpb suffix is protobuf's own for the binary wire encoding, which is
+// what the file holds. The JSON rendering a person reads is a separate artifact
+// (#112), and a plugin is never handed one — a plugin that accepted both would
+// have to sniff which it had.
+const descriptorFilename = "descriptor.binpb"
+
+// descriptorFileMode is the mode avroc creates a descriptor with.
+//
+// docs/plugin/SPEC.md forbids a plugin writing to the descriptor, and a mode bit
+// does not enforce that — the plugin usually runs as the user that created the
+// file and can chmod it back. What it does is turn the accidental case, a plugin
+// opening the path for writing, into an error where the mistake is rather than
+// into a descriptor quietly different from the one avroc wrote.
+const descriptorFileMode os.FileMode = 0o444
+
+// newDescriptor builds the descriptor for a single generator invocation: the IR
+// contract version, that generator's own options, and the resolved schemas it
+// was asked to generate from.
+//
+// It is built once per invocation and then both written and sent, so the file on
+// disk is the value the generator received rather than a second encoding of the
+// same inputs that could drift from it.
+func newDescriptor(options []*avrocpb.Option, schemas []*avrocpb.Schema) *avrocpb.GenerateRequest {
+	return &avrocpb.GenerateRequest{
+		// Every descriptor avroc emits carries the version of the contract it
+		// was written against, so a generator built against an IR avroc has
+		// since moved past can say so instead of misreading the schemas.
+		Version: proto.Int32(ir.Version),
+		Options: options,
+		Schemas: schemas,
+	}
+}
+
+// writeDescriptor encodes desc and writes it into dir, returning the path it
+// wrote. dir is expected to be the private directory created for this one
+// invocation, and the file is expected not to exist yet: O_EXCL turns a reused
+// directory into an error here rather than into a descriptor that silently
+// belongs to some earlier invocation.
+//
+// The file is written and closed before it is returned, which is what lets the
+// caller start the generator against a descriptor that is complete by
+// construction — no lock, no sentinel and no retry on the reading side.
+func writeDescriptor(dir string, desc *avrocpb.GenerateRequest) (path string, err error) {
+	b, err := ir.MarshalDescriptor(desc)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode descriptor: %w", err)
+	}
+
+	path = filepath.Join(dir, descriptorFilename)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, descriptorFileMode)
+	if err != nil {
+		return "", fmt.Errorf("failed to create descriptor file: %w", err)
+	}
+	defer func() {
+		closeErr := f.Close()
+		if closeErr == nil {
+			return
+		}
+		// A close that failed may have lost buffered bytes, so the path is not
+		// handed back: a caller must not start a generator against a descriptor
+		// avroc cannot say it finished writing.
+		err = errors.Join(err, fmt.Errorf("failed to close descriptor file %q: %w", path, closeErr))
+		path = ""
+	}()
+
+	if _, err := f.Write(b); err != nil {
+		return "", fmt.Errorf("failed to write descriptor file %q: %w", path, err)
+	}
+
+	return path, nil
+}

--- a/internal/avroc/descriptor_test.go
+++ b/internal/avroc/descriptor_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// testSchema is a small resolved schema: enough structure for the encoding to
+// have an order to get wrong, and no more.
+func testSchema(record string) *avrocpb.Schema {
+	return &avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:     proto.String(record),
+					FullName: proto.String("com.example." + record),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("name"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_Reference{
+									Reference: &avrocpb.Reference{
+										Name: proto.String("string"),
+										Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestNewDescriptor(t *testing.T) {
+	t.Run("stamps the IR version this build writes", func(t *testing.T) {
+		desc := newDescriptor(nil, nil)
+		if err := ir.CheckVersion(desc.GetVersion()); err != nil {
+			t.Errorf("descriptor would be refused by this build's own generators: %v", err)
+		}
+	})
+
+	t.Run("carries the invocation's options and schemas", func(t *testing.T) {
+		options := GeneratorConfig{Options: map[string]string{"package": "models"}}.options()
+		schemas := []*avrocpb.Schema{testSchema("User"), testSchema("Order")}
+
+		desc := newDescriptor(options, schemas)
+
+		if len(desc.GetOptions()) != 1 || desc.GetOptions()[0].GetName() != "package" {
+			t.Errorf("options = %v", desc.GetOptions())
+		}
+		if len(desc.GetSchemas()) != 2 {
+			t.Fatalf("schemas = %d, want 2", len(desc.GetSchemas()))
+		}
+		// Schemas keep the order they were handed in; nothing re-sorts them.
+		if got := desc.GetSchemas()[0].GetType().GetRecord().GetName(); got != "User" {
+			t.Errorf("first schema = %q, want User", got)
+		}
+	})
+}
+
+func TestWriteDescriptor(t *testing.T) {
+	t.Run("writes the descriptor the generator was handed", func(t *testing.T) {
+		dir := t.TempDir()
+		desc := newDescriptor(
+			GeneratorConfig{Options: map[string]string{"package": "models"}}.options(),
+			[]*avrocpb.Schema{testSchema("User")},
+		)
+
+		path, err := writeDescriptor(dir, desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(dir, descriptorFilename); path != want {
+			t.Errorf("path = %q, want %q", path, want)
+		}
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The bytes on disk must decode back to the value avroc sent, not to
+		// something merely similar: this is the file a plugin will be handed.
+		var got avrocpb.GenerateRequest
+		if err := proto.Unmarshal(b, &got); err != nil {
+			t.Fatalf("descriptor file does not decode: %v", err)
+		}
+		if !proto.Equal(&got, desc) {
+			t.Errorf("decoded descriptor differs from the one written\n got: %v\nwant: %v", &got, desc)
+		}
+	})
+
+	t.Run("creates the file read-only", func(t *testing.T) {
+		dir := t.TempDir()
+
+		path, err := writeDescriptor(dir, newDescriptor(nil, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// docs/plugin/SPEC.md: a plugin MUST NOT write to the descriptor. The
+		// mode does not enforce that, but it makes the accidental case fail
+		// where the mistake is.
+		if mode := info.Mode().Perm(); mode&0o222 != 0 {
+			t.Errorf("mode = %v, want no write bits", mode)
+		}
+	})
+
+	t.Run("refuses to overwrite an existing descriptor", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if _, err := writeDescriptor(dir, newDescriptor(nil, nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// One file per invocation is what makes a descriptor attributable, so a
+		// directory that already holds one is a bug rather than a thing to
+		// clobber.
+		if _, err := writeDescriptor(dir, newDescriptor(nil, nil)); err == nil {
+			t.Error("expected an error writing a second descriptor into the same directory, got nil")
+		}
+	})
+
+	t.Run("errors when the directory does not exist", func(t *testing.T) {
+		path, err := writeDescriptor(filepath.Join(t.TempDir(), "absent"), newDescriptor(nil, nil))
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if path != "" {
+			t.Errorf("path = %q, want empty on error", path)
+		}
+	})
+}
+
+// TestWriteDescriptor_Deterministic is the acceptance criterion stated as a
+// test: identical inputs, identical bytes. The options are built from a Go map
+// on every iteration, so a producer that let map iteration order reach the
+// encoding fails here — intermittently in principle, but with enough keys and
+// enough iterations to make that a near certainty rather than a coin toss.
+func TestWriteDescriptor_Deterministic(t *testing.T) {
+	options := map[string]string{
+		"package": "models",
+		"module":  "github.com/z5labs/avroc",
+		"prefix":  "Avro",
+		"suffix":  "Message",
+		"tags":    "json",
+		"pointer": "true",
+		"stream":  "false",
+		"marshal": "true",
+	}
+	schemas := []*avrocpb.Schema{testSchema("User"), testSchema("Order"), testSchema("Item")}
+
+	var want []byte
+	for i := range 32 {
+		dir := t.TempDir()
+		desc := newDescriptor(GeneratorConfig{Options: options}.options(), schemas)
+
+		path, err := writeDescriptor(dir, desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if i == 0 {
+			want = got
+			continue
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("descriptor bytes differ on iteration %d: %d bytes vs %d", i, len(got), len(want))
+		}
+	}
+}
+
+// TestPlanGenerators_DescriptorsAreReproducible is the same criterion one level
+// up, over the path a real run takes: parse the project's IDL, resolve it, plan
+// the generators, encode each task's descriptor. Regenerating an unchanged
+// project twice must produce the same bytes, so anything nondeterministic in
+// parsing or resolution — a map walked in iteration order, a pointer formatted
+// into a name — fails here rather than as an unexplained diff in somebody's
+// generated code.
+func TestPlanGenerators_DescriptorsAreReproducible(t *testing.T) {
+	dir := t.TempDir()
+	shared := writeIDL(t, dir, "shared.avdl")
+
+	m := &Manifest{
+		Inputs: []string{shared},
+		Generators: []GeneratorConfig{
+			{Name: "go", Out: "gen/go", Options: map[string]string{"package": "models", "module": "example.com/m"}},
+			{Name: "json", Out: "gen/json"},
+		},
+	}
+	generators := map[string]string{
+		"avroc-gen-go":   "/fake/avroc-gen-go",
+		"avroc-gen-json": "/fake/avroc-gen-json",
+	}
+
+	encode := func() [][]byte {
+		t.Helper()
+		tasks, err := planGenerators(m, generators, dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := make([][]byte, len(tasks))
+		for i, task := range tasks {
+			b, err := ir.MarshalDescriptor(newDescriptor(task.options, task.schemas))
+			if err != nil {
+				t.Fatal(err)
+			}
+			out[i] = b
+		}
+		return out
+	}
+
+	first := encode()
+	if len(first) != 2 {
+		t.Fatalf("descriptors = %d, want 2", len(first))
+	}
+	for i, b := range encode() {
+		if !bytes.Equal(b, first[i]) {
+			t.Errorf("descriptor %d differs between two runs over an unchanged project", i)
+		}
+	}
+}

--- a/internal/ir/descriptor.go
+++ b/internal/ir/descriptor.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package ir
+
+import (
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// MarshalDescriptor encodes a descriptor into the protobuf binary wire encoding
+// docs/plugin/SPEC.md requires of the bytes at --descriptor.
+//
+// It is the one place those bytes are produced, because the encoding carries a
+// requirement the call site cannot see: two runs over unchanged inputs MUST
+// produce byte-identical descriptors. Generated output is a thing a project
+// commits and reviews, and a descriptor that differed run to run would make
+// every regeneration a diff, with nothing in it that anybody changed.
+//
+// Deterministic marshalling is what buys that. protobuf-go emits fields in
+// field-number order, so a message built the same way twice already encodes the
+// same way twice; the option additionally fixes the order of any map field the
+// IR grows later, which is the one construct whose encoding would otherwise
+// follow Go's randomised map iteration — and would break intermittently rather
+// than every time, which is worse.
+//
+// Determinism upstream of the encoding is the producer's: the repeated fields
+// carry an order, and avroc fixes it before it gets here. Manifest options sort
+// by key (see GeneratorConfig.options), and schemas follow the manifest's input
+// order.
+func MarshalDescriptor(desc *avrocpb.GenerateRequest) ([]byte, error) {
+	return proto.MarshalOptions{Deterministic: true}.Marshal(desc)
+}

--- a/internal/ir/descriptor_test.go
+++ b/internal/ir/descriptor_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package ir
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func descriptorFixture() *avrocpb.GenerateRequest {
+	return &avrocpb.GenerateRequest{
+		Version: proto.Int32(Version),
+		Options: []*avrocpb.Option{
+			{Name: proto.String("module"), Value: proto.String("example.com/m")},
+			{Name: proto.String("package"), Value: proto.String("models")},
+		},
+		Schemas: []*avrocpb.Schema{
+			{
+				Namespace: proto.String("com.example"),
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:     proto.String("User"),
+							FullName: proto.String("com.example.User"),
+							Fields: []*avrocpb.Field{
+								{
+									Name: proto.String("name"),
+									Type: &avrocpb.Type{
+										Type: &avrocpb.Type_Reference{
+											Reference: &avrocpb.Reference{
+												Name: proto.String("string"),
+												Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMarshalDescriptor(t *testing.T) {
+	t.Run("round-trips through the binary wire encoding", func(t *testing.T) {
+		desc := descriptorFixture()
+
+		b, err := MarshalDescriptor(desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got avrocpb.GenerateRequest
+		if err := proto.Unmarshal(b, &got); err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(&got, desc) {
+			t.Errorf("decoded descriptor differs from the one encoded\n got: %v\nwant: %v", &got, desc)
+		}
+	})
+
+	t.Run("encodes equal messages to equal bytes", func(t *testing.T) {
+		// Two independently built values that are proto.Equal must encode
+		// identically. That is the property the descriptor file rests on: the
+		// bytes are a function of the message, not of the process that built it.
+		var want []byte
+		for i := range 64 {
+			got, err := MarshalDescriptor(descriptorFixture())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if i == 0 {
+				want = got
+				continue
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("encoding differs on iteration %d", i)
+			}
+		}
+	})
+
+	t.Run("distinguishes descriptors that differ", func(t *testing.T) {
+		// Determinism is worth nothing if the encoding is insensitive to the
+		// inputs, so check the other direction too: a changed option changes the
+		// bytes, which is what makes a byte comparison a meaningful check.
+		a, err := MarshalDescriptor(descriptorFixture())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		changed := descriptorFixture()
+		changed.Options[1].Value = proto.String("types")
+		b, err := MarshalDescriptor(changed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if bytes.Equal(a, b) {
+			t.Error("descriptors differing in an option encoded to the same bytes")
+		}
+	})
+}


### PR DESCRIPTION
Closes #111

Replaces `GenerateRequest`-as-a-wire-message-only with a descriptor written to
disk — the thing `--descriptor` will point at once generators become executables
(#114).

## Acceptance criteria

- [x] **avroc writes one descriptor file per generator invocation, containing
  the options and the resolved schemas for that generator.**
  `generator.generate` builds the descriptor once (`newDescriptor`), writes it
  with `writeDescriptor` into a directory created by `os.MkdirTemp` for that one
  invocation, and sends *the same value* over the gRPC service. The file is
  therefore the value the generator received, not a second encoding of the same
  inputs that could drift from it.
- [x] **The bytes are deterministic for identical inputs; the encoding must not
  depend on map iteration order.** `ir.MarshalDescriptor` is the single place
  those bytes are produced and marshals with `Deterministic: true`. Ordering
  upstream of the encoder is unchanged and now documented as load-bearing:
  manifest options already sort by key, schemas follow the manifest's input
  order. Covered by `TestMarshalDescriptor/encodes equal messages to equal
  bytes` (64 iterations), `TestWriteDescriptor_Deterministic` (32 iterations,
  options rebuilt from an 8-key Go map each time), and — the other direction, so
  the byte comparison means something — `TestMarshalDescriptor/distinguishes
  descriptors that differ`.
- [x] **The descriptor file's location and lifetime are specified and match
  `docs/plugin/SPEC.md`.** The spec gains a `Location and lifetime` subsection
  under `The descriptor`: one file per invocation in a directory created for it
  alone, never shared between generators or runs; written in full and closed
  before the generator starts; file and directory removed once the generator has
  exited, zero or not; created read-only; and no promise at all about the path.
  The implementation is exactly that — `O_EXCL` at mode `0444`, and a
  `RemoveAll` deferred *first* in `generate` so it unwinds last, after the
  process has been waited on and never while it may still be reading.
- [x] **Regenerating twice from an unchanged project produces byte-identical
  descriptors.** `TestPlanGenerators_DescriptorsAreReproducible` runs the real
  path — parse the project's IDL, resolve it, plan the generators, encode each
  task's descriptor — twice and byte-compares, so nondeterminism anywhere in
  parsing or resolution fails there rather than as an unexplained diff in
  somebody's generated code. `docs/ir/SPEC.md` now states that requirement over
  the whole descriptor rather than only over its options.
- [x] **`go test -race ./...` passes.**

## Judgment calls

- **The path is not passed to the generator yet.** The argument vector is #114's
  and the gRPC service is #124's; changing either here would break every
  generator in the repository mid-story. The descriptor is written, logged at
  debug, and cleaned up, and the same value goes over the wire.
- **`ir.MarshalDescriptor` rather than a bare `proto.Marshal` at the call site.**
  The encoding carries a requirement the call site cannot see, and generators
  will need the matching read in #121–#123.
- **Read-only (`0444`) descriptors.** `docs/plugin/SPEC.md` forbids a plugin
  writing to the descriptor. A mode bit does not enforce that — the plugin
  usually runs as the user that created the file — but it turns the accidental
  case into an error where the mistake is. Written as **SHOULD** in the spec for
  that reason.
- **`O_EXCL`.** A descriptor found in a directory that already holds one would be
  unattributable, so a reused directory is an error rather than a clobber.
- **The lifetime test lives inside the stand-in generator subprocess.** "The file
  exists, is complete, and holds exactly what this generator received" is only
  observable from a process running *during* the invocation; the parent then
  asserts the directory did not survive it. Verified to bite: stubbing out the
  write fails `TestGeneratorGenerate` with `no descriptor file under "/tmp" while
  the generator is running`.

## Verification

All four `verify` commands from `.claude/backlog.json`, from a clean worktree:

- `go build ./...`
- `go test -race -cover ./...` — all packages ok; `internal/avroc` 83.8%,
  `internal/ir` 87.6%
- `golangci-lint run` — `0 issues`. (A first run reported two `staticcheck`
  findings in `avrocpb/generator_grpc.pb.go` of a *deleted sibling worktree*, out
  of a stale golangci-lint cache. `golangci-lint cache clean` cleared it; a tool
  artifact, not a code defect, and nothing was edited around it.)
- the `example/` round-trip — regenerates and `git diff --exit-code -- example`
  is clean, so the descriptor work changes no generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)