### PR TITLE
story(ir): publish the FileDescriptorSet

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -166,6 +166,37 @@ func (m *Avroc) Test(ctx context.Context) error {
 		Check(ctx)
 }
 
+// IrDescriptorSet builds the IR's protobuf FileDescriptorSet — the published
+// ir.binpb — by compiling this repository and asking avrocpb for it. It is the
+// pipeline's one artifact, and it is what the release workflow attaches to a
+// release and what the base image copies to
+// /usr/local/share/avroc/ir.binpb (docs/container/SPEC.md, #126).
+//
+// It is a function on this module rather than a step in a workflow for the
+// reason .github/workflows/build.yaml gives: repo-specific work lands here and
+// is invoked with `dagger call`, so a contributor produces the same bytes CI
+// does with the same command, and there is no second recipe living in YAML that
+// nobody can run locally.
+//
+// dag.Go().Container is the escape hatch the standard Go module offers for
+// exactly this — a command its typed helpers do not cover. Using it rather than
+// a container of this module's own keeps the toolchain version read out of
+// go.mod, where this repository's toolchain version already lives, instead of
+// pinning a golang: tag here that could drift from it.
+//
+// The bytes are a function of the source: avrocpb.MarshalFileDescriptorSet
+// encodes deterministically and the file order is fixed by the protos'
+// imports, so two runs over an unchanged tree produce an identical artifact.
+// That is what makes the published file comparable across releases at all.
+func (m *Avroc) IrDescriptorSet() *dagger.File {
+	const out = "/out/ir.binpb"
+
+	return dag.Go().
+		Container(m.Source).
+		WithExec([]string{"go", "run", "./internal/tools/ir-descriptor-set", "-o", out}).
+		File(out)
+}
+
 // stage returns the check builder the standard pipeline builds on, bound to
 // this module's source and with no stage enabled yet. Callers enable the one
 // they want. The Go toolchain version is left unset so the builder reads it from

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,12 +44,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      # Reading the source is all the pipeline does. No `packages: write`,
-      # because nothing is pushed; no `id-token: write`, because nothing is
-      # attested — the module produces no artifact to sign. Both grants belong
-      # to the change that gives it one, next to the stage that needs them,
-      # rather than being held here in advance against a job that would not
-      # notice them missing.
+      # Reading the source is all this job does. No `packages: write`, because
+      # nothing is pushed; no `id-token: write`, because nothing is attested.
+      # The module does now produce an artifact — the IR FileDescriptorSet
+      # below — but this job only builds it and throws it away; the grant that
+      # publishes it lives on the job that publishes it, in release.yaml.
       contents: read
     steps:
       # A shallow checkout on purpose. The module excludes .git from the source
@@ -82,3 +81,14 @@ jobs:
       # while CI fails.
       - name: Run the pipeline
         run: dagger call ci
+
+      # The one artifact this repository builds, built on every pull request
+      # rather than only at release time. Its contents are asserted by the tests
+      # `dagger call ci` just ran — that the set covers proto/, resolves on its
+      # own and decodes a descriptor leaving nothing undescribed — and what this
+      # step adds is that the artifact still *builds*, so a release is never the
+      # first time anybody finds out that it does not. It is exported to the
+      # runner's temporary directory and discarded; release.yaml is what
+      # publishes it.
+      - name: Build the IR FileDescriptorSet
+        run: dagger call ir-descriptor-set export --path "$RUNNER_TEMP/ir.binpb"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+name: Release
+
+# A published release is the trigger, not a pushed tag. The distinction matters
+# for what this workflow does: it uploads an asset onto a release object, and a
+# release object only exists once somebody has published one. Firing on the tag
+# would mean racing the human who is about to create the release, and losing
+# that race means uploading to a release that is not there yet.
+#
+# `published` covers both a release created straight away and a draft released
+# later, which is the shape a release with notes to write actually takes.
+on:
+  release:
+    types: [published]
+
+# The floor for every job. The one job that has to write says so itself.
+permissions:
+  contents: read
+
+jobs:
+  # The IR's FileDescriptorSet, attached to the release as ir.binpb.
+  #
+  # It is here so that a plugin author whose language has no protobuf code
+  # generation in the build can fetch one file and decode a descriptor
+  # dynamically — docs/ir/SPEC.md's "Reading a descriptor without generated
+  # code". The same bytes ship inside the published image at
+  # /usr/local/share/avroc/ir.binpb (docs/container/SPEC.md); a release asset is
+  # the form for somebody who is not using the image at all, and neither is a
+  # substitute for the other.
+  ir-descriptor-set:
+    name: IR FileDescriptorSet
+    runs-on: ubuntu-latest
+    permissions:
+      # Reading the source, and writing the one asset onto the release. Nothing
+      # else on this workflow needs either, which is why the grant is on the job
+      # rather than at the top of the file.
+      contents: write
+    steps:
+      # At the release's tag, not at whatever main has moved to since. The
+      # artifact is a function of the source, so an asset built from a different
+      # commit would describe an IR that release never shipped.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Pinned to the engineVersion the module declares, read out of dagger.json
+      # rather than repeated here — the same step, for the same reason, as
+      # build.yaml's.
+      - name: Install the Dagger CLI
+        run: |
+          curl -fsSL https://dl.dagger.io/dagger/install.sh \
+            | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
+              BIN_DIR="$HOME/.local/bin" sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The same function CI builds on every pull request and a contributor runs
+      # locally, so the released asset is produced by the recipe that has already
+      # been exercised rather than by one that only ever runs at release time.
+      - name: Build the IR FileDescriptorSet
+        run: dagger call ir-descriptor-set export --path "$RUNNER_TEMP/ir.binpb"
+
+      # --clobber so that re-running a failed release job replaces the asset
+      # instead of failing on a name that is already taken. The bytes are a
+      # function of the tag's source, so a re-upload cannot change what the
+      # asset says.
+      - name: Attach it to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "$RUNNER_TEMP/ir.binpb" --clobber

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,24 @@ regardless of the descriptor's IR version and without validating the closed sets
 looking is not consuming, and the descriptor worth reading is usually the one a
 generator refused.
 
+### The published `FileDescriptorSet`
+
+`avrocpb.FileDescriptorSet` is the IR's self-description: `GenerateRequest`'s
+file plus the transitive closure of its imports, in dependency order, computed
+from the descriptors compiled into `avrocpb` rather than from a committed
+`.binpb`. There is no second copy of the IR to keep in step, which is the whole
+point — a hand-produced set goes stale invisibly.
+
+The service files (`generator.proto`, `generate_response.proto`) are
+deliberately absent: `docs/ir/SPEC.md` says the IR defines no service, and #124
+removes both.
+
+`internal/tools/ir-descriptor-set` writes it out, `dagger call ir-descriptor-set`
+is how the pipeline builds `ir.binpb`, `.github/workflows/release.yaml` attaches
+it to each release, and `docs/container/SPEC.md` fixes the path it ships at
+inside the image. `avrocpb/descriptor_set_test.go` is the staleness gate: a new
+`.proto` that nothing in the descriptor's import graph reaches fails there.
+
 ### Plugin Discovery
 
 The CLI scans all directories in `PATH` for executables matching `avroc-gen-<name>`. Each discovered generator gets a corresponding `-<name>_out` CLI flag for specifying its output directory.

--- a/README.md
+++ b/README.md
@@ -260,3 +260,16 @@ import "github.com/z5labs/avroc/avrocpb"
 ```console
 go get github.com/z5labs/avroc
 ```
+
+### A generator in a language with no protobuf codegen
+
+A generator does not have to compile `proto/` to read a descriptor. Every release
+carries an **`ir.binpb`** asset — a protobuf `FileDescriptorSet` describing the
+descriptor — and the published image ships the same bytes at
+`/usr/local/share/avroc/ir.binpb`. Load it, look up `GenerateRequest` by name, and
+decode the descriptor as a dynamic message: four library calls in any protobuf
+runtime, and no build step.
+
+See [_A descriptor is readable by a program with no
+bindings_](docs/ir/SPEC.md#a-descriptor-is-readable-by-a-program-with-no-bindings)
+for the worked example and what the set does and does not contain.

--- a/README.md
+++ b/README.md
@@ -263,12 +263,17 @@ go get github.com/z5labs/avroc
 
 ### A generator in a language with no protobuf codegen
 
-A generator does not have to compile `proto/` to read a descriptor. Every release
-carries an **`ir.binpb`** asset — a protobuf `FileDescriptorSet` describing the
-descriptor — and the published image ships the same bytes at
-`/usr/local/share/avroc/ir.binpb`. Load it, look up `GenerateRequest` by name, and
-decode the descriptor as a dynamic message: four library calls in any protobuf
-runtime, and no build step.
+A generator does not have to compile `proto/` to read a descriptor. avroc publishes
+**`ir.binpb`** — a protobuf `FileDescriptorSet` describing the descriptor — as an
+asset on each release. Load it, look up `GenerateRequest` by name, and decode the
+descriptor as a dynamic message: four library calls in any protobuf runtime, and no
+build step.
+
+The same bytes are also destined for avroc's container image, at the path
+[`docs/container/SPEC.md`](docs/container/SPEC.md#the-ir-filedescriptorset) fixes.
+That image is not published yet — it is
+[#126](https://github.com/z5labs/avroc/issues/126) — so today the release asset is
+the way to get the file.
 
 See [_A descriptor is readable by a program with no
 bindings_](docs/ir/SPEC.md#a-descriptor-is-readable-by-a-program-with-no-bindings)

--- a/avrocpb/descriptor_set.go
+++ b/avrocpb/descriptor_set.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocpb
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// FileDescriptorSet returns the IR's self-description: the protobuf
+// FileDescriptorSet that describes a descriptor, and so the thing that lets a
+// consumer decode one without any generated code at all.
+//
+// It exists for the plugin author whose language has weak protobuf tooling, or
+// none in the build. protobuf's one real disadvantage against a self-describing
+// format is that a reader normally needs the schema compiled in ahead of time;
+// a FileDescriptorSet closes that, because every runtime worth the name can
+// build a message type out of one at run time and decode against it.
+// docs/ir/SPEC.md's "protobuf is a schema language, not a service" is where that
+// trade is argued; this function is the half of it that ships.
+//
+// # Why it is computed rather than committed
+//
+// The set is derived, on every call, from the descriptors compiled into this
+// package by protoc-gen-go — the same descriptors avroc itself encodes a
+// descriptor with. There is no .binpb checked into the repository and no protoc
+// invocation anyone has to remember, so there is no second copy of the IR that
+// could describe a version of it that no longer exists. Adding a field to
+// proto/ and regenerating avrocpb/ changes what this returns in the same commit,
+// because it is the same input read twice rather than two artifacts kept in
+// step by hand.
+//
+// # What is in it, and what is deliberately not
+//
+// GenerateRequest is the only root. It is the descriptor — docs/ir/SPEC.md
+// specifies exactly one message a plugin is handed — so the set is its file
+// plus the transitive closure of that file's imports, and nothing else.
+//
+// generator.proto and generate_response.proto are therefore absent, and their
+// absence is a decision rather than an oversight. Both belong to the gRPC
+// Generator service, which docs/ir/SPEC.md says the IR MUST NOT define and which
+// is being removed outright; publishing them here would hand a plugin author a
+// self-description of a service the specification tells them does not exist, and
+// would then break them when it goes. A generator needs to decode a descriptor,
+// not to speak a protocol.
+//
+// # Order
+//
+// Files are emitted in dependency order: a file appears only after every file it
+// imports. That is what `protoc --include_imports` produces and what a consumer
+// that walks the set linearly — building each file's types as it goes, which is
+// the shape of most dynamic protobuf APIs — needs in order to resolve a type
+// reference the first time it meets one. Within that, the order is fixed by the
+// import declarations themselves, so the output is a function of the protos and
+// not of a map iteration.
+func FileDescriptorSet() *descriptorpb.FileDescriptorSet {
+	set := &descriptorpb.FileDescriptorSet{}
+	appendFileWithImports(set, make(map[string]struct{}), descriptorFileDescriptor())
+	return set
+}
+
+// MarshalFileDescriptorSet encodes FileDescriptorSet into the protobuf binary
+// wire encoding, which is the form every dynamic protobuf runtime reads a
+// FileDescriptorSet in and the form the published ir.binpb artifact holds.
+//
+// The bytes are deterministic, for the same reason MarshalDescriptor's are
+// (internal/ir): the artifact is published against a release and copied into an
+// image, and a set whose bytes moved between two builds of the same source would
+// make every rebuild look like a change to the contract. Field order is
+// protobuf's own, the file order is fixed by FileDescriptorSet above, and the
+// deterministic option pins the one construct — a map field — whose encoding
+// would otherwise follow Go's randomised map iteration.
+func MarshalFileDescriptorSet() ([]byte, error) {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(FileDescriptorSet())
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the IR FileDescriptorSet: %w", err)
+	}
+	return b, nil
+}
+
+// descriptorFileDescriptor returns the file GenerateRequest is defined in.
+//
+// It is read off the message rather than named as a string so that the root of
+// the set is the descriptor type itself. A path like "generate_request.proto"
+// written here would be a second place the IR's shape is recorded, and would go
+// on compiling after the file it names had been renamed or its message moved.
+func descriptorFileDescriptor() protoreflect.FileDescriptor {
+	return new(GenerateRequest).ProtoReflect().Descriptor().ParentFile()
+}
+
+// appendFileWithImports appends fd's imports, transitively and depth first,
+// before appending fd itself — which is what puts the result in the dependency
+// order FileDescriptorSet documents.
+//
+// seen is keyed by path and marked on entry, so a file reached through two
+// different import chains is emitted once, at its first (deepest) position.
+// Marking on entry rather than on append also means a cyclic import graph
+// terminates instead of recursing forever; protobuf forbids one, and relying on
+// that to stay true is a worse bargain than one map write.
+func appendFileWithImports(set *descriptorpb.FileDescriptorSet, seen map[string]struct{}, fd protoreflect.FileDescriptor) {
+	if _, ok := seen[fd.Path()]; ok {
+		return
+	}
+	seen[fd.Path()] = struct{}{}
+
+	imports := fd.Imports()
+	for i := range imports.Len() {
+		appendFileWithImports(set, seen, imports.Get(i).FileDescriptor)
+	}
+
+	set.File = append(set.File, protodesc.ToFileDescriptorProto(fd))
+}

--- a/avrocpb/descriptor_set_test.go
+++ b/avrocpb/descriptor_set_test.go
@@ -1,0 +1,420 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocpb_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// serviceOnlyProtos are the files in proto/ that the published set leaves out,
+// with the reason each one is out. They are the gRPC Generator service and the
+// message that exists only as its streamed response; docs/ir/SPEC.md says the IR
+// MUST NOT define a service, and #124 removes both files outright.
+//
+// The list is here rather than in the implementation on purpose. The
+// implementation names one root and follows imports, so it has no exclusion list
+// to get wrong; this is the test's own statement of which files that root is
+// expected to miss, and it is what turns "a new .proto nobody wired into the
+// descriptor" into a failure rather than a silently unpublished file.
+func serviceOnlyProtos() []string {
+	return []string{"generate_response.proto", "generator.proto"}
+}
+
+// TestFileDescriptorSetCoversEveryProtoTheDescriptorReaches is the staleness
+// gate. The set is computed from the descriptors compiled into avrocpb, so it
+// cannot drift from them; what it can do is quietly stop covering proto/, which
+// is what happens when a new IR message lands in a file nothing in the
+// descriptor's import graph reaches. A consumer decoding dynamically would then
+// meet a field whose type the published set does not describe.
+//
+// So the assertion is against the directory rather than against another copy of
+// the same descriptors: every .proto on disk is either in the set or in
+// serviceOnlyProtos, and nothing is in the set that is not on disk.
+func TestFileDescriptorSetCoversEveryProtoTheDescriptorReaches(t *testing.T) {
+	onDisk, err := filepath.Glob(filepath.Join(moduleRoot(t), "proto", "*.proto"))
+	if err != nil {
+		t.Fatalf("glob proto/: %v", err)
+	}
+	if len(onDisk) == 0 {
+		t.Fatal("no .proto files found: the check would pass vacuously")
+	}
+
+	var want []string
+	for _, path := range onDisk {
+		name := filepath.Base(path)
+		if slices.Contains(serviceOnlyProtos(), name) {
+			continue
+		}
+		want = append(want, name)
+	}
+	slices.Sort(want)
+
+	var got []string
+	for _, file := range avrocpb.FileDescriptorSet().GetFile() {
+		got = append(got, file.GetName())
+	}
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("published FileDescriptorSet does not cover proto/:\n got: %v\nwant: %v\n\nA new .proto reachable from GenerateRequest is published automatically; one that is not reachable is either a mistake or belongs beside the service files in serviceOnlyProtos.", got, want)
+	}
+}
+
+// TestFileDescriptorSetIsInDependencyOrder asserts the ordering the doc comment
+// promises: no file appears before a file it imports. A consumer that walks the
+// set once, building each file's types as it goes — which is what most dynamic
+// protobuf APIs make easy — fails outright on the other order, and it fails at
+// the type reference rather than at the file, so the diagnostic points nowhere
+// useful.
+func TestFileDescriptorSetIsInDependencyOrder(t *testing.T) {
+	var placed []string
+	for _, file := range avrocpb.FileDescriptorSet().GetFile() {
+		for _, dep := range file.GetDependency() {
+			if !slices.Contains(placed, dep) {
+				t.Errorf("%s is emitted before its import %s", file.GetName(), dep)
+			}
+		}
+		placed = append(placed, file.GetName())
+	}
+}
+
+// TestMarshalFileDescriptorSetIsDeterministic asserts what the artifact's
+// consumers depend on: two encodings of the same source produce the same bytes.
+// The set is published against a release and copied into an image, so bytes that
+// moved between two builds would make a rebuild indistinguishable from a change
+// to the contract.
+func TestMarshalFileDescriptorSetIsDeterministic(t *testing.T) {
+	first, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("encoded an empty FileDescriptorSet")
+	}
+
+	second, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal again: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("two encodings of the same set differ: %d bytes then %d bytes", len(first), len(second))
+	}
+}
+
+// TestDynamicDecodeLeavesNothingUndescribed is the end-to-end half of the
+// staleness gate. It decodes a descriptor through the published set alone and
+// then asserts two things the coverage test cannot: that nothing in the
+// descriptor landed in the dynamic message's unknown fields — every byte avroc
+// wrote is described by what is published — and that re-encoding the dynamic
+// message reproduces the descriptor exactly, which is the property a consumer
+// relies on when it reads a descriptor, edits nothing, and hands it on.
+func TestDynamicDecodeLeavesNothingUndescribed(t *testing.T) {
+	descriptor, err := proto.Marshal(exampleDescriptor())
+	if err != nil {
+		t.Fatalf("encode descriptor: %v", err)
+	}
+
+	msg := newDynamicDescriptor(t)
+	if err := proto.Unmarshal(descriptor, msg); err != nil {
+		t.Fatalf("decode descriptor dynamically: %v", err)
+	}
+
+	assertNoUnknownFields(t, msg.ProtoReflect())
+
+	roundTripped, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
+	if err != nil {
+		t.Fatalf("re-encode descriptor: %v", err)
+	}
+	if !bytes.Equal(descriptor, roundTripped) {
+		t.Fatalf("dynamic round trip changed the descriptor: %d bytes in, %d bytes out", len(descriptor), len(roundTripped))
+	}
+}
+
+// newDynamicDescriptor builds a message type for GenerateRequest out of the
+// published bytes and nothing else — the exact path a plugin author with no
+// generated code takes.
+func newDynamicDescriptor(t *testing.T) *dynamicpb.Message {
+	t.Helper()
+
+	irBinpb, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal the published set: %v", err)
+	}
+
+	var set descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(irBinpb, &set); err != nil {
+		t.Fatalf("decode the published set: %v", err)
+	}
+
+	files, err := protodesc.NewFiles(&set)
+	if err != nil {
+		t.Fatalf("build a type registry from the published set: %v", err)
+	}
+
+	desc, err := files.FindDescriptorByName("GenerateRequest")
+	if err != nil {
+		t.Fatalf("find GenerateRequest in the published set: %v", err)
+	}
+
+	md, ok := desc.(protoreflect.MessageDescriptor)
+	if !ok {
+		t.Fatalf("GenerateRequest resolved to %T, not a message", desc)
+	}
+	return dynamicpb.NewMessage(md)
+}
+
+// assertNoUnknownFields walks a decoded message and reports any bytes the
+// published set had no field for. Unknown fields are how a stale set fails
+// quietly: the decode succeeds, the message looks plausible, and the parts the
+// consumer never heard of are simply not there.
+func assertNoUnknownFields(t *testing.T, msg protoreflect.Message) {
+	t.Helper()
+
+	if unknown := msg.GetUnknown(); len(unknown) > 0 {
+		t.Errorf("%s carries %d bytes the published FileDescriptorSet does not describe", msg.Descriptor().FullName(), len(unknown))
+	}
+
+	msg.Range(func(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		switch {
+		case fd.IsList() && fd.Message() != nil:
+			list := value.List()
+			for i := range list.Len() {
+				assertNoUnknownFields(t, list.Get(i).Message())
+			}
+		case fd.IsMap() && fd.MapValue().Message() != nil:
+			value.Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
+				assertNoUnknownFields(t, v.Message())
+				return true
+			})
+		case !fd.IsList() && !fd.IsMap() && fd.Message() != nil:
+			assertNoUnknownFields(t, value.Message())
+		}
+		return true
+	})
+}
+
+// exampleDescriptor is a descriptor of the shape avroc emits: a version, one
+// generator option, and one resolved record whose single field references an
+// Avro primitive by name.
+func exampleDescriptor() *avrocpb.GenerateRequest {
+	return &avrocpb.GenerateRequest{
+		Version: proto.Int32(1),
+		Options: []*avrocpb.Option{
+			{Name: proto.String("package_name"), Value: proto.String("gen")},
+		},
+		Schemas: []*avrocpb.Schema{
+			{
+				Namespace: proto.String("example.avro"),
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:      proto.String("TestRecord"),
+							Namespace: proto.String("example.avro"),
+							FullName:  proto.String("example.avro.TestRecord"),
+							Fields: []*avrocpb.Field{
+								{
+									Name: proto.String("id"),
+									Type: &avrocpb.Type{
+										Type: &avrocpb.Type_Reference{
+											Reference: &avrocpb.Reference{
+												Name: proto.String("string"),
+												Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Example_readADescriptorWithoutGeneratedCode is the worked example
+// docs/ir/SPEC.md points at: a consumer reads a descriptor through the published
+// FileDescriptorSet alone, with no code generated from proto/ anywhere in it.
+//
+// Everything below the marked line uses only protobuf's own runtime — the
+// descriptor types, a registry built from the published bytes, and a dynamic
+// message — so it transliterates directly into any language whose protobuf
+// runtime can load a FileDescriptorSet, which is every one of them. In the
+// image the first two lines of the consumer half are a read of
+// /usr/local/share/avroc/ir.binpb and the path avroc passed as --descriptor;
+// they are spelled as in-process calls here so the example runs as a test.
+func Example_readADescriptorWithoutGeneratedCode() {
+	// The producer half. avroc encodes a descriptor and publishes the set that
+	// describes it; a plugin author writes neither of these two lines.
+	descriptor, err := proto.Marshal(exampleDescriptor())
+	if err != nil {
+		panic(err)
+	}
+	irBinpb, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		panic(err)
+	}
+
+	// ---- The consumer half: no generated code past this line. ----
+
+	var set descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(irBinpb, &set); err != nil {
+		panic(err)
+	}
+
+	files, err := protodesc.NewFiles(&set)
+	if err != nil {
+		panic(err)
+	}
+
+	desc, err := files.FindDescriptorByName("GenerateRequest")
+	if err != nil {
+		panic(err)
+	}
+	md := desc.(protoreflect.MessageDescriptor)
+
+	msg := dynamicpb.NewMessage(md)
+	if err := proto.Unmarshal(descriptor, msg); err != nil {
+		panic(err)
+	}
+
+	// The IR version comes first, always: docs/ir/SPEC.md makes reading it
+	// before anything else a consumer's first obligation, and it is the one
+	// field whose absence means the rest is not safe to look at.
+	fmt.Println("ir version:", msg.Get(md.Fields().ByName("version")).Int())
+
+	schemas := msg.Get(md.Fields().ByName("schemas")).List()
+	for i := range schemas.Len() {
+		schema := schemas.Get(i).Message()
+		typ := schema.Get(schema.Descriptor().Fields().ByName("type")).Message()
+
+		record := typ.Get(typ.Descriptor().Fields().ByName("record")).Message()
+		fullName := record.Get(record.Descriptor().Fields().ByName("full_name")).String()
+		fmt.Println("record:", fullName)
+
+		fields := record.Get(record.Descriptor().Fields().ByName("fields")).List()
+		for j := range fields.Len() {
+			field := fields.Get(j).Message()
+			name := field.Get(field.Descriptor().Fields().ByName("name")).String()
+
+			fieldType := field.Get(field.Descriptor().Fields().ByName("type")).Message()
+			ref := fieldType.Get(fieldType.Descriptor().Fields().ByName("reference")).Message()
+			refName := ref.Get(ref.Descriptor().Fields().ByName("name")).String()
+
+			fmt.Printf("  field %s: %s\n", name, refName)
+		}
+	}
+
+	// Output:
+	// ir version: 1
+	// record: example.avro.TestRecord
+	//   field id: string
+}
+
+// TestPublishedSetHasNoServiceDefinition guards the decision the set's doc
+// comment records. docs/ir/SPEC.md says the IR MUST NOT define an RPC service,
+// so publishing one in the IR's own self-description would contradict the
+// specification in the artifact a plugin author reads instead of the
+// specification.
+func TestPublishedSetHasNoServiceDefinition(t *testing.T) {
+	for _, file := range avrocpb.FileDescriptorSet().GetFile() {
+		if services := file.GetService(); len(services) > 0 {
+			t.Errorf("%s publishes %d service definition(s); the IR defines no service", file.GetName(), len(services))
+		}
+	}
+}
+
+// TestPublishedSetIsSelfContained asserts the set resolves on its own. A set
+// naming an import it does not carry is the classic way this artifact breaks:
+// it decodes, it looks complete, and it fails only in the consumer's registry,
+// with an error naming a file they have never heard of.
+func TestPublishedSetIsSelfContained(t *testing.T) {
+	set := avrocpb.FileDescriptorSet()
+
+	carried := make(map[string]struct{}, len(set.GetFile()))
+	for _, file := range set.GetFile() {
+		carried[file.GetName()] = struct{}{}
+	}
+	for _, file := range set.GetFile() {
+		for _, dep := range file.GetDependency() {
+			if _, ok := carried[dep]; !ok {
+				t.Errorf("%s imports %s, which the set does not carry", file.GetName(), dep)
+			}
+		}
+	}
+
+	if _, err := protodesc.NewFiles(set); err != nil {
+		t.Fatalf("the published set does not resolve on its own: %v", err)
+	}
+}
+
+// TestMarshalledSetIsWhatTheArtifactHolds checks the encoded form decodes back
+// to the same set, which is the only thing standing between an artifact written
+// to disk and one a consumer can use.
+func TestMarshalledSetIsWhatTheArtifactHolds(t *testing.T) {
+	b, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(b, &got); err != nil {
+		t.Fatalf("decode the encoded set: %v", err)
+	}
+
+	if !proto.Equal(&got, avrocpb.FileDescriptorSet()) {
+		t.Fatal("the encoded set does not decode back to the set that was encoded")
+	}
+}
+
+// fileNames is a small helper for diagnostics in tests that need to name what
+// the set carried.
+func fileNames(set *descriptorpb.FileDescriptorSet) []string {
+	names := make([]string, 0, len(set.GetFile()))
+	for _, file := range set.GetFile() {
+		names = append(names, file.GetName())
+	}
+	return names
+}
+
+// TestFileDescriptorSetIsNotEmpty is the guard that keeps every other assertion
+// in this file from passing vacuously.
+func TestFileDescriptorSetIsNotEmpty(t *testing.T) {
+	set := avrocpb.FileDescriptorSet()
+	if len(set.GetFile()) == 0 {
+		t.Fatal("the published FileDescriptorSet carries no files")
+	}
+	if !slices.Contains(fileNames(set), "generate_request.proto") {
+		t.Fatalf("the set does not carry the descriptor's own file; it carries %v", fileNames(set))
+	}
+}
+
+// TestModuleRootHasProtoDirectory keeps the coverage test honest about where it
+// is looking, so a moved proto/ shows up as this failure rather than as an empty
+// glob somewhere else.
+func TestModuleRootHasProtoDirectory(t *testing.T) {
+	info, err := os.Stat(filepath.Join(moduleRoot(t), "proto"))
+	if err != nil {
+		t.Fatalf("stat proto/: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("proto/ is not a directory")
+	}
+}

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -287,10 +287,31 @@ The image ships the IR's protobuf `FileDescriptorSet` at
 It is there for a plugin author whose language has no protobuf code generation
 available in the build: a `FileDescriptorSet` is enough to decode a descriptor
 dynamically, so the file turns "my language has no avroc bindings" into a
-runtime lookup rather than a blocker. What it contains, and which IR version it
-describes, is [`ir/SPEC.md`](../ir/SPEC.md)'s (#113); that it is at a fixed path
-inside the image is this document's, because a path is the only part of it a
-`COPY --from` can name.
+runtime lookup rather than a blocker. What it contains, which IR version it
+describes, and the four calls that read a descriptor with it are
+[`ir/SPEC.md`](../ir/SPEC.md)'s ([A descriptor is readable by a program with no
+bindings](../ir/SPEC.md#a-descriptor-is-readable-by-a-program-with-no-bindings),
+#113); that it is at a fixed path inside the image is this document's, because a
+path is the only part of it a `COPY --from` can name.
+
+The file **MUST** be readable by the [image's user](#the-user) and by any user a
+caller overrides it with, since a generator running as `--user $(id -u)` reads
+the same file. It is a regular file and not a symlink, so a `COPY --from`
+naming it copies bytes.
+
+**Size.** It is small — on the order of **two kilobytes**, because the set
+carries the IR's six `.proto` files stripped of comments and source positions,
+and nothing else. That number is descriptive, not covered: it moves whenever the
+IR grows a field, and no derived image should be sized against it. It is stated
+because "ships a protobuf descriptor set" is otherwise a phrase that could mean
+anything from this to a hundred megabytes of transitively imported schemas, and
+somebody deciding whether to `COPY --from` it into a distroless image is
+entitled to know which.
+
+It is the same file, byte for byte, as the `ir.binpb` asset attached to the
+corresponding release. The image and the release asset are two ways of getting
+one artifact, not two artifacts, and a build that has already fetched one has no
+reason to fetch the other.
 
 A derived image **MAY** copy it out into its own stage and **MUST NOT** modify
 it in place.

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -29,8 +29,9 @@ version identifying the contract it was written against, the options for the
 invocation it belongs to, and the resolved schemas themselves, with their
 fully-qualified names, their type structure, and the ordering that decides
 where a named type is defined and where it is merely referenced. Together with
-the protobuf schema language that carries all of it, and the compatibility
-policy that governs changing it.
+the protobuf schema language that carries all of it, the compatibility policy
+that governs changing it, and the `FileDescriptorSet` avroc publishes so that a
+consumer with no generated code can decode a descriptor at all.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -387,6 +388,130 @@ so not this document's: the file avroc writes for an invocation is removed when
 that generator exits, so what a person inspects is a copy — one the plugin saved
 from the path it was handed.
 
+## A descriptor is readable by a program with no bindings
+
+The rendering above is for a person. This section is the same promise made to a
+program: a generator **MUST** be able to decode a descriptor without any code
+generated from [`proto/`](../../proto/), and avroc **MUST** publish what makes
+that possible.
+
+What makes it possible is protobuf's own `FileDescriptorSet`. Every protobuf
+runtime can build a message type out of one at run time and decode against it,
+so a set describing the IR turns "my language has no avroc bindings, and my
+build has no protobuf code generation in it" from a blocker into a file to read.
+That is the whole of Avro's self-description advantage, bought back for the
+price of one artifact, and it is why
+[protobuf is a schema language, not a service](#protobuf-is-a-schema-language-not-a-service)
+does not have to apologise for the choice.
+
+### What is published
+
+avroc **MUST** publish a `FileDescriptorSet` covering the descriptor: the file
+`GenerateRequest` is defined in, and the transitive closure of that file's
+imports, and nothing else (#113). It is called `ir.binpb`, in protobuf's binary
+wire encoding, and it is published in two places, neither of which is a
+substitute for the other:
+
+| Where | For |
+| --- | --- |
+| A release asset on each release | A build that fetches one file and never touches the image |
+| Inside the published image, at the path [`container/SPEC.md`](../container/SPEC.md) fixes | A generator image built `FROM` avroc's |
+
+The path inside the image is deliberately not written here: it is a promise a
+`COPY --from` depends on, and it is [made and versioned by
+`container/SPEC.md`](#also-out-of-scope). Two documents naming it would be two
+places to change it and one of them would be missed.
+
+The set **MUST** be self-contained — every file it names as an import is a file
+it carries — and **MUST** be ordered so that no file precedes a file it imports.
+A consumer that walks it once, building each file's types as it goes, is the
+common shape of a dynamic protobuf API, and the other order fails it at a type
+reference rather than at a file, with a diagnostic that points nowhere useful.
+
+Two publications of the same source **MUST** produce identical bytes, for the
+reason [What a descriptor carries](#what-a-descriptor-carries) gives about the
+descriptor itself: an artifact attached to a release and copied into an image is
+compared across releases, and one whose bytes moved on a rebuild would make
+every rebuild look like a change to the contract.
+
+The set **MUST** be derived from the same protos avroc itself encodes a
+descriptor with, and **MUST NOT** be a separately maintained copy of them.
+A hand-produced set is one that describes whatever the IR looked like the last
+time somebody remembered to regenerate it, and its staleness is invisible: a
+consumer decoding against it succeeds, and the fields it has never heard of
+simply are not there. Deriving it means a change to `proto/` changes the
+published set in the same commit, and it is the difference between an artifact
+that is current by construction and one that is current by diligence.
+
+### What is deliberately absent
+
+The service definition. `generator.proto` and the `GenerateResponse` it streams
+are **not** in the published set (#113), and their absence follows directly from
+[the IR defining no service](#protobuf-is-a-schema-language-not-a-service):
+publishing them in the IR's own self-description would hand a plugin author a
+machine-readable description of a service this document tells them does not
+exist, and would then break them when it is removed (#124). A generator needs to
+decode a descriptor, not to speak a protocol.
+
+### Worked example
+
+The recipe is four steps and is the same in every language: read `ir.binpb`,
+decode it as a `FileDescriptorSet`, build a registry from it, look up
+`GenerateRequest`, and decode the descriptor as a dynamic message of that type.
+Fields are then read by name — the same names this document uses.
+
+```go
+// No import of github.com/z5labs/avroc/avrocpb, and nothing generated from
+// proto/: only protobuf's own runtime. irBinpbPath is the release asset, or
+// the path container/SPEC.md fixes inside the image.
+irBinpb, err := os.ReadFile(irBinpbPath)
+if err != nil {
+	return err
+}
+
+var set descriptorpb.FileDescriptorSet
+if err := proto.Unmarshal(irBinpb, &set); err != nil {
+	return err
+}
+
+files, err := protodesc.NewFiles(&set)
+if err != nil {
+	return err
+}
+
+desc, err := files.FindDescriptorByName("GenerateRequest")
+if err != nil {
+	return err
+}
+md := desc.(protoreflect.MessageDescriptor)
+
+descriptor, err := os.ReadFile(descriptorPath) // the path avroc handed the plugin
+if err != nil {
+	return err
+}
+
+msg := dynamicpb.NewMessage(md)
+if err := proto.Unmarshal(descriptor, msg); err != nil {
+	return err
+}
+
+// The version first, as ever.
+version := msg.Get(md.Fields().ByName("version")).Int()
+```
+
+It is written in Go because this repository can execute it — the example is a
+runnable test in `avrocpb`, so it is checked rather than asserted — and not
+because Go is the audience. Go is the one language that does not need it.
+A reader in Python, C#, Java or Rust is translating four library calls whose
+names differ and whose meanings do not: `FileDescriptorSet`, a descriptor pool
+to add it to, a message type looked up by name, and a dynamic parse.
+
+Reading the version first is not a stylistic note. [The version
+field](#the-version-field) makes it a consumer's first obligation, and it binds
+a dynamic consumer exactly as it binds a generated one — a set published today
+describes today's contract, and a descriptor claiming a version this consumer
+does not know is not made safe to read by having been decoded successfully.
+
 ## Out of Scope
 
 ### Avro IDL and JSON schema syntax
@@ -463,3 +588,4 @@ is making their input identical rather than shipping one of the outputs:
 | [What *resolved* means](#what-resolved-means) | [#108](https://github.com/z5labs/avroc/issues/108) |
 | [The nested tree is kept](#the-nested-tree-is-kept) | [#108](https://github.com/z5labs/avroc/issues/108), [#112](https://github.com/z5labs/avroc/issues/112) |
 | [A descriptor is readable by a person](#a-descriptor-is-readable-by-a-person) | [#112](https://github.com/z5labs/avroc/issues/112) |
+| [A descriptor is readable by a program with no bindings](#a-descriptor-is-readable-by-a-program-with-no-bindings) | [#113](https://github.com/z5labs/avroc/issues/113) |

--- a/internal/tools/ir-descriptor-set/main.go
+++ b/internal/tools/ir-descriptor-set/main.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command ir-descriptor-set writes the IR's protobuf FileDescriptorSet — the
+// published ir.binpb — to a file.
+//
+// It is the pipeline's hands and nothing more. Everything about what the set
+// contains, what order it is in and why its bytes are stable is
+// avrocpb.FileDescriptorSet's; this program exists so that a Dagger function has
+// something to run, and so that the artifact is produced by compiling this
+// repository rather than by somebody remembering to run protoc and commit the
+// output. There is no committed .binpb for that reason: the set is a function of
+// proto/, and the only way to keep a second copy of it honest is not to have
+// one.
+//
+// It lives under internal/ deliberately. It is not part of avroc's published
+// surface, nothing outside this repository has a reason to run it, and putting
+// it in cmd/ would make a build tool look like a fifth shipped binary.
+//
+//	go run ./internal/tools/ir-descriptor-set -o ir.binpb
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/z5labs/avroc/avrocpb"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "ir-descriptor-set: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is separated from main so that the exit path is the only thing main owns.
+func run(args []string) error {
+	flags := flag.NewFlagSet("ir-descriptor-set", flag.ContinueOnError)
+	out := flags.String("o", "", "path to write the FileDescriptorSet to (required)")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *out == "" {
+		return fmt.Errorf("-o is required: name the file to write")
+	}
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v", rest)
+	}
+
+	b, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		return err
+	}
+
+	// The parent directory is created rather than required, because the caller
+	// is a pipeline naming an output path in a fresh container filesystem —
+	// /out/ir.binpb has no /out until something makes one, and failing there
+	// would be this program reporting on the shape of its caller's environment
+	// instead of doing its job.
+	if dir := filepath.Dir(*out); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", *out, err)
+	}
+	return nil
+}

--- a/internal/tools/ir-descriptor-set/main_test.go
+++ b/internal/tools/ir-descriptor-set/main_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+)
+
+// TestWritesThePublishedBytes asserts the file this tool produces is exactly
+// what avrocpb publishes. The artifact ends up attached to a release and copied
+// into an image, so a tool that re-encoded, reordered or truncated on the way
+// out would put a second definition of the IR into circulation under the same
+// name.
+func TestWritesThePublishedBytes(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "ir.binpb")
+
+	if err := run([]string{"-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+
+	want, err := avrocpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("wrote %d bytes, expected the %d published bytes", len(got), len(want))
+	}
+}
+
+// TestCreatesTheParentDirectory covers the pipeline's case: an output path in a
+// container filesystem where nothing has made the directory yet.
+func TestCreatesTheParentDirectory(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nested", "deeper", "ir.binpb")
+
+	if err := run([]string{"-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("stat %s: %v", out, err)
+	}
+}
+
+// TestRejectsAMissingOutputPath keeps the tool from having a default that
+// writes somewhere nobody asked for.
+func TestRejectsAMissingOutputPath(t *testing.T) {
+	if err := run(nil); err == nil {
+		t.Fatal("expected an error when -o is absent")
+	}
+}
+
+// TestRejectsPositionalArguments makes a mistyped invocation fail loudly rather
+// than silently ignoring the argument that was meant to be the output path.
+func TestRejectsPositionalArguments(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "ir.binpb")
+
+	if err := run([]string{"-o", out, "extra"}); err == nil {
+		t.Fatal("expected an error for an unexpected positional argument")
+	}
+}


### PR DESCRIPTION
Closes #113

A plugin author whose language has weak protobuf tooling can now read a descriptor
dynamically, with no build step at all. This publishes the IR's `FileDescriptorSet` —
protobuf's one real gap against a self-describing format — as `ir.binpb`.

## Acceptance criteria

- [x] **A `FileDescriptorSet` covering the IR protos is built by the pipeline rather than by
  hand.** `avrocpb.FileDescriptorSet` computes it from the descriptors protoc-gen-go compiled
  into `avrocpb` — the same descriptors avroc itself encodes a descriptor with — and
  `dagger call ir-descriptor-set` is the pipeline function that emits it. Nothing is committed
  and nobody runs protoc by hand.
- [x] **It is published as a release asset.** `.github/workflows/release.yaml` fires on
  `release: published`, checks out the release's tag, builds the artifact with the same Dagger
  function CI already exercises, and uploads `ir.binpb`.
- [x] **It ships in the base image at a documented path, sized in `docs/container/SPEC.md`.**
  The path (`/usr/local/share/avroc/ir.binpb`) was already normative there; this adds what was
  missing — its size (~2 KiB, explicitly descriptive rather than covered), that it must be
  readable by the image's user *and* by an overridden one, that it is a regular file rather
  than a symlink, and that it is byte-identical to the release asset. See the note below on
  the `COPY` itself.
- [x] **A worked example reads a descriptor dynamically using it, without generated code.**
  `Example_readADescriptorWithoutGeneratedCode` in `avrocpb/descriptor_set_test.go` — a
  runnable test, so the example is checked rather than asserted — plus the prose worked
  example in the new `docs/ir/SPEC.md` section and a pointer from the README.
- [x] **It is regenerated automatically when the protos change; a stale set fails the
  pipeline.** It is derived, so a change to `proto/` changes the set in the same commit. The
  staleness gates are in `avrocpb/descriptor_set_test.go`:
  `TestFileDescriptorSetCoversEveryProtoTheDescriptorReaches` fails when a `.proto` on disk is
  neither in the set nor a named service file; `TestDynamicDecodeLeavesNothingUndescribed`
  decodes a descriptor through the published set alone and fails on any byte the set does not
  describe; `TestPublishedSetIsSelfContained` fails on an import the set does not carry.
  `build.yaml` additionally builds the artifact on every pull request.

## Judgment calls that shaped the public API

**`GenerateRequest` is the only root, so `generator.proto` and `generate_response.proto` are
not published.** Both belong to the gRPC `Generator` service, which `docs/ir/SPEC.md` says the
IR MUST NOT define and which #124 removes outright. Publishing them in the IR's own
self-description would hand a plugin author a machine-readable description of a service the
specification tells them does not exist, and would then break them when it goes. The exclusion
list lives in the test, not the implementation — the implementation names one root and follows
imports, so it has nothing to get wrong.

**Files are emitted in dependency order**, matching `protoc --include_imports`. A consumer that
walks the set once, building each file's types as it goes, is the common shape of a dynamic
protobuf API, and the other order fails it at a type reference rather than at a file.

**The bytes are deterministic**, for the same reason `ir.MarshalDescriptor`'s are: the artifact
is attached to a release and copied into an image, and bytes that moved on a rebuild would make
every rebuild look like a change to the contract.

**The emitting tool lives under `internal/`.** Nothing outside this repository has a reason to
run it, and putting it in `cmd/` would make a build tool look like a fifth shipped binary.

**`docs/ir/SPEC.md` does not repeat the in-image path.** That path is a promise a `COPY --from`
depends on and is versioned by `docs/container/SPEC.md`; two documents naming it would be two
places to change it, and one would be missed.

## One thing this PR does not do

The base image does not exist yet — #126 is the story that publishes it — so nothing here can
perform the `COPY` into `/usr/local/share/avroc/ir.binpb`. `docs/container/SPEC.md`'s story
mapping already assigns that section to #113 **and** #126 jointly, and this PR delivers #113's
half: the artifact, its contract, and a pipeline function for #126's image build to consume as
`dag.Avroc().IrDescriptorSet()`.

## Verified

- `go build ./...`
- `go test -race -cover ./...`
- `golangci-lint run` — 0 issues
- The example round trip (four binaries, `avroc generate` in `example/`, `git diff --exit-code`)
- `dagger call ci` — the full pipeline, locally
- `dagger call ir-descriptor-set export --path …` — produces 2062 bytes, byte-identical to a
  local `go run` of the tool, which is the determinism claim exercised across two toolchains

🤖 Generated with [Claude Code](https://claude.com/claude-code)