### PR TITLE
story(ir): render a descriptor as JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ options sort by key, schemas follow the manifest's input order — and
 reaching the encoder in Go's map iteration order is the way this gets broken, and
 it breaks intermittently.
 
+**Reading one is `avroc inspect <descriptor>`** (`-` for stdin), which renders it
+as JSON via `ir.MarshalDescriptorJSON`: `docs/ir/SPEC.md`'s "A descriptor is
+readable by a person". The rendering uses protobuf field names and is byte-stable
+across builds — protojson varies its whitespace per binary on purpose, so the
+output is re-indented through `encoding/json` before it is printed. It renders
+regardless of the descriptor's IR version and without validating the closed sets:
+looking is not consuming, and the descriptor worth reading is usually the one a
+generator refused.
+
 ### Plugin Discovery
 
 The CLI scans all directories in `PATH` for executables matching `avroc-gen-<name>`. Each discovered generator gets a corresponding `-<name>_out` CLI flag for specifying its output directory.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ avroc is driven by a project manifest (`avroc.json`) and exposes these commands:
 avroc init        # scaffold a starter avroc.json (never clobbers an existing one)
 avroc get         # resolve & pull generator images, pinning them in avroc.lock
 avroc generate    # run the generators declared in avroc.json
+avroc inspect     # render a descriptor file as JSON (use - for stdin)
 ```
 
 ### Manifest (`avroc.json`)
@@ -182,6 +183,27 @@ This produces:
 - `pcf/test_record.avsc` — Avro Parsing Canonical Form
 
 See the [`example/`](example/) directory for a working example.
+
+### Inspecting a descriptor (`avroc inspect`)
+
+Every generator invocation is handed a **descriptor**: the IR version, that generator's
+options, and the resolved schemas, in the protobuf binary encoding
+([`docs/ir/SPEC.md`](docs/ir/SPEC.md)). When a generator emits output nobody expected, the
+first question is what it was actually handed, and `avroc inspect` answers it:
+
+```bash
+avroc inspect descriptor.binpb    # render a saved descriptor as JSON
+avroc inspect - < descriptor.binpb # or read it from stdin
+```
+
+The rendering uses the field names from `proto/` and the spec (`full_name`, not `fullName`),
+and is byte-stable across runs and across avroc builds, so two descriptors can simply be
+diffed. It is a rendering for people, never an input: a generator is handed the binary
+descriptor, and nothing reads the JSON back. A descriptor whose IR version this avroc does
+not know still renders — that is the case worth reading.
+
+> avroc removes an invocation's descriptor once the generator exits, so what you inspect is a
+> copy a generator saved from the path it was handed.
 
 ## Built-in Generators
 

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -340,6 +340,53 @@ copy, so the descriptor stays finite. A consumer **MUST NOT** assume the type
 graph is acyclic once references are followed, even though the message it
 decoded is nested.
 
+## A descriptor is readable by a person
+
+The descriptor's encoding is protobuf, which nobody reads. avroc **MUST**
+therefore ship a rendering of a descriptor as JSON, and that rendering is the
+inspection path: the answer to *what was this generator actually handed*, which
+is the first question asked whenever a generator emits the wrong output. In
+avroc it is `avroc inspect <descriptor>`, which writes the rendering to standard
+output and accepts `-` for standard input (#112).
+
+The rendering **MUST** use protobuf's own field names — `full_name`, not
+`fullName` — so that a name on screen is the name in the schema language and in
+this document. Anyone reading a descriptor is reading it beside this spec, and a
+lowerCamelCase rendering would make them translate every name back before they
+could look one up.
+
+Two renderings of one descriptor **MUST** be byte-identical, and a rendering
+**MUST NOT** vary with the build of the tool producing it (#112). That is the
+same requirement [What a descriptor carries](#what-a-descriptor-carries) makes
+of the binary encoding, and it is here for the same reason one step further out:
+a rendering is a thing to commit, diff and paste into an issue, and one that
+churned on an upgrade could not be any of the three. It is a requirement worth
+stating because the obvious implementation does not satisfy it — a JSON printer
+is entitled to vary its whitespace, and Go's varies it deliberately, per binary,
+to stop anyone depending on the exact bytes.
+
+The rendering is **one-way**, and no consumer is entitled to be handed one. A
+plugin receives the binary encoding; a plugin that accepted both would have to
+sniff which it had, which is
+[`plugin/SPEC.md`](../plugin/SPEC.md)'s reasoning and not restated here. Nothing
+in this document defines a JSON *encoding* of a descriptor — a renderer **MUST
+NOT** be relied on to round-trip, and a producer **MUST NOT** emit JSON where a
+descriptor is called for.
+
+A renderer **MUST NOT** refuse a descriptor because of its
+[version](#the-version-field), and **MUST NOT** require the closed sets to hold.
+Rendering is looking, not consuming: a descriptor from a contract the tool does
+not know, or one carrying a member it cannot act on, is precisely the one
+somebody needs to read, and the version it claims is the first thing the
+rendering shows. `CheckVersion` and validation belong to a consumer about to act
+on a descriptor, and refusing to *print* one would withhold the output in the
+case that motivates printing it.
+
+Getting hold of a descriptor to render is [delivery](#also-out-of-scope), and
+so not this document's: the file avroc writes for an invocation is removed when
+that generator exits, so what a person inspects is a copy — one the plugin saved
+from the path it was handed.
+
 ## Out of Scope
 
 ### Avro IDL and JSON schema syntax
@@ -415,3 +462,4 @@ is making their input identical rather than shipping one of the outputs:
 | [Compatibility](#compatibility) | [#109](https://github.com/z5labs/avroc/issues/109) |
 | [What *resolved* means](#what-resolved-means) | [#108](https://github.com/z5labs/avroc/issues/108) |
 | [The nested tree is kept](#the-nested-tree-is-kept) | [#108](https://github.com/z5labs/avroc/issues/108), [#112](https://github.com/z5labs/avroc/issues/112) |
+| [A descriptor is readable by a person](#a-descriptor-is-readable-by-a-person) | [#112](https://github.com/z5labs/avroc/issues/112) |

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -49,6 +49,10 @@ func Main(ctx context.Context, cli cli.Context) int {
 			return code
 		}
 		return runGenerate(ctx, cli)
+	case "inspect":
+		// inspect names the descriptor it renders, so it owns its own argument
+		// handling rather than being routed through rejectExtraArgs.
+		return runInspect(ctx, cli)
 	case "help", "-h", "-help", "--help":
 		printUsage(os.Stdout)
 		return 0
@@ -79,6 +83,7 @@ Commands:
   init       Scaffold an avroc.json manifest
   get        Resolve and pull generator images, pinning them in avroc.lock
   generate   Run the generators declared in avroc.json
+  inspect    Render a descriptor file as JSON (- reads standard input)
   help       Show this help
 `
 	_, _ = io.WriteString(w, usage)

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -236,6 +236,20 @@ func TestMain_Dispatch(t *testing.T) {
 			t.Errorf("exit code = %d, want 1", code)
 		}
 	})
+
+	t.Run("inspect renders the descriptor it is given", func(t *testing.T) {
+		path, _ := writeInspectFixture(t)
+
+		if code := Main(context.Background(), newContext("inspect", path)); code != 0 {
+			t.Errorf("exit code = %d, want 0", code)
+		}
+	})
+
+	t.Run("inspect requires a descriptor", func(t *testing.T) {
+		if code := Main(context.Background(), newContext("inspect")); code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
+		}
+	})
 }
 
 // TestHelperGenerator is a test function that doubles as a real generator subprocess.

--- a/internal/avroc/descriptor.go
+++ b/internal/avroc/descriptor.go
@@ -28,8 +28,8 @@ import (
 //
 // The .binpb suffix is protobuf's own for the binary wire encoding, which is
 // what the file holds. The JSON rendering a person reads is a separate artifact
-// (#112), and a plugin is never handed one — a plugin that accepted both would
-// have to sniff which it had.
+// — avroc inspect produces it on demand — and a plugin is never handed one; a
+// plugin that accepted both would have to sniff which it had.
 const descriptorFilename = "descriptor.binpb"
 
 // descriptorFileMode is the mode avroc creates a descriptor with.

--- a/internal/avroc/inspect.go
+++ b/internal/avroc/inspect.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+)
+
+// stdinPath is the argument that means "read the descriptor from standard
+// input" rather than from a file of that name. The convention is the usual one,
+// and it is what lets a descriptor be piped straight out of wherever it was
+// saved without landing on disk first.
+const stdinPath = "-"
+
+// runInspect renders a descriptor file as JSON on stdout: docs/ir/SPEC.md's
+// inspection path, and the first thing to reach for when a generator produces
+// output nobody expected. The descriptor is what the generator was handed, and
+// until there was a way to read one the question "what did it actually get"
+// had no answer at all.
+//
+// It takes exactly one argument, the descriptor to read, or "-" for stdin.
+func runInspect(ctx context.Context, c cli.Context) int {
+	flags := flag.NewFlagSet("inspect", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	flags.Usage = func() {
+		_, _ = io.WriteString(os.Stderr, "Usage: avroc inspect <descriptor>\n\nRenders a descriptor file as JSON. Use - to read standard input.\n")
+	}
+	if err := flags.Parse(c.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 1
+	}
+
+	args := flags.Args()
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "inspect takes exactly one descriptor path, got %d\n\n", len(args))
+		flags.Usage()
+		return 1
+	}
+
+	return inspectDescriptor(ctx, c, args[0], os.Stdin, os.Stdout)
+}
+
+// inspectDescriptor is the testable core of avroc inspect: stdin and stdout are
+// parameters so the rendering can be exercised without touching the process's
+// own streams.
+//
+// The version is deliberately not checked. Rendering is looking, not consuming,
+// and a descriptor from a contract this build does not know is exactly the one
+// somebody needs to look at — refusing it would withhold the rendering in the
+// case that motivates the subcommand. The version is the first field of the
+// output, so what a check would have said is on screen anyway. The closed sets
+// go unchecked for the same reason; ir.Validate is for a generator about to act
+// on a descriptor, not for a person reading one.
+func inspectDescriptor(ctx context.Context, c cli.Context, path string, stdin io.Reader, stdout io.Writer) int {
+	b, err := readDescriptorBytes(path, stdin)
+	if err != nil {
+		c.Log.ErrorContext(ctx, "failed to read descriptor", slog.String("path", path), slog.Any("error", err))
+		return 1
+	}
+
+	desc, err := ir.UnmarshalDescriptor(b)
+	if err != nil {
+		c.Log.ErrorContext(ctx, "failed to decode descriptor", slog.String("path", path), slog.Any("error", err))
+		return 1
+	}
+
+	out, err := ir.MarshalDescriptorJSON(desc)
+	if err != nil {
+		c.Log.ErrorContext(ctx, "failed to render descriptor", slog.String("path", path), slog.Any("error", err))
+		return 1
+	}
+
+	// One trailing newline, so the rendering is a text file: it ends where a
+	// line ends, a shell prompt starts on its own line, and diffing two of them
+	// does not report a missing newline at end of file.
+	if _, err := fmt.Fprintf(stdout, "%s\n", out); err != nil {
+		c.Log.ErrorContext(ctx, "failed to write descriptor JSON", slog.Any("error", err))
+		return 1
+	}
+
+	return 0
+}
+
+func readDescriptorBytes(path string, stdin io.Reader) ([]byte, error) {
+	if path == stdinPath {
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(path)
+}

--- a/internal/avroc/inspect_test.go
+++ b/internal/avroc/inspect_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func inspectContext(args ...string) cli.Context {
+	return cli.Context{
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: ".",
+		Args:       args,
+	}
+}
+
+// writeInspectFixture writes a descriptor to a temporary file the way avroc
+// writes one, and returns both the path and the descriptor.
+func writeInspectFixture(t *testing.T) (string, *avrocpb.GenerateRequest) {
+	t.Helper()
+
+	desc := newDescriptor(
+		[]*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("models")}},
+		[]*avrocpb.Schema{
+			{
+				Namespace: proto.String("com.example"),
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:     proto.String("User"),
+							FullName: proto.String("com.example.User"),
+							Fields: []*avrocpb.Field{
+								{
+									Name: proto.String("id"),
+									Type: &avrocpb.Type{
+										Type: &avrocpb.Type_Reference{
+											Reference: &avrocpb.Reference{
+												Name: proto.String("long"),
+												Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	path, err := writeDescriptor(t.TempDir(), desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path, desc
+}
+
+func TestInspectDescriptor(t *testing.T) {
+	t.Run("renders a descriptor avroc wrote", func(t *testing.T) {
+		// End to end over a real descriptor file: the subcommand must read what
+		// writeDescriptor produced, which is the artifact a person actually has
+		// in hand when they reach for this.
+		path, desc := writeInspectFixture(t)
+
+		var out bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &out); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+
+		want, err := ir.MarshalDescriptorJSON(desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := out.String(); got != string(want)+"\n" {
+			t.Errorf("rendering differs\n got:\n%s\nwant:\n%s\n", got, want)
+		}
+		if !json.Valid(out.Bytes()) {
+			t.Errorf("output is not valid JSON:\n%s", out.String())
+		}
+		if !strings.HasSuffix(out.String(), "}\n") {
+			t.Errorf("output does not end in a single newline: %q", out.String())
+		}
+	})
+
+	t.Run("reads the descriptor from stdin", func(t *testing.T) {
+		path, _ := writeInspectFixture(t)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var fromStdin, fromFile bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), stdinPath, bytes.NewReader(b), &fromStdin); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &fromFile); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+
+		if fromStdin.String() != fromFile.String() {
+			t.Errorf("piped descriptor rendered differently\n stdin:\n%s\n file:\n%s", fromStdin.String(), fromFile.String())
+		}
+	})
+
+	t.Run("renders the same bytes every time", func(t *testing.T) {
+		// The output is a thing to diff across runs, so two renderings of one
+		// file must not differ.
+		path, _ := writeInspectFixture(t)
+
+		var first bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &first); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		for i := range 8 {
+			var next bytes.Buffer
+			if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &next); code != 0 {
+				t.Fatalf("exit code = %d, want 0", code)
+			}
+			if next.String() != first.String() {
+				t.Fatalf("rendering differs on iteration %d\n got:\n%s\nwant:\n%s", i, next.String(), first.String())
+			}
+		}
+	})
+
+	t.Run("fails on a missing file", func(t *testing.T) {
+		var out bytes.Buffer
+		path := filepath.Join(t.TempDir(), "absent.binpb")
+
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &out); code == 0 {
+			t.Error("exit code = 0, want non-zero for a missing descriptor")
+		}
+		if out.Len() != 0 {
+			t.Errorf("wrote output for a missing descriptor:\n%s", out.String())
+		}
+	})
+
+	t.Run("fails on bytes that are not a descriptor", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "junk.binpb")
+		if err := os.WriteFile(path, []byte("not a descriptor"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var out bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &out); code == 0 {
+			t.Error("exit code = 0, want non-zero for a file that is not a descriptor")
+		}
+		if out.Len() != 0 {
+			t.Errorf("wrote output for a file that is not a descriptor:\n%s", out.String())
+		}
+	})
+
+	t.Run("renders a descriptor from an unknown IR version", func(t *testing.T) {
+		// The case the subcommand exists for: a descriptor this build would
+		// refuse to generate from is still one a person can read.
+		desc := newDescriptor(nil, nil)
+		desc.Version = proto.Int32(ir.Version + 41)
+		b, err := ir.MarshalDescriptor(desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var out bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), stdinPath, bytes.NewReader(b), &out); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if !strings.Contains(out.String(), `"version"`) {
+			t.Errorf("rendering does not carry the version:\n%s", out.String())
+		}
+	})
+}
+
+func TestRunInspect(t *testing.T) {
+	t.Run("renders the descriptor it is given", func(t *testing.T) {
+		path, _ := writeInspectFixture(t)
+
+		if code := runInspect(context.Background(), inspectContext("inspect", path)); code != 0 {
+			t.Errorf("exit code = %d, want 0", code)
+		}
+	})
+
+	t.Run("rejects an invocation naming no descriptor", func(t *testing.T) {
+		if code := runInspect(context.Background(), inspectContext("inspect")); code == 0 {
+			t.Error("exit code = 0, want non-zero when no descriptor is named")
+		}
+	})
+
+	t.Run("rejects an invocation naming more than one descriptor", func(t *testing.T) {
+		// Two paths is a mistake with two plausible readings — render both, or
+		// render the first — so it fails instead of picking one.
+		path, _ := writeInspectFixture(t)
+
+		if code := runInspect(context.Background(), inspectContext("inspect", path, path)); code == 0 {
+			t.Error("exit code = 0, want non-zero when two descriptors are named")
+		}
+	})
+}

--- a/internal/avroc/inspect_test.go
+++ b/internal/avroc/inspect_test.go
@@ -170,6 +170,26 @@ func TestInspectDescriptor(t *testing.T) {
 		}
 	})
 
+	t.Run("fails on an empty file", func(t *testing.T) {
+		// An empty file decodes as a descriptor carrying nothing, so without a
+		// check it would render as {} and exit 0 — sending whoever ran it
+		// looking for a producer bug that is really a truncated write or the
+		// wrong path.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.binpb")
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var out bytes.Buffer
+		if code := inspectDescriptor(context.Background(), inspectContext(), path, nil, &out); code == 0 {
+			t.Error("exit code = 0, want non-zero for an empty descriptor file")
+		}
+		if out.Len() != 0 {
+			t.Errorf("wrote output for an empty descriptor file:\n%s", out.String())
+		}
+	})
+
 	t.Run("renders a descriptor from an unknown IR version", func(t *testing.T) {
 		// The case the subcommand exists for: a descriptor this build would
 		// refuse to generate from is still one a person can read.

--- a/internal/ir/descriptor.go
+++ b/internal/ir/descriptor.go
@@ -6,8 +6,13 @@
 package ir
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
 	"github.com/z5labs/avroc/avrocpb"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -33,4 +38,80 @@ import (
 // order.
 func MarshalDescriptor(desc *avrocpb.GenerateRequest) ([]byte, error) {
 	return proto.MarshalOptions{Deterministic: true}.Marshal(desc)
+}
+
+// UnmarshalDescriptor decodes the protobuf binary wire encoding MarshalDescriptor
+// produces back into a descriptor.
+//
+// It is the reading half of the same one place, so a consumer never spells the
+// message type at its own call site and cannot decode a descriptor into
+// something that merely resembles one.
+//
+// Unknown fields are kept rather than discarded, which is the ignoring half of
+// docs/ir/SPEC.md's asymmetry done properly: a descriptor from a producer that
+// carries a field this build has never heard of decodes, and the field survives
+// a re-encode instead of being silently dropped by whatever reads it next. What
+// is *not* checked here is the version or the closed sets — CheckVersion and
+// Validate own those, in that order, and a caller that only wants to look at a
+// descriptor is entitled to skip both.
+func UnmarshalDescriptor(b []byte) (*avrocpb.GenerateRequest, error) {
+	var desc avrocpb.GenerateRequest
+	if err := proto.Unmarshal(b, &desc); err != nil {
+		return nil, fmt.Errorf("failed to decode descriptor: %w", err)
+	}
+	return &desc, nil
+}
+
+// descriptorJSONIndent is the indentation a rendered descriptor is written with.
+// Two spaces, matching the manifest and lockfile avroc writes, so the three
+// artifacts a person reads in one sitting are indented alike.
+const descriptorJSONIndent = "  "
+
+// MarshalDescriptorJSON renders a descriptor as the JSON a person reads:
+// docs/ir/SPEC.md's inspection path, and the answer to "what was this generator
+// actually handed".
+//
+// It is a rendering and never an interchange format. Only avroc writes it,
+// nothing reads it back, and a plugin is handed the binary encoding — a plugin
+// accepting both would have to sniff which it had (docs/plugin/SPEC.md, "The
+// descriptor").
+//
+// Two choices make the output worth diffing:
+//
+// Field names are protobuf's own, so a name in the rendering is a name in
+// proto/ and in docs/ir/SPEC.md — full_name, not fullName. Someone reading a
+// descriptor is reading it beside the spec, and a lowerCamelCase rendering
+// would make them translate every name back.
+//
+// The bytes are stable across runs *and across builds*, which the obvious
+// implementation is not. protojson deliberately emits an unstable amount of
+// whitespace — an extra space after a comma, or after a "key":, chosen by a
+// hash of the running binary — precisely so that nobody depends on its exact
+// output. That is stable within one avroc and different in the next, so a
+// descriptor re-rendered after an upgrade would diff on every line with nothing
+// in it that anybody changed. Re-indenting through encoding/json rewrites every
+// byte of insignificant whitespace and leaves the token sequence alone, which
+// pins the output to what protojson *said* rather than to how it spaced it.
+//
+// Field order is protobuf's field-number order and map entries are sorted by
+// key, both of which protojson already guarantees; the re-indent preserves the
+// order it was given.
+func MarshalDescriptorJSON(desc *avrocpb.GenerateRequest) ([]byte, error) {
+	b, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(desc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render descriptor as JSON: %w", err)
+	}
+	return indentJSON(b)
+}
+
+// indentJSON reformats valid JSON into one canonical indented shape, dropping
+// whatever insignificant whitespace it arrived with. It is the step that makes
+// MarshalDescriptorJSON's output a function of the descriptor rather than of
+// the binary that rendered it; see there for why protojson's own output is not.
+func indentJSON(b []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, b, "", descriptorJSONIndent); err != nil {
+		return nil, fmt.Errorf("failed to indent descriptor JSON: %w", err)
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/ir/descriptor.go
+++ b/internal/ir/descriptor.go
@@ -54,7 +54,20 @@ func MarshalDescriptor(desc *avrocpb.GenerateRequest) ([]byte, error) {
 // is *not* checked here is the version or the closed sets — CheckVersion and
 // Validate own those, in that order, and a caller that only wants to look at a
 // descriptor is entitled to skip both.
+//
+// Emptiness is the one exception, and it is not a version check in disguise.
+// Zero bytes are a valid encoding of an empty message, so proto.Unmarshal
+// accepts them and hands back a descriptor carrying nothing — which is how a
+// truncated write, an empty file or a path that was never a descriptor at all
+// turns into a successful read and an empty rendering. No conforming producer
+// emits one, because every descriptor carries at least a version, so refusing
+// here puts the diagnostic where the mistake is instead of leaving somebody to
+// wonder why their schemas vanished.
 func UnmarshalDescriptor(b []byte) (*avrocpb.GenerateRequest, error) {
+	if len(b) == 0 {
+		return nil, fmt.Errorf("failed to decode descriptor: no bytes to decode")
+	}
+
 	var desc avrocpb.GenerateRequest
 	if err := proto.Unmarshal(b, &desc); err != nil {
 		return nil, fmt.Errorf("failed to decode descriptor: %w", err)

--- a/internal/ir/descriptor_test.go
+++ b/internal/ir/descriptor_test.go
@@ -7,6 +7,7 @@ package ir
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/z5labs/avroc/avrocpb"
@@ -106,6 +107,176 @@ func TestMarshalDescriptor(t *testing.T) {
 
 		if bytes.Equal(a, b) {
 			t.Error("descriptors differing in an option encoded to the same bytes")
+		}
+	})
+}
+
+func TestUnmarshalDescriptor(t *testing.T) {
+	t.Run("decodes what MarshalDescriptor encoded", func(t *testing.T) {
+		desc := descriptorFixture()
+
+		b, err := MarshalDescriptor(desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := UnmarshalDescriptor(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(got, desc) {
+			t.Errorf("decoded descriptor differs from the one encoded\n got: %v\nwant: %v", got, desc)
+		}
+	})
+
+	t.Run("rejects bytes that are not a descriptor", func(t *testing.T) {
+		// A truncated or unrelated file must fail here rather than decode into
+		// an empty descriptor: a caller shown "version 0, no schemas" would go
+		// looking for a producer bug that is really a wrong path.
+		_, err := UnmarshalDescriptor([]byte("this is not protobuf at all"))
+		if err == nil {
+			t.Error("expected an error decoding non-descriptor bytes")
+		}
+	})
+}
+
+func TestMarshalDescriptorJSON(t *testing.T) {
+	t.Run("renders the descriptor with protobuf field names", func(t *testing.T) {
+		// A golden rendering, because every part of it is a thing a reader
+		// depends on: snake_case names matching proto/ and docs/ir/SPEC.md, the
+		// enum spelled rather than numbered, two-space indentation, and
+		// protobuf's field-number ordering (full_name after fields).
+		const want = `{
+  "version": 1,
+  "options": [
+    {
+      "name": "module",
+      "value": "example.com/m"
+    },
+    {
+      "name": "package",
+      "value": "models"
+    }
+  ],
+  "schemas": [
+    {
+      "namespace": "com.example",
+      "type": {
+        "record": {
+          "name": "User",
+          "fields": [
+            {
+              "name": "name",
+              "type": {
+                "reference": {
+                  "name": "string",
+                  "kind": "TYPE_REF_KIND_PRIMITIVE"
+                }
+              }
+            }
+          ],
+          "full_name": "com.example.User"
+        }
+      }
+    }
+  ]
+}`
+
+		got, err := MarshalDescriptorJSON(descriptorFixture())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Errorf("rendering differs\n got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("renders equal descriptors identically", func(t *testing.T) {
+		var want []byte
+		for i := range 64 {
+			got, err := MarshalDescriptorJSON(descriptorFixture())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if i == 0 {
+				want = got
+				continue
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("rendering differs on iteration %d", i)
+			}
+		}
+	})
+
+	t.Run("distinguishes descriptors that differ", func(t *testing.T) {
+		a, err := MarshalDescriptorJSON(descriptorFixture())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		changed := descriptorFixture()
+		changed.Options[1].Value = proto.String("types")
+		b, err := MarshalDescriptorJSON(changed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if bytes.Equal(a, b) {
+			t.Error("descriptors differing in an option rendered identically")
+		}
+	})
+
+	t.Run("renders a descriptor carrying an unknown version", func(t *testing.T) {
+		// Rendering is looking, not consuming. A descriptor from a contract
+		// this build does not know is the one somebody most needs to read, and
+		// the version it claims is right there in the output.
+		desc := descriptorFixture()
+		desc.Version = proto.Int32(Version + 41)
+
+		got, err := MarshalDescriptorJSON(desc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(got, fmt.Appendf(nil, `"version": %d`, Version+41)) {
+			t.Errorf("rendering does not report the descriptor's own version:\n%s", got)
+		}
+	})
+}
+
+func TestIndentJSON(t *testing.T) {
+	t.Run("is insensitive to the whitespace it is handed", func(t *testing.T) {
+		// This is the property MarshalDescriptorJSON rests on, and it cannot be
+		// observed through protojson from inside one test binary: protojson's
+		// extra spaces are chosen by a hash of the running binary, so they are
+		// fixed for this process and differ in the next build. The two inputs
+		// below are the two shapes it emits — a space after a comma and a
+		// second space after a "key": — written out by hand so that a
+		// regression here fails every time rather than in half of all builds.
+		compact := []byte(`{"version":1,"options":[{"name":"module","value":"a, b"}]}`)
+		spaced := []byte(`{"version":  1, "options": [{"name":  "module", "value":  "a, b"}]}`)
+
+		fromCompact, err := indentJSON(compact)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fromSpaced, err := indentJSON(spaced)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(fromCompact, fromSpaced) {
+			t.Errorf("indentation depends on the input's whitespace\n from compact:\n%s\n from spaced:\n%s", fromCompact, fromSpaced)
+		}
+		// A string's own spacing is content, not whitespace between tokens, and
+		// must survive untouched.
+		if !bytes.Contains(fromCompact, []byte(`"a, b"`)) {
+			t.Errorf("string content was reformatted:\n%s", fromCompact)
+		}
+	})
+
+	t.Run("reports invalid JSON", func(t *testing.T) {
+		if _, err := indentJSON([]byte(`{"unterminated":`)); err == nil {
+			t.Error("expected an error indenting invalid JSON")
 		}
 	})
 }

--- a/internal/ir/descriptor_test.go
+++ b/internal/ir/descriptor_test.go
@@ -138,6 +138,22 @@ func TestUnmarshalDescriptor(t *testing.T) {
 			t.Error("expected an error decoding non-descriptor bytes")
 		}
 	})
+
+	t.Run("rejects empty input", func(t *testing.T) {
+		// Zero bytes are a valid encoding of an empty message, so this is the
+		// one malformed input protobuf accepts: an empty file, a truncated
+		// write or the wrong path would otherwise decode successfully and
+		// render as {}. Both spellings of empty are checked, because a caller
+		// reading a file gets one and a caller reading an empty stream the
+		// other.
+		for name, b := range map[string][]byte{"nil": nil, "empty": {}} {
+			t.Run(name, func(t *testing.T) {
+				if _, err := UnmarshalDescriptor(b); err == nil {
+					t.Error("expected an error decoding empty input")
+				}
+			})
+		}
+	})
 }
 
 func TestMarshalDescriptorJSON(t *testing.T) {


### PR DESCRIPTION
Closes #112

Adds `avroc inspect <descriptor>` — the inspection path `docs/ir/SPEC.md` promised. A descriptor is protobuf, so until now the first question asked when a generator emits the wrong output ("what was it actually handed?") had no answer.

```
$ avroc inspect descriptor.binpb
{
  "version": 1,
  "options": [
    {
      "name": "package_name",
      "value": "models"
    }
  ],
  "schemas": [
    {
      "namespace": "com.example",
      "type": {
        "record": {
          "name": "User",
          "full_name": "com.example.User"
        }
      }
    }
  ]
}
```

## Acceptance criteria

- [x] **A subcommand renders a descriptor file as JSON.** `avroc inspect <descriptor>`, writing to stdout; `-` reads stdin so a descriptor can be piped without landing on disk. `internal/avroc/inspect.go`; the rendering itself is `ir.MarshalDescriptorJSON`, next to `ir.MarshalDescriptor` which produces the bytes it reads.
- [x] **The output is stable enough to diff across runs.** Byte-identical across runs *and across builds* — see the judgment call below. Covered by a golden rendering, a repeated-render test, and a direct test of the normalisation.
- [x] **Documented in `docs/ir/SPEC.md` as the inspection path.** New normative section "A descriptor is readable by a person", plus its row in the Mapping to Stories appendix. `README.md` and `CLAUDE.md` gain the user-facing and contributor-facing versions.
- [x] **`go test -race ./...` passes.**

## Judgment calls

**protojson's output is not stable, and the fix is not obvious.** protojson emits a random extra space after a comma, or after a `"key":`, chosen by a hash of the running binary — deliberately, to stop anyone depending on its exact bytes. That is fixed within one avroc and different in the next, so a naive implementation would re-render a descriptor identically all day and then diff on every line after an upgrade. `MarshalDescriptorJSON` re-indents through `encoding/json`, which rewrites insignificant whitespace and leaves the token sequence alone. This cannot be caught by re-rendering in one test binary (the randomness is per-process), so `TestIndentJSON` asserts the property directly against the two whitespace shapes protojson emits, written out by hand — a regression fails every time rather than in half of all builds.

**Protobuf field names, not lowerCamelCase** (`UseProtoNames: true`). A descriptor is read beside `docs/ir/SPEC.md` and `proto/`; rendering `fullName` would make the reader translate every name back before they could look one up.

**Rendering checks neither the version nor the closed sets.** Looking is not consuming: a descriptor from an IR version this build does not know, or one carrying a member it could not act on, is precisely the one somebody needs to read, and the version it claims is the first line of the output. `ir.CheckVersion` and `ir.Validate` remain a consumer's, and the spec section states this as a `MUST NOT` so a later refactor does not "tighten" it.

**`ir.UnmarshalDescriptor` was added alongside**, so the reading half of the descriptor encoding lives in the same one place as the writing half rather than being spelled out at each call site. It keeps unknown fields (the ignoring half of the spec's asymmetry) and checks nothing else.

## Verification

All four `verify` commands pass locally: `go build ./...`, `go test -race -cover ./...`, `golangci-lint run`, and the example regeneration round-trip with `git diff --exit-code -- example`. `internal/ir` coverage 87.9%, `internal/avroc` 83.6%. Also smoke-tested through the built binary — file, stdin, a missing path, a file that is not a descriptor, and `avroc help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)