### PR TITLE
story(plugin): invoke generators as executables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-avroc is a modular code generator for messages and services defined in Avro IDL. It follows a plugin architecture inspired by protoc: generators are external executables discovered on `PATH` with the naming convention `avroc-gen-<name>`, and they communicate with avroc via a gRPC `Generator` service (defined in `proto/`).
+avroc is a modular code generator for messages and services defined in Avro IDL. Generators are external executables discovered on `PATH` with the naming convention `avroc-gen-<name>`. avroc runs one with a descriptor and an output directory on its command line and waits for it to exit; there is no server, no socket and no port. `docs/plugin/SPEC.md` is normative.
 
 ## Build & Test Commands
 
@@ -27,18 +27,23 @@ go test -v ./...
 - **`cmd/avroc/`** — CLI entry point. Sets up signal handling, logger, and delegates to `avroc.Main`.
 - **`cmd/avroc-gen-go/`** — Entry point for the Go code generator plugin.
 - **`internal/avroc/`** — Core CLI logic. Discovers generator plugins on `PATH`, registers `-<name>_out` flags for each, parses Avro IDL files, and orchestrates code generation.
-- **`internal/avroc-gen-go/`** — Go generator plugin. Implements the `Generator` gRPC service, listens on a Unix socket, and handles `GenerateRequest`s.
+- **`internal/avroc-gen-go/`** — Go generator plugin. Reads the descriptor it is handed and writes Go source beneath `--out`.
+- **`internal/plugin/`** — The generator's half of `docs/plugin/SPEC.md`: parsing the argument vector, reading the descriptor it names, and writing files beneath `--out`. Every generator here routes its `Main` through it. avroc's half — discovery and building the vector — is `internal/avroc`'s, and the two are separate on purpose: a third-party generator implements the contract without importing anything from this repository.
 - **`internal/cli/`** — Shared CLI context type (`cli.Context`) providing structured logger, environment, filesystem, and args.
 - **`internal/ir/`** — Operations every generator performs on the resolved IR: the repository's single Avro Parsing Canonical Form implementation (shared by `avroc-gen-pcf` and `avroc-gen-go`'s fingerprint), plus name and filename helpers. No symbol table, no namespace qualification, no primitive list.
 - **`avrocpb/`** — Generated Go code from the protobuf definitions, and the only package here a third-party generator imports. Public rather than internal because the IR is a contract; do not edit the generated files directly.
 - **`proto/`** — Protobuf definitions (edition 2023) for the `Generator` gRPC service.
 
-### Plugin Communication
+### Plugin Invocation
 
-1. avroc creates a temporary Unix socket and starts the generator subprocess (`avroc-gen-<name>`), passing the socket path as its first argument.
-2. The generator listens on the Unix socket and registers its `Generator` gRPC service.
-3. avroc connects as a gRPC client, sends a `GenerateRequest` (schemas + output directory), and receives a `GenerateResponse` (output file paths).
-4. Generators run concurrently via `sourcegraph/conc` pools.
+1. avroc writes the descriptor into a directory created for that one invocation.
+2. avroc forks and execs `avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]`, both paths absolute, and waits for it to exit. Nothing else is on the vector, and in particular nothing comes from the environment — `AVROC_GENERATOR_ARGS` is gone.
+3. The generator writes its own files beneath `--out` and reports on stderr. A zero exit is the whole of the success signal.
+4. Generators run concurrently via `sourcegraph/conc` pools. Cancellation flows from the signal-based parent context through `exec.CommandContext`, and every child is waited on — on success, on failure and on cancellation.
+
+Discovery is a `PATH` search in order, and **the earliest match wins**, exactly as it does for a shell: prepending a directory is how an author shadows an installed generator with one under development. An empty `PATH` element is not the working directory.
+
+What is not yet there, so that it is not mistaken for a gap: `--out` is the project's own output directory rather than a private empty scratch directory, and avroc does not yet enforce the boundary or merge — that is #117, with collisions #118 and stale files #119. The generators here still emit chunks internally through the `Generator` service's stream type, reassembled in `internal/plugin`; #121–#123 replace that with a plain write and #124 deletes the service.
 
 ### The resolved IR
 
@@ -59,10 +64,12 @@ directory created for that invocation alone, read-only, complete before the
 generator starts and removed once it has exited. `docs/plugin/SPEC.md`'s
 "Location and lifetime" is normative; nothing may derive meaning from the path.
 
-The descriptor value is built once and then both written and sent, so the file is
-the value the generator received rather than a second encoding that could drift
-from it. Passing it as `--descriptor` is #114's; until then the same value still
-travels over the gRPC service #124 removes.
+The file **is** the value the generator received: its path is what `--descriptor`
+names, so there is no second encoding of the same inputs that could drift from
+it. The generator's options travel twice — in the descriptor, which
+`docs/ir/SPEC.md` puts them in, and as `--opt` pairs, which `docs/plugin/SPEC.md`
+configures a generator through. avroc emits the same pairs in the same order in
+both places, and `internal/plugin` believes the command line.
 
 **The bytes are deterministic**: two runs over unchanged inputs produce
 byte-identical descriptors, because generated output is a thing a project commits
@@ -100,14 +107,11 @@ it to each release, and `docs/container/SPEC.md` fixes the path it ships at
 inside the image. `avrocpb/descriptor_set_test.go` is the staleness gate: a new
 `.proto` that nothing in the descriptor's import graph reaches fails there.
 
-### Plugin Discovery
-
-The CLI scans all directories in `PATH` for executables matching `avroc-gen-<name>`. Each discovered generator gets a corresponding `-<name>_out` CLI flag for specifying its output directory.
-
 ### Key Dependencies
 
 - `github.com/z5labs/avro-go` — Avro IDL parser
-- `google.golang.org/grpc` + `google.golang.org/protobuf` — gRPC plugin communication
+- `google.golang.org/protobuf` — the IR's schema language, and the descriptor's wire encoding
+- `google.golang.org/grpc` — no longer a transport. Nothing dials or serves; what is left is the generated `Generator` service types the generators here still emit through, which #124 deletes
 - `github.com/sourcegraph/conc` — Structured concurrency for parallel generator execution
 
 ## Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,10 +144,9 @@ part of `dagger call ci`. It runs in the repository's local verify list instead.
 
 It comes back to CI the same way everything else does: as another function on the
 root module invoked by another `dagger call`, never as raw Go steps beside it in
-[`.github/workflows/build.yaml`](.github/workflows/build.yaml). Writing it now
-would mean writing it against today's gRPC-socket generator invocation, which the
-plugin-contract work is replacing; it belongs in the change that settles how
-generators are invoked at all.
+[`.github/workflows/build.yaml`](.github/workflows/build.yaml). It belongs with
+the stage that generates twice and byte-compares, because that stage needs the
+same four binaries and the same worked example — one function, not two that drift.
 
 Until then, run it by hand before pushing a change to generation:
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,17 @@ three use, and what else they have in common.
 │  2. Resolve each generator to avroc-gen-<name>       │
 │  3. Parse & validate the declared Avro IDL inputs    │
 │  4. For each generator (concurrently):               │
-│     a. Create a temporary Unix socket                │
-│     b. Launch avroc-gen-<name> subprocess            │
-│     c. Connect via gRPC (Generator service)          │
-│     d. Send GenerateRequest  ──────────────────────► │  avroc-gen-<name>
-│     e. Receive streamed GenerateResponse ◄─────────  │  (gRPC server on
-│     f. avroc writes the streamed files               │   Unix socket)
+│     a. Write the descriptor into a directory         │
+│        created for that invocation alone             │
+│     b. exec avroc-gen-<name>  ─────────────────────► │  avroc-gen-<name>
+│          --descriptor <path>                         │  reads the descriptor,
+│          --out <dir>                                 │  writes files beneath
+│          [--opt k=v ...]                             │  --out, exits
+│     c. Wait for it to exit; non-zero fails the run   │
 └─────────────────────────────────────────────────────┘
 ```
 
-Generators communicate with `avroc` over a gRPC `Generator` service defined in [`proto/`](proto/). This means you can write a generator in **any language** that supports gRPC — just name the executable `avroc-gen-<name>` and put it on your `PATH`.
+A generator is an **executable, not a server**: avroc finds it on `PATH`, runs it with a descriptor and an output directory, and waits. There is no socket, no port and no protobuf runtime required to be reachable — so a generator can be written in any language, including a shell script. [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md) is the contract.
 
 ## Installation
 
@@ -245,9 +246,11 @@ No options required.
 ## Writing a Custom Generator
 
 1. Create an executable named `avroc-gen-<name>` and put it on your `PATH`.
-2. On startup, read the Unix socket path from `os.Args[1]`.
-3. Start a gRPC server on that socket and register your implementation of the `Generator` service (see [`proto/generator.proto`](proto/generator.proto)).
-4. Handle a `GenerateRequest` (options + schemas) by **streaming** the generated files back: each `GenerateResponse` carries a relative `path`, a chunk of `content`, and a `last` flag. avroc reassembles the chunks and writes the files, so the generator never touches the filesystem.
+2. Accept `--descriptor <path> --out <dir> [--opt k=v ...]`, each option followed by its value as the next argument. `--descriptor -` means the descriptor arrives on standard input.
+3. Decode the descriptor at that path: it is a `GenerateRequest` in the protobuf binary wire encoding (see [`proto/`](proto/) and [`docs/ir/SPEC.md`](docs/ir/SPEC.md)). Check its `version` first.
+4. Write every generated file beneath `--out`, report problems on stderr, and exit zero. A non-zero exit fails the run.
+
+The full contract — discovery, the argument vector, the descriptor's lifetime, exit codes and the stderr diagnostic format, and the determinism a plugin must exhibit — is [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md).
 
 The schemas you are handed are **resolved**: every named type carries its fully-qualified name, every `Reference` states whether it names an Avro primitive or a named type, and a named type's definition travels at its first use with every later use carrying only its name. A generator therefore builds no symbol table and re-derives no namespace qualification, primitive classification or first-use ordering — see [`docs/ir/SPEC.md`](docs/ir/SPEC.md).
 

--- a/internal/avroc-gen-go/avroc-gen-go.go
+++ b/internal/avroc-gen-go/avroc-gen-go.go
@@ -7,83 +7,19 @@ package avrocgengo
 
 import (
 	"context"
-	"errors"
-	"flag"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
-	"os"
 
-	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
-
-	"github.com/sourcegraph/conc/pool"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
-func Main(ctx context.Context, cli cli.Context) int {
-	flags := flag.NewFlagSet("avroc-gen-go", flag.ContinueOnError)
-	flags.Usage = func() {}
-
-	err := flags.Parse(cli.Args)
-	if errors.Is(err, flag.ErrHelp) {
-		err = printHelp(os.Stdout)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to print help", slog.Any("error", err))
-			return 1
-		}
-		return 0
-	}
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to parse flags", slog.Any("error", err))
-		return 1
-	}
-
-	args := flags.Args()
-	if len(args) != 1 {
-		cli.Log.ErrorContext(ctx, "unix socket address must be provided")
-		return 1
-	}
-
-	ls, err := net.ListenUnix("unix", &net.UnixAddr{
-		Name: args[0],
-		Net:  "unix",
-	})
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to listen on unix socket", slog.Any("error", err))
-		return 1
-	}
-
-	generatorService := &generatorService{}
-
-	srv := grpc.NewServer(
-		grpc.Creds(insecure.NewCredentials()),
-	)
-	avrocpb.RegisterGeneratorServer(srv, generatorService)
-
-	pool := pool.New().WithContext(ctx)
-
-	pool.Go(func(ctx context.Context) error {
-		<-ctx.Done()
-		srv.GracefulStop()
-		return nil
-	})
-	pool.Go(func(ctx context.Context) error {
-		return srv.Serve(ls)
-	})
-
-	err = pool.Wait()
-	if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-		cli.Log.ErrorContext(ctx, "failed to serve gRPC server", slog.Any("error", err))
-		return 1
-	}
-
-	return 0
-}
-
-func printHelp(w io.Writer) error {
-	_, err := fmt.Fprintln(w, "Usage: avroc-gen-go <unix socket address>")
-	return err
+// Main runs one generation and returns the process exit status.
+//
+// avroc-gen-go is an executable, not a server: it is handed a descriptor and an
+// output directory on its command line, writes files, and exits. The Unix
+// listener and the gRPC server it used to stand up are gone with the socket
+// rendezvous that required them (#114); what remains of the service — the
+// streaming emission generatorService still implements internally — is #121's
+// to replace and #124's to delete.
+func Main(ctx context.Context, c cli.Context) int {
+	return plugin.Main(ctx, c, "avroc-gen-go", (&generatorService{}).Generate)
 }

--- a/internal/avroc-gen-json/avroc-gen-json.go
+++ b/internal/avroc-gen-json/avroc-gen-json.go
@@ -7,83 +7,19 @@ package avrocgenjson
 
 import (
 	"context"
-	"errors"
-	"flag"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
-	"os"
 
-	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
-
-	"github.com/sourcegraph/conc/pool"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
-func Main(ctx context.Context, cli cli.Context) int {
-	flags := flag.NewFlagSet("avroc-gen-json", flag.ContinueOnError)
-	flags.Usage = func() {}
-
-	err := flags.Parse(cli.Args)
-	if errors.Is(err, flag.ErrHelp) {
-		err = printHelp(os.Stdout)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to print help", slog.Any("error", err))
-			return 1
-		}
-		return 0
-	}
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to parse flags", slog.Any("error", err))
-		return 1
-	}
-
-	args := flags.Args()
-	if len(args) != 1 {
-		cli.Log.ErrorContext(ctx, "unix socket address must be provided")
-		return 1
-	}
-
-	ls, err := net.ListenUnix("unix", &net.UnixAddr{
-		Name: args[0],
-		Net:  "unix",
-	})
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to listen on unix socket", slog.Any("error", err))
-		return 1
-	}
-
-	generatorService := &generatorService{}
-
-	srv := grpc.NewServer(
-		grpc.Creds(insecure.NewCredentials()),
-	)
-	avrocpb.RegisterGeneratorServer(srv, generatorService)
-
-	pool := pool.New().WithContext(ctx)
-
-	pool.Go(func(ctx context.Context) error {
-		<-ctx.Done()
-		srv.GracefulStop()
-		return nil
-	})
-	pool.Go(func(ctx context.Context) error {
-		return srv.Serve(ls)
-	})
-
-	err = pool.Wait()
-	if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-		cli.Log.ErrorContext(ctx, "failed to serve gRPC server", slog.Any("error", err))
-		return 1
-	}
-
-	return 0
-}
-
-func printHelp(w io.Writer) error {
-	_, err := fmt.Fprintln(w, "Usage: avroc-gen-json <unix socket address>")
-	return err
+// Main runs one generation and returns the process exit status.
+//
+// avroc-gen-json is an executable, not a server: it is handed a descriptor and
+// an output directory on its command line, writes files, and exits. The Unix
+// listener and the gRPC server it used to stand up are gone with the socket
+// rendezvous that required them (#114); what remains of the service — the
+// streaming emission generatorService still implements internally — is #122's
+// to replace and #124's to delete.
+func Main(ctx context.Context, c cli.Context) int {
+	return plugin.Main(ctx, c, "avroc-gen-json", (&generatorService{}).Generate)
 }

--- a/internal/avroc-gen-pcf/avroc-gen-pcf.go
+++ b/internal/avroc-gen-pcf/avroc-gen-pcf.go
@@ -7,83 +7,19 @@ package avrocgenpcf
 
 import (
 	"context"
-	"errors"
-	"flag"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
-	"os"
 
-	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
-
-	"github.com/sourcegraph/conc/pool"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
-func Main(ctx context.Context, cli cli.Context) int {
-	flags := flag.NewFlagSet("avroc-gen-pcf", flag.ContinueOnError)
-	flags.Usage = func() {}
-
-	err := flags.Parse(cli.Args)
-	if errors.Is(err, flag.ErrHelp) {
-		err = printHelp(os.Stdout)
-		if err != nil {
-			cli.Log.ErrorContext(ctx, "failed to print help", slog.Any("error", err))
-			return 1
-		}
-		return 0
-	}
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to parse flags", slog.Any("error", err))
-		return 1
-	}
-
-	args := flags.Args()
-	if len(args) != 1 {
-		cli.Log.ErrorContext(ctx, "unix socket address must be provided")
-		return 1
-	}
-
-	ls, err := net.ListenUnix("unix", &net.UnixAddr{
-		Name: args[0],
-		Net:  "unix",
-	})
-	if err != nil {
-		cli.Log.ErrorContext(ctx, "failed to listen on unix socket", slog.Any("error", err))
-		return 1
-	}
-
-	generatorService := &generatorService{}
-
-	srv := grpc.NewServer(
-		grpc.Creds(insecure.NewCredentials()),
-	)
-	avrocpb.RegisterGeneratorServer(srv, generatorService)
-
-	pool := pool.New().WithContext(ctx)
-
-	pool.Go(func(ctx context.Context) error {
-		<-ctx.Done()
-		srv.GracefulStop()
-		return nil
-	})
-	pool.Go(func(ctx context.Context) error {
-		return srv.Serve(ls)
-	})
-
-	err = pool.Wait()
-	if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-		cli.Log.ErrorContext(ctx, "failed to serve gRPC server", slog.Any("error", err))
-		return 1
-	}
-
-	return 0
-}
-
-func printHelp(w io.Writer) error {
-	_, err := fmt.Fprintln(w, "Usage: avroc-gen-pcf <unix socket address>")
-	return err
+// Main runs one generation and returns the process exit status.
+//
+// avroc-gen-pcf is an executable, not a server: it is handed a descriptor and
+// an output directory on its command line, writes files, and exits. The Unix
+// listener and the gRPC server it used to stand up are gone with the socket
+// rendezvous that required them (#114); what remains of the service — the
+// streaming emission generatorService still implements internally — is #123's
+// to replace and #124's to delete.
+func Main(ctx context.Context, c cli.Context) int {
+	return plugin.Main(ctx, c, "avroc-gen-pcf", (&generatorService{}).Generate)
 }

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -12,18 +12,16 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/cli"
 
 	"github.com/z5labs/avro-go/idl"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Main dispatches to an avroc subcommand. Generators are declared in an
@@ -99,10 +97,28 @@ func isGeneratorExecutable(name string, mode fs.FileMode) bool {
 	return strings.HasPrefix(name, "avroc-gen-") && mode.IsRegular() && mode&0o111 != 0
 }
 
+// lookupGenerators indexes every generator plugin reachable from dirs, which
+// are the PATH entries in the order PATH wrote them.
+//
+// The earliest match wins, exactly as it does for a shell resolving a command
+// name (docs/plugin/SPEC.md, Discovery). That rule is what makes a generator
+// under development shadow an installed one by prepending a directory, which is
+// how an author tests a change; the opposite rule makes that gesture silently do
+// nothing, and the difference is invisible in the generated output.
+//
+// An empty PATH element is a directory named "", which no host resolves to
+// anything — the working directory is searched only when PATH writes it out.
+// avroc runs generators as a side effect of a build command, and one picked up
+// from whatever directory a user happened to be standing in is an execution
+// surface nobody chose.
 func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string) fs.FS, dirs ...string) (map[string]string, error) {
 	generatorIndex := make(map[string]string)
 
 	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+
 		fsys := openDir(dir)
 		entries, err := fs.ReadDir(fsys, ".")
 		if errors.Is(err, fs.ErrNotExist) {
@@ -123,6 +139,9 @@ func lookupGenerators(ctx context.Context, log *slog.Logger, openDir func(string
 				continue
 			}
 			if !isGeneratorExecutable(name, info.Mode()) {
+				continue
+			}
+			if _, found := generatorIndex[name]; found {
 				continue
 			}
 			generatorIndex[name] = filepath.Join(dir, name)
@@ -146,11 +165,27 @@ func parseIDL(path string) (_ *idl.File, err error) {
 
 type generator struct {
 	log            *slog.Logger
-	env            cli.Environment
 	name           string
 	executablePath string
 }
 
+// generatorWaitDelay bounds how long avroc waits after a generator's process
+// has been killed before giving up on the streams it inherited.
+//
+// Cancellation kills the child, which cannot be caught or ignored, so this is
+// not what makes a cancelled run terminate. What it covers is a grandchild that
+// outlived its parent still holding avroc's stderr open: without it Wait blocks
+// on a descriptor nobody is going to close, and a cancelled run hangs on a
+// process avroc never started.
+const generatorWaitDelay = 5 * time.Second
+
+// generate runs one generator over one descriptor, as docs/plugin/SPEC.md's
+// Invocation specifies: fork and exec avroc-gen-<name> with the descriptor and
+// the output directory as absolute paths, and wait for it to exit.
+//
+// There is no socket, no client and no stream. The generator writes its own
+// files beneath output and says what went wrong on stderr; a zero exit is the
+// whole of the success signal.
 func (g generator) generate(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (err error) {
 	desc := newDescriptor(options, schemas)
 
@@ -173,169 +208,72 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 		g.log.ErrorContext(ctx, "failed to write descriptor", slog.String("generator", g.name), slog.Any("error", err))
 		return err
 	}
-	// The path is logged and not yet passed: the argument vector that hands it
-	// to the generator is #114's, and until then the same descriptor value
-	// travels over the gRPC service #124 removes. Logging it is what makes the
-	// file findable while it exists.
-	g.log.DebugContext(ctx, "wrote descriptor", slog.String("generator", g.name), slog.String("descriptor", descriptorPath))
 
-	socketFile, err := os.CreateTemp("", g.name+"-*.sock")
+	// Both paths go across as absolute ones, so that two runs of the same
+	// generator from different working directories are the same invocation.
+	descriptorPath, err = filepath.Abs(descriptorPath)
 	if err != nil {
-		g.log.ErrorContext(ctx, "failed to create temporary socket file", slog.String("generator", g.name), slog.Any("error", err))
+		g.log.ErrorContext(ctx, "failed to resolve descriptor path", slog.String("generator", g.name), slog.Any("error", err))
 		return err
 	}
-	socketPath := socketFile.Name()
-	err = errors.Join(socketFile.Close(), os.Remove(socketPath))
+	outputDir, err := filepath.Abs(output)
 	if err != nil {
-		g.log.ErrorContext(ctx, "failed to prepare socket path", slog.String("generator", g.name), slog.Any("error", err))
+		g.log.ErrorContext(ctx, "failed to resolve output directory", slog.String("generator", g.name), slog.Any("error", err))
 		return err
 	}
-	defer func() {
-		err = errors.Join(err, os.Remove(socketPath))
-	}()
 
-	cmd, err := g.startGenerator(ctx, socketPath)
-	if err != nil {
-		g.log.ErrorContext(ctx, "failed to start generator", slog.String("generator", g.name), slog.Any("error", err))
+	// A plugin may assume the output directory exists and is writable, so avroc
+	// creates it rather than making every generator do it. Making it *empty* and
+	// private, and merging what lands in it into the project tree, is #117's.
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		g.log.ErrorContext(ctx, "failed to create output directory", slog.String("generator", g.name), slog.Any("error", err))
 		return err
 	}
-	defer func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-		}
-		_ = cmd.Wait()
-	}()
 
-	// Use the passthrough resolver with a custom dialer rather than "unix://":
-	// passthrough hands the address to the dialer verbatim, so a socket path
-	// is never run through gRPC's URL-based target parsing. The whole gRPC
-	// path here goes away with the story that deletes the Generator service.
-	cc, err := grpc.NewClient(
-		"passthrough:///"+socketPath,
-		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			var d net.Dialer
-			return d.DialContext(ctx, "unix", addr)
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+	args := generatorArgs(descriptorPath, outputDir, options)
+	g.log.DebugContext(ctx, "running generator",
+		slog.String("generator", g.name),
+		slog.String("executable", g.executablePath),
+		slog.Any("args", args),
 	)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, cc.Close())
-	}()
 
-	// No overall RPC timeout: a large streamed generation can legitimately run
-	// long. Cancellation flows from the signal-based parent context instead.
-	client := avrocpb.NewGeneratorClient(cc)
-	stream, err := client.Generate(ctx, desc)
-	if err != nil {
-		g.log.ErrorContext(ctx, "failed to generate code", slog.String("generator", g.name), slog.Any("error", err))
-		return err
-	}
+	// CommandContext kills the child when the signal-based parent context is
+	// done, and Run waits on it either way — so the process is reaped on
+	// success, on failure and on cancellation, and no generator outlives the
+	// avroc that started it.
+	cmd := exec.CommandContext(ctx, g.executablePath, args...)
+	// Standard input is unused: avroc always passes the descriptor as a path,
+	// never through the "-" form the contract also allows.
+	cmd.Stdin = nil
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = generatorWaitDelay
 
-	outputFiles, err := g.writeStream(output, stream)
-	if err != nil {
-		g.log.ErrorContext(ctx, "failed to write generated output", slog.String("generator", g.name), slog.Any("error", err))
-		return err
+	if err := cmd.Run(); err != nil {
+		g.log.ErrorContext(ctx, "generator failed", slog.String("generator", g.name), slog.Any("error", err))
+		return fmt.Errorf("generator %q failed: %w", g.name, err)
 	}
 
-	g.log.InfoContext(ctx, "generated output", slog.String("generator", g.name), slog.Any("output_files", outputFiles))
+	g.log.InfoContext(ctx, "generated output", slog.String("generator", g.name), slog.String("out", outputDir))
 	return nil
 }
 
-// writeStream consumes the generator's server stream, writing each file's
-// ordered chunks directly to disk under output rather than buffering whole
-// files in memory. A path is validated to stay within output and its file is
-// created on the first chunk, so an unsafe or buggy generator cannot force
-// avroc to buffer arbitrary content before being rejected. A file is only
-// considered written once a chunk with last=true terminates it; the stream
-// ending with files still open, or any chunk arriving after a file's
-// terminating chunk, is reported as an error. It returns the OS-native paths
-// of the files written.
-func (g generator) writeStream(output string, stream avrocpb.Generator_GenerateClient) ([]string, error) {
-	open := make(map[string]*os.File)
-	finalized := make(map[string]struct{})
-	var written []string
-
-	// On any early return, discard files that never received their terminating
-	// chunk so partial/corrupt output is not left behind in the output tree.
-	defer func() {
-		for path, f := range open {
-			name := f.Name()
-			_ = f.Close()
-			_ = os.Remove(name)
-			delete(open, path)
-		}
-	}()
-
-	for {
-		msg, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			if len(open) > 0 {
-				return written, fmt.Errorf("generator %q closed the stream with %d unterminated file(s)", g.name, len(open))
-			}
-			return written, nil
-		}
-		if err != nil {
-			return written, err
-		}
-
-		path := msg.GetPath()
-		if _, done := finalized[path]; done {
-			return written, fmt.Errorf("generator %q sent a chunk for already-completed file %q", g.name, path)
-		}
-
-		f, ok := open[path]
-		if !ok {
-			dst, err := safeOutputPath(output, path)
-			if err != nil {
-				return written, fmt.Errorf("generator %q returned unsafe path %q: %w", g.name, path, err)
-			}
-			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-				return written, fmt.Errorf("failed to create output directory for %q: %w", dst, err)
-			}
-			f, err = os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
-			if err != nil {
-				return written, fmt.Errorf("failed to create file %q: %w", dst, err)
-			}
-			open[path] = f
-		}
-
-		if _, err := f.Write(msg.GetContent()); err != nil {
-			return written, fmt.Errorf("failed to write file %q: %w", f.Name(), err)
-		}
-
-		if !msg.GetLast() {
-			continue
-		}
-
-		name := f.Name()
-		delete(open, path)
-		finalized[path] = struct{}{}
-		if err := f.Close(); err != nil {
-			return written, fmt.Errorf("failed to close file %q: %w", name, err)
-		}
-		written = append(written, name)
+// generatorArgs builds the argument vector docs/plugin/SPEC.md specifies:
+//
+//	avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]
+//
+// and nothing else. In particular nothing is taken from the environment: the
+// AVROC_GENERATOR_ARGS variable that used to prepend arbitrary words here is
+// gone, because it made the vector a function of the ambient environment, which
+// is the one input a manifest does not record and a reviewer cannot see.
+//
+// The options are emitted in the order they arrive, which the manifest fixes,
+// so the vector is a function of the manifest rather than of a map iteration.
+func generatorArgs(descriptorPath, outputDir string, options []*avrocpb.Option) []string {
+	args := make([]string, 0, 4+2*len(options))
+	args = append(args, "--descriptor", descriptorPath, "--out", outputDir)
+	for _, opt := range options {
+		args = append(args, "--opt", opt.GetName()+"="+opt.GetValue())
 	}
-}
-
-func (g generator) startGenerator(ctx context.Context, socket string) (*exec.Cmd, error) {
-	args := []string{socket}
-	if extra, ok := g.env.LookupEnv("AVROC_GENERATOR_ARGS"); ok {
-		args = append(strings.Fields(extra), args...)
-	}
-
-	cmd := exec.CommandContext(ctx, g.executablePath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Start()
-	if err != nil {
-		return nil, err
-	}
-
-	return cmd, nil
+	return args
 }

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -12,9 +12,10 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -23,8 +24,6 @@ import (
 	"github.com/z5labs/avroc/internal/cli"
 	"github.com/z5labs/avroc/internal/ir"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -109,6 +108,46 @@ func TestLookupGenerators(t *testing.T) {
 		}
 		if got["avroc-gen-java"] != filepath.Join(dir2, "avroc-gen-java") {
 			t.Errorf("avroc-gen-java path = %q", got["avroc-gen-java"])
+		}
+	})
+
+	t.Run("the earliest PATH entry wins", func(t *testing.T) {
+		first := filepath.Join(string(filepath.Separator), "first")
+		second := filepath.Join(string(filepath.Separator), "second")
+		openDir := func(string) fs.FS {
+			return fstest.MapFS{"avroc-gen-go": executableFile()}
+		}
+
+		got, err := lookupGenerators(context.Background(), discardLog, openDir, first, second)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Prepending a directory is how an author shadows an installed
+		// generator with one under development, so the later entry must not
+		// quietly replace it.
+		if want := filepath.Join(first, "avroc-gen-go"); got["avroc-gen-go"] != want {
+			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], want)
+		}
+	})
+
+	t.Run("an empty PATH entry is not the working directory", func(t *testing.T) {
+		var opened []string
+		openDir := func(d string) fs.FS {
+			opened = append(opened, d)
+			return fstest.MapFS{"avroc-gen-go": executableFile()}
+		}
+
+		got, err := lookupGenerators(context.Background(), discardLog, openDir, "", dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if slices.Contains(opened, "") {
+			t.Error("an empty PATH entry was searched")
+		}
+		if want := filepath.Join(dir, "avroc-gen-go"); got["avroc-gen-go"] != want {
+			t.Errorf("avroc-gen-go path = %q, want %q", got["avroc-gen-go"], want)
 		}
 	})
 
@@ -252,165 +291,96 @@ func TestMain_Dispatch(t *testing.T) {
 	})
 }
 
-// TestHelperGenerator is a test function that doubles as a real generator subprocess.
-// When run normally by "go test", AVROC_TEST_GENERATOR is not set, so it returns immediately.
-// When re-invoked as a subprocess, it starts a real gRPC server on the Unix socket.
-func TestHelperGenerator(t *testing.T) {
-	if os.Getenv("AVROC_TEST_GENERATOR") != "1" {
-		return
-	}
+// testGeneratorName is the generator these tests drive. It is part of the
+// per-invocation descriptor directory's name, so a leftover from some other
+// test — or from another package's temporary files — is not mistaken for one of
+// these.
+const testGeneratorName = "avroc-gen-test"
 
-	socketPath := os.Args[len(os.Args)-1]
-
-	lis, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	srv := grpc.NewServer(grpc.Creds(insecure.NewCredentials()))
-	avrocpb.RegisterGeneratorServer(srv, &testGeneratorServer{path: os.Getenv("AVROC_TEST_GEN_PATH")})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		<-ctx.Done()
-		srv.GracefulStop()
-	}()
-
-	if err := srv.Serve(lis); err != nil {
-		t.Fatal(err)
-	}
-}
-
-type testGeneratorServer struct {
-	avrocpb.UnimplementedGeneratorServer
-	path string
-}
-
-// testDescriptorGlob matches the descriptor files avroc writes for the
-// stand-in generator these tests drive. It leans on the generator's name being
-// part of the per-invocation directory, so a leftover from some other test —
-// or from another package's temporary files — is not mistaken for this one's.
-const testDescriptorGlob = "avroc-gen-test-descriptor-*/" + descriptorFilename
-
-// findDescriptorMatching reports whether a descriptor file holding exactly req
-// is readable right now. A leftover from an earlier crashed run may sit beside
-// it, so the test is "at least one decodes and equals req" rather than "exactly
-// one file exists": a stale file cannot make this pass, and cannot make it fail
-// either.
+// writeShellGenerator writes body out as an executable shell script and returns
+// its path.
 //
-// Making good on the second half is why a match that cannot be read or decoded
-// is skipped rather than returned as an error. A file that vanished between the
-// glob and the read, or that some earlier run left half-written, is not evidence
-// about the descriptor this invocation wrote — but it would sit ahead of it in
-// the glob's sorted order often enough to make the failure look real. The last
-// such error is kept only to be quoted when nothing matched, so a genuinely
-// unreadable descriptor still says why rather than reporting a bare miss.
-func findDescriptorMatching(req *avrocpb.GenerateRequest) error {
-	matches, err := filepath.Glob(filepath.Join(os.TempDir(), testDescriptorGlob))
+// A shell script is the generator these tests use on purpose. docs/plugin/SPEC.md
+// makes the contract "deliberately small enough that a generator can be a shell
+// script", and a test driving one holds avroc to that: a vector that needed a
+// flag-parsing library, or a descriptor a script could not read, would fail here
+// rather than in a plugin author's terminal.
+func writeShellGenerator(t *testing.T, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), testGeneratorName)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// recordArgsScript is the body of a generator that records its whole argument
+// vector one argument per line, copies the descriptor it was handed to
+// copyPath, and writes outFile beneath --out.
+//
+// Copying the descriptor rather than checking it in the shell is what lets the
+// assertions be about the bytes: the copy is taken while the generator is
+// running, which is the only vantage point from which "written in full before
+// the generator started, and removed once it exited" is observable at all.
+func recordArgsScript(argsPath, copyPath, outFile string) string {
+	return fmt.Sprintf(`set -e
+: > '%s'
+for a in "$@"; do printf '%%s\n' "$a" >> '%s'; done
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --descriptor) descriptor=$2; shift 2 ;;
+    --out) out=$2; shift 2 ;;
+    --opt) shift 2 ;;
+    *) echo "error: unexpected argument $1" >&2; exit 1 ;;
+  esac
+done
+
+cp "$descriptor" '%s'
+mkdir -p "$(dirname "$out/%s")"
+printf 'package main\n' > "$out/%s"
+`, argsPath, argsPath, copyPath, outFile, outFile)
+}
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("failed to search for the descriptor file: %w", err)
+		t.Fatal(err)
 	}
-	if len(matches) == 0 {
-		return fmt.Errorf("no descriptor file under %q while the generator is running", os.TempDir())
-	}
-
-	var skipped error
-	for _, m := range matches {
-		b, err := os.ReadFile(m)
-		if err != nil {
-			skipped = fmt.Errorf("failed to read descriptor %q: %w", m, err)
-			continue
-		}
-		var onDisk avrocpb.GenerateRequest
-		if err := proto.Unmarshal(b, &onDisk); err != nil {
-			skipped = fmt.Errorf("descriptor %q does not decode: %w", m, err)
-			continue
-		}
-		if proto.Equal(&onDisk, req) {
-			return nil
-		}
-	}
-
-	if skipped != nil {
-		return fmt.Errorf("none of the %d descriptor file(s) on disk match what this generator received; last unusable one: %w", len(matches), skipped)
-	}
-	return fmt.Errorf("none of the %d descriptor file(s) on disk match what this generator received", len(matches))
+	return strings.Split(strings.TrimSuffix(string(b), "\n"), "\n")
 }
 
-func (s *testGeneratorServer) Generate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
-	// This stand-in generator holds avroc to the producer half of
-	// docs/ir/SPEC.md's version rule, on the real client path rather than on a
-	// request a test constructed: if avroc stops stamping every descriptor it
-	// emits, TestGeneratorGenerate fails here with the reason rather than
-	// somewhere downstream with a missing file.
-	if err := ir.CheckVersion(req.GetVersion()); err != nil {
-		return fmt.Errorf("avroc emitted a descriptor this generator will not read: %w", err)
-	}
+func testGenerator(t *testing.T, executablePath string) generator {
+	t.Helper()
 
-	// And to the other half docs/plugin/SPEC.md adds: while a generator is
-	// running, a complete descriptor carrying exactly what it received is on
-	// disk. Checked from inside the subprocess because that is the only vantage
-	// point from which "before the generator started, and not yet deleted" is
-	// observable at all.
-	if err := findDescriptorMatching(req); err != nil {
-		return err
+	return generator{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		name:           testGeneratorName,
+		executablePath: executablePath,
 	}
-
-	path := s.path
-	if path == "" {
-		path = "output.go"
-	}
-	last := true
-	return stream.Send(&avrocpb.GenerateResponse{
-		Path:    &path,
-		Content: []byte("package main\n"),
-		Last:    &last,
-	})
 }
 
+// TestGeneratorGenerate is docs/plugin/SPEC.md's Invocation on the real
+// fork/exec path: the argument vector, the absolute paths in it, the descriptor
+// those paths name, and the files the generator wrote for itself.
 func TestGeneratorGenerate(t *testing.T) {
-	t.Setenv("AVROC_TEST_GENERATOR", "1")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	g := generator{
-		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		env: cli.EnvironmentFunc(func(key string) (string, bool) {
-			if key == "AVROC_GENERATOR_ARGS" {
-				return "-test.run=TestHelperGenerator --", true
-			}
-			return "", false
-		}),
-		name:           "avroc-gen-test",
-		executablePath: os.Args[0],
-	}
+	scratch := t.TempDir()
+	argsPath := filepath.Join(scratch, "args")
+	copyPath := filepath.Join(scratch, "descriptor.copy")
 
-	schema := &avrocpb.Schema{
-		Namespace: proto.String("com.example"),
-		Type: &avrocpb.Type{
-			Type: &avrocpb.Type_Record{
-				Record: &avrocpb.Record{
-					Name: proto.String("User"),
-					Fields: []*avrocpb.Field{
-						{
-							Name: proto.String("name"),
-							Type: &avrocpb.Type{
-								Type: &avrocpb.Type_Reference{
-									Reference: &avrocpb.Reference{
-										Name: proto.String("string"),
-										Kind: avrocpb.TypeRefKind_TYPE_REF_KIND_PRIMITIVE.Enum(),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+	g := testGenerator(t, writeShellGenerator(t, recordArgsScript(argsPath, copyPath, "pkg/output.go")))
+
+	options := []*avrocpb.Option{
+		{Name: proto.String("encoding"), Value: proto.String("single_object")},
+		{Name: proto.String("package_name"), Value: proto.String("avro")},
 	}
+	schema := testSchema("User")
 
 	// The descriptor's lifetime ends when the generator exits, so the set of
 	// descriptor directories on disk must not grow across an invocation. Taken
@@ -418,17 +388,58 @@ func TestGeneratorGenerate(t *testing.T) {
 	// earlier run may have left one and that is not this test's failure.
 	before := descriptorDirs(t)
 
-	outputDir := t.TempDir()
-	err := g.generate(ctx, outputDir, nil, schema)
-	if err != nil {
+	// A directory avroc has to create: a plugin may assume --out exists.
+	outputDir := filepath.Join(t.TempDir(), "gen")
+
+	if err := g.generate(ctx, outputDir, options, schema); err != nil {
 		t.Fatal(err)
 	}
 
-	// avroc, not the generator, performs the write. Confirm the streamed file
-	// landed under the output directory.
-	written := filepath.Join(outputDir, "output.go")
-	if _, err := os.Stat(written); err != nil {
-		t.Errorf("expected generated file at %q: %v", written, err)
+	args := readLines(t, argsPath)
+	if len(args) != 8 {
+		t.Fatalf("generator received %d arguments %q, want 8", len(args), args)
+	}
+	if args[0] != "--descriptor" || args[2] != "--out" {
+		t.Errorf("argument vector = %q, want --descriptor <path> --out <dir> first", args)
+	}
+	if !filepath.IsAbs(args[1]) {
+		t.Errorf("--descriptor %q is not an absolute path", args[1])
+	}
+	if filepath.Base(args[1]) != descriptorFilename {
+		t.Errorf("--descriptor %q is not the descriptor avroc writes", args[1])
+	}
+	if want, err := filepath.Abs(outputDir); err != nil {
+		t.Fatal(err)
+	} else if args[3] != want {
+		t.Errorf("--out = %q, want the absolute %q", args[3], want)
+	}
+	// The options follow in the order the manifest fixed, so the vector is a
+	// function of the manifest rather than of a map iteration.
+	wantOpts := []string{"--opt", "encoding=single_object", "--opt", "package_name=avro"}
+	if got := args[4:]; !slices.Equal(got, wantOpts) {
+		t.Errorf("option arguments = %q, want %q", got, wantOpts)
+	}
+
+	// The descriptor the generator could read while it ran is the one avroc
+	// built for this invocation, complete and decodable.
+	b, err := os.ReadFile(copyPath)
+	if err != nil {
+		t.Fatalf("the generator could not copy the descriptor it was handed: %v", err)
+	}
+	var onDisk avrocpb.GenerateRequest
+	if err := proto.Unmarshal(b, &onDisk); err != nil {
+		t.Fatalf("the descriptor the generator read does not decode: %v", err)
+	}
+	if err := ir.CheckVersion(onDisk.GetVersion()); err != nil {
+		t.Errorf("avroc emitted a descriptor no generator here would read: %v", err)
+	}
+	if want := newDescriptor(options, []*avrocpb.Schema{schema}); !proto.Equal(&onDisk, want) {
+		t.Errorf("descriptor on disk = %v, want %v", &onDisk, want)
+	}
+
+	// The generator writes its own files now; avroc only creates the directory.
+	if _, err := os.Stat(filepath.Join(outputDir, "pkg", "output.go")); err != nil {
+		t.Errorf("expected the generator's file under the output directory: %v", err)
 	}
 
 	for dir := range descriptorDirs(t) {
@@ -438,12 +449,88 @@ func TestGeneratorGenerate(t *testing.T) {
 	}
 }
 
+// TestGeneratorGenerateNonZeroExit is the whole of the failure signal: a
+// non-zero exit fails the run, and the descriptor is still removed.
+func TestGeneratorGenerateNonZeroExit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	g := testGenerator(t, writeShellGenerator(t, "echo 'error: nope' >&2\nexit 3\n"))
+
+	before := descriptorDirs(t)
+
+	err := g.generate(ctx, t.TempDir(), nil, testSchema("User"))
+	if err == nil {
+		t.Fatal("generate accepted a generator that exited non-zero")
+	}
+	if !strings.Contains(err.Error(), testGeneratorName) {
+		t.Errorf("error %q does not name the generator", err)
+	}
+
+	for dir := range descriptorDirs(t) {
+		if _, ok := before[dir]; !ok {
+			t.Errorf("descriptor directory %q survived a failed invocation", dir)
+		}
+	}
+}
+
+// TestGeneratorGenerateCancellation is the other half of the process lifecycle:
+// cancelling the signal-based parent context reaches the child, and generate
+// returns rather than waiting on a process nobody is going to stop.
+func TestGeneratorGenerateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	started := filepath.Join(t.TempDir(), "started")
+	// exec, so that the process avroc kills is the one that sleeps. A shell that
+	// forked the sleep would leave it orphaned holding the inherited standard
+	// streams, and the test binary would then outlive its own generator.
+	g := testGenerator(t, writeShellGenerator(t, fmt.Sprintf(": > '%s'\nexec sleep 300\n", started)))
+
+	before := descriptorDirs(t)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.generate(ctx, t.TempDir(), nil, testSchema("User"))
+	}()
+
+	// Cancel only once the child is definitely running, so the test is about
+	// cancellation reaching a live process rather than about a context that was
+	// already done before the fork.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the generator never started")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("generate reported success for a cancelled invocation")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("generate did not return after its context was cancelled")
+	}
+
+	for dir := range descriptorDirs(t) {
+		if _, ok := before[dir]; !ok {
+			t.Errorf("descriptor directory %q survived a cancelled invocation", dir)
+		}
+	}
+}
+
 // descriptorDirs is the set of per-invocation descriptor directories currently
 // on disk for the stand-in generator.
 func descriptorDirs(t *testing.T) map[string]struct{} {
 	t.Helper()
 
-	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "avroc-gen-test-descriptor-*"))
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), testGeneratorName+"-descriptor-*"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,143 +541,41 @@ func descriptorDirs(t *testing.T) map[string]struct{} {
 	return dirs
 }
 
-// fakeClientStream replays a fixed sequence of GenerateResponse messages,
-// implementing avrocpb.Generator_GenerateClient for writeStream tests.
-type fakeClientStream struct {
-	grpc.ClientStream
-	msgs []*avrocpb.GenerateResponse
-	i    int
-}
-
-func (f *fakeClientStream) Recv() (*avrocpb.GenerateResponse, error) {
-	if f.i >= len(f.msgs) {
-		return nil, io.EOF
-	}
-	m := f.msgs[f.i]
-	f.i++
-	return m, nil
-}
-
-func TestWriteStream(t *testing.T) {
-	g := generator{
-		log:  slog.New(slog.NewTextHandler(io.Discard, nil)),
-		name: "avroc-gen-test",
-	}
-
-	t.Run("writes reassembled file under output root", func(t *testing.T) {
-		root := t.TempDir()
-		path := "pkg/person.go"
-		last := func(b bool) *bool { return &b }
-		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
-			{Path: &path, Content: []byte("package pkg\n"), Last: last(false)},
-			{Path: &path, Content: []byte("// trailer\n"), Last: last(true)},
-		}}
-
-		written, err := g.writeStream(root, stream)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(written) != 1 {
-			t.Fatalf("expected 1 written file, got %d", len(written))
-		}
-
-		got, err := os.ReadFile(filepath.Join(root, "pkg", "person.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want := "package pkg\n// trailer\n"; string(got) != want {
-			t.Errorf("content = %q, want %q", string(got), want)
-		}
-	})
-
-	t.Run("rejects paths that escape the output root", func(t *testing.T) {
-		for _, bad := range []string{"../escape.go", "/etc/evil.go", "a/../../escape.go"} {
-			root := t.TempDir()
-			path := bad
-			last := true
-			stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
-				{Path: &path, Content: []byte("package x\n"), Last: &last},
-			}}
-
-			if _, err := g.writeStream(root, stream); err == nil {
-				t.Errorf("path %q: expected error, got nil", bad)
-			}
-
-			// Nothing must be written next to the output root.
-			if _, err := os.Stat(filepath.Join(filepath.Dir(root), "escape.go")); !os.IsNotExist(err) {
-				t.Errorf("path %q: file escaped the output root", bad)
-			}
-		}
-	})
-
-	t.Run("errors when the stream ends with an unterminated file", func(t *testing.T) {
-		root := t.TempDir()
-		path := "pkg/person.go"
-		last := func(b bool) *bool { return &b }
-		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
-			{Path: &path, Content: []byte("package pkg\n"), Last: last(false)},
-			// No terminating chunk: the stream just ends.
-		}}
-
-		if _, err := g.writeStream(root, stream); err == nil {
-			t.Fatal("expected error for unterminated file, got nil")
-		}
-
-		// The partial file must not be left behind in the output tree.
-		if _, err := os.Stat(filepath.Join(root, "pkg", "person.go")); !os.IsNotExist(err) {
-			t.Errorf("partial file was not discarded: %v", err)
-		}
-	})
-
-	t.Run("errors when a chunk follows a terminated file", func(t *testing.T) {
-		root := t.TempDir()
-		path := "person.go"
-		last := func(b bool) *bool { return &b }
-		stream := &fakeClientStream{msgs: []*avrocpb.GenerateResponse{
-			{Path: &path, Content: []byte("package pkg\n"), Last: last(true)},
-			{Path: &path, Content: []byte("// extra\n"), Last: last(true)},
-		}}
-
-		if _, err := g.writeStream(root, stream); err == nil {
-			t.Fatal("expected error for chunk after termination, got nil")
-		}
-	})
-}
-
-func TestGeneratorGenerate_RejectsUnsafePath(t *testing.T) {
-	t.Setenv("AVROC_TEST_GENERATOR", "1")
-	t.Setenv("AVROC_TEST_GEN_PATH", "../escape.go")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	g := generator{
-		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		env: cli.EnvironmentFunc(func(key string) (string, bool) {
-			if key == "AVROC_GENERATOR_ARGS" {
-				return "-test.run=TestHelperGenerator --", true
-			}
-			return "", false
-		}),
-		name:           "avroc-gen-test",
-		executablePath: os.Args[0],
-	}
-
-	schema := &avrocpb.Schema{
-		Namespace: proto.String("com.example"),
-		Type: &avrocpb.Type{
-			Type: &avrocpb.Type_Record{
-				Record: &avrocpb.Record{Name: proto.String("User")},
+// TestGeneratorArgs pins the vector docs/plugin/SPEC.md specifies, including
+// the case the invocation tests above cannot reach: a generator with no
+// options at all still gets --descriptor and --out and nothing more.
+func TestGeneratorArgs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		options []*avrocpb.Option
+		want    []string
+	}{
+		{
+			name: "no options",
+			want: []string{"--descriptor", "/tmp/d/descriptor.binpb", "--out", "/w/gen"},
+		},
+		{
+			name: "an option whose value is empty",
+			options: []*avrocpb.Option{
+				{Name: proto.String("package_name"), Value: proto.String("")},
 			},
+			want: []string{"--descriptor", "/tmp/d/descriptor.binpb", "--out", "/w/gen", "--opt", "package_name="},
+		},
+		{
+			name: "an option whose value carries further equals signs",
+			options: []*avrocpb.Option{
+				{Name: proto.String("tag"), Value: proto.String("a=b=c")},
+			},
+			want: []string{"--descriptor", "/tmp/d/descriptor.binpb", "--out", "/w/gen", "--opt", "tag=a=b=c"},
 		},
 	}
 
-	outputDir := t.TempDir()
-	if err := g.generate(ctx, outputDir, nil, schema); err == nil {
-		t.Fatal("expected error for generator returning an escaping path")
-	}
-
-	if _, err := os.Stat(filepath.Join(filepath.Dir(outputDir), "escape.go")); !os.IsNotExist(err) {
-		t.Errorf("file escaped the output root")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generatorArgs("/tmp/d/descriptor.binpb", "/w/gen", tc.options)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("generatorArgs = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -61,7 +61,6 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 		genPool.Go(func(ctx context.Context) error {
 			g := generator{
 				log:            cli.Log,
-				env:            cli.Env,
 				name:           task.name,
 				executablePath: task.executablePath,
 			}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package plugin is the generator's half of docs/plugin/SPEC.md: the argument
+// vector avroc invokes an executable with, the descriptor that vector names,
+// and the directory every generated file is written beneath.
+//
+// avroc's half — discovering the executable and building the vector — is
+// internal/avroc's. The two are deliberately separate packages either side of a
+// process boundary: a third-party generator implements this contract without
+// importing anything here, and the only thing that binds the two is the vector
+// itself.
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// Invocation is one parsed generator argument vector.
+type Invocation struct {
+	// Descriptor is the path the descriptor was handed at, or "-" for standard
+	// input. Nothing may be derived from the path itself: docs/plugin/SPEC.md
+	// makes it a temporary location avroc chose and not a place to hang meaning.
+	Descriptor string
+
+	// Out is the directory every generated file is written beneath.
+	Out string
+
+	// Options are the --opt pairs, in the order they appeared on the command
+	// line. avroc emits them in the order the manifest fixed, so a generator
+	// reading them in order reads them in the manifest's.
+	Options []*avrocpb.Option
+}
+
+// ParseArgs parses the argument vector docs/plugin/SPEC.md specifies:
+//
+//	avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]
+//
+// Only the separated form is accepted — each option followed by its value as
+// the next argument — because that is the one form avroc emits and the one a
+// shell-script plugin can handle in a three-line case statement. The joined
+// --descriptor=<path> spelling is a thing a plugin MAY accept and avroc never
+// produces, so accepting it here would be surface with nothing behind it.
+//
+// "--" ends the options. The contract defines no operands and avroc passes
+// none, so anything after it is an error rather than something to ignore.
+func ParseArgs(args []string) (*Invocation, error) {
+	inv := &Invocation{}
+	var sawDescriptor, sawOut bool
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" {
+			if rest := args[i+1:]; len(rest) > 0 {
+				return nil, fmt.Errorf("unexpected operand %q: the generator contract defines none", rest[0])
+			}
+			break
+		}
+
+		switch arg {
+		case "--descriptor", "--out", "--opt":
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return nil, fmt.Errorf("unknown option %q", arg)
+			}
+			return nil, fmt.Errorf("unexpected operand %q: the generator contract defines none", arg)
+		}
+
+		if i+1 >= len(args) {
+			return nil, fmt.Errorf("%s requires a value", arg)
+		}
+		value := args[i+1]
+		i++
+
+		switch arg {
+		case "--descriptor":
+			if sawDescriptor {
+				return nil, errors.New("--descriptor given more than once")
+			}
+			sawDescriptor, inv.Descriptor = true, value
+		case "--out":
+			if sawOut {
+				return nil, errors.New("--out given more than once")
+			}
+			sawOut, inv.Out = true, value
+		case "--opt":
+			opt, err := parseOption(value)
+			if err != nil {
+				return nil, err
+			}
+			inv.Options = append(inv.Options, opt)
+		}
+	}
+
+	if !sawDescriptor {
+		return nil, errors.New("--descriptor is required")
+	}
+	if !sawOut {
+		return nil, errors.New("--out is required")
+	}
+	return inv, nil
+}
+
+// parseOption splits one --opt value at its first "=". Everything before it is
+// the key and everything after it is the value, so a value may be empty or
+// carry further "=" characters; a key may do neither.
+func parseOption(s string) (*avrocpb.Option, error) {
+	key, value, ok := strings.Cut(s, "=")
+	if !ok {
+		return nil, fmt.Errorf("option %q is not of the form k=v", s)
+	}
+	if key == "" {
+		return nil, fmt.Errorf("option %q has an empty key", s)
+	}
+	return &avrocpb.Option{
+		Name:  proto.String(key),
+		Value: proto.String(value),
+	}, nil
+}
+
+// Usage is the one-line usage every generator in this repository prints, with
+// name the executable's own.
+func Usage(name string) string {
+	return fmt.Sprintf("Usage: %s --descriptor <path> --out <dir> [--opt k=v ...]\n", name)
+}
+
+// ReadDescriptor reads and decodes the descriptor this invocation names,
+// reading stdin instead when the path is "-".
+//
+// The options on the returned descriptor are the ones from the command line,
+// not the ones the encoded descriptor happens to carry. docs/plugin/SPEC.md is
+// normative for how a generator is configured — "everything that configures its
+// output arrives as --opt" — and avroc emits the same pairs in both places, so
+// the two never disagree in practice. Preferring the vector is what keeps a
+// descriptor saved from a failing run re-runnable by hand with the options
+// changed.
+func (inv *Invocation) ReadDescriptor(stdin io.Reader) (*avrocpb.GenerateRequest, error) {
+	var b []byte
+	var err error
+	if inv.Descriptor == "-" {
+		b, err = io.ReadAll(stdin)
+	} else {
+		b, err = os.ReadFile(inv.Descriptor)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read descriptor: %w", err)
+	}
+
+	var req avrocpb.GenerateRequest
+	if err := proto.Unmarshal(b, &req); err != nil {
+		return nil, fmt.Errorf("failed to decode descriptor: %w", err)
+	}
+
+	req.Options = inv.Options
+	return &req, nil
+}
+
+// OutputPath resolves a generated file's relative path against the output
+// directory, refusing anything that would land outside it.
+//
+// docs/plugin/SPEC.md puts the requirement on the plugin — every file beneath
+// --out, not through "..", not through an absolute path — and avroc enforcing
+// it as well is #117's. Checking here means a generator in this repository
+// cannot break the rule even while avroc is not yet watching.
+func OutputPath(out, p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return "", fmt.Errorf("path %q is absolute", p)
+	}
+
+	root, err := filepath.Abs(out)
+	if err != nil {
+		return "", err
+	}
+
+	dst := filepath.Join(root, filepath.FromSlash(p))
+	rel, err := filepath.Rel(root, dst)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes the output directory", p)
+	}
+	return dst, nil
+}
+
+// WriteFile writes one generated file beneath this invocation's output
+// directory, creating any parent directories it names.
+func (inv *Invocation) WriteFile(path string, content []byte) error {
+	dst, err := OutputPath(inv.Out, path)
+	if err != nil {
+		return fmt.Errorf("refusing to write %q: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory for %q: %w", dst, err)
+	}
+	if err := os.WriteFile(dst, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write %q: %w", dst, err)
+	}
+	return nil
+}
+
+// GenerateFunc is the generation entry point every generator in this
+// repository exposes: a descriptor in, files out through the stream.
+//
+// The streaming shape is the one the generators here still implement, and it is
+// transitional — #121, #122 and #123 replace it with a plain write into --out,
+// and #124 removes the service the type comes from. Nothing in the contract
+// this package implements requires it: avroc no longer speaks to a generator
+// over a socket, and the chunks never leave the process.
+type GenerateFunc func(*avrocpb.GenerateRequest, avrocpb.Generator_GenerateServer) error
+
+// Main runs one generation from an argument vector and returns the process
+// exit status: parse the vector, read the descriptor, run generate, and write
+// what it produced beneath --out.
+//
+// Diagnostics go to the logger, which every generator's main wires to standard
+// error. Standard output carries nothing during a generation invocation, which
+// is what keeps it free for the --plugin-info declaration (#116) and makes an
+// invocation safe to put in a pipeline.
+func Main(ctx context.Context, c cli.Context, name string, generate GenerateFunc) int {
+	inv, err := ParseArgs(c.Args)
+	if err != nil {
+		c.Log.ErrorContext(ctx, "invalid arguments", slog.String("generator", name), slog.Any("error", err))
+		_, _ = io.WriteString(os.Stderr, Usage(name))
+		return 1
+	}
+
+	req, err := inv.ReadDescriptor(os.Stdin)
+	if err != nil {
+		c.Log.ErrorContext(ctx, "failed to read descriptor", slog.String("generator", name), slog.Any("error", err))
+		return 1
+	}
+
+	sink := &fileStream{ctx: ctx, inv: inv}
+	if err := generate(req, sink); err != nil {
+		c.Log.ErrorContext(ctx, "failed to generate", slog.String("generator", name), slog.Any("error", err))
+		return 1
+	}
+	if err := sink.finish(); err != nil {
+		c.Log.ErrorContext(ctx, "failed to write generated output", slog.String("generator", name), slog.Any("error", err))
+		return 1
+	}
+
+	c.Log.DebugContext(ctx, "generated output", slog.String("generator", name), slog.Any("output_files", sink.written))
+	return 0
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -177,8 +178,19 @@ func (inv *Invocation) ReadDescriptor(stdin io.Reader) (*avrocpb.GenerateRequest
 // --out, not through "..", not through an absolute path — and avroc enforcing
 // it as well is #117's. Checking here means a generator in this repository
 // cannot break the rule even while avroc is not yet watching.
+//
+// The path a generator emits is a slash-separated relative path, whatever the
+// host's separator, so it is converted before it is joined.
 func OutputPath(out, p string) (string, error) {
-	if filepath.IsAbs(p) {
+	if p == "" {
+		return "", errors.New("path is empty")
+	}
+	if path.IsAbs(p) {
+		return "", fmt.Errorf("path %q is absolute", p)
+	}
+
+	osPath := filepath.FromSlash(p)
+	if filepath.IsAbs(osPath) {
 		return "", fmt.Errorf("path %q is absolute", p)
 	}
 
@@ -187,31 +199,21 @@ func OutputPath(out, p string) (string, error) {
 		return "", err
 	}
 
-	dst := filepath.Join(root, filepath.FromSlash(p))
+	dst := filepath.Join(root, osPath)
 	rel, err := filepath.Rel(root, dst)
 	if err != nil {
 		return "", err
+	}
+	// "." is the output directory itself, which is not a file a generator can
+	// write — "", "." and "./" all reach it, and each would otherwise fail
+	// later as a confusing "is a directory" from the open.
+	if rel == "." {
+		return "", fmt.Errorf("path %q names the output directory, not a file in it", p)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %q escapes the output directory", p)
 	}
 	return dst, nil
-}
-
-// WriteFile writes one generated file beneath this invocation's output
-// directory, creating any parent directories it names.
-func (inv *Invocation) WriteFile(path string, content []byte) error {
-	dst, err := OutputPath(inv.Out, path)
-	if err != nil {
-		return fmt.Errorf("refusing to write %q: %w", path, err)
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("failed to create output directory for %q: %w", dst, err)
-	}
-	if err := os.WriteFile(dst, content, 0o644); err != nil {
-		return fmt.Errorf("failed to write %q: %w", dst, err)
-	}
-	return nil
 }
 
 // GenerateFunc is the generation entry point every generator in this
@@ -247,6 +249,10 @@ func Main(ctx context.Context, c cli.Context, name string, generate GenerateFunc
 	}
 
 	sink := &fileStream{ctx: ctx, inv: inv}
+	// A file whose terminating chunk never arrived is discarded however this
+	// returns, so a failed generation leaves no half-written source behind.
+	defer sink.discard()
+
 	if err := generate(req, sink); err != nil {
 		c.Log.ErrorContext(ctx, "failed to generate", slog.String("generator", name), slog.Any("error", err))
 		return 1

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,391 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func option(name, value string) *avrocpb.Option {
+	return &avrocpb.Option{Name: proto.String(name), Value: proto.String(value)}
+}
+
+func TestParseArgs(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+		want *Invocation
+	}{
+		{
+			name: "the vector avroc emits",
+			args: []string{"--descriptor", "/tmp/d/descriptor.binpb", "--out", "/w/gen"},
+			want: &Invocation{Descriptor: "/tmp/d/descriptor.binpb", Out: "/w/gen"},
+		},
+		{
+			name: "options in the order they were given",
+			args: []string{"--descriptor", "d", "--out", "o", "--opt", "b=2", "--opt", "a=1"},
+			want: &Invocation{
+				Descriptor: "d",
+				Out:        "o",
+				Options:    []*avrocpb.Option{option("b", "2"), option("a", "1")},
+			},
+		},
+		{
+			name: "an option value may be empty",
+			args: []string{"--descriptor", "d", "--out", "o", "--opt", "k="},
+			want: &Invocation{Descriptor: "d", Out: "o", Options: []*avrocpb.Option{option("k", "")}},
+		},
+		{
+			name: "an option value may carry further equals signs",
+			args: []string{"--descriptor", "d", "--out", "o", "--opt", "k=a=b"},
+			want: &Invocation{Descriptor: "d", Out: "o", Options: []*avrocpb.Option{option("k", "a=b")}},
+		},
+		{
+			name: "- names standard input",
+			args: []string{"--descriptor", "-", "--out", "o"},
+			want: &Invocation{Descriptor: "-", Out: "o"},
+		},
+		{
+			name: "-- ends the options",
+			args: []string{"--descriptor", "d", "--out", "o", "--"},
+			want: &Invocation{Descriptor: "d", Out: "o"},
+		},
+		{
+			name: "the order of --descriptor and --out is not fixed",
+			args: []string{"--out", "o", "--opt", "k=v", "--descriptor", "d"},
+			want: &Invocation{Descriptor: "d", Out: "o", Options: []*avrocpb.Option{option("k", "v")}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseArgs(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Descriptor != tc.want.Descriptor {
+				t.Errorf("Descriptor = %q, want %q", got.Descriptor, tc.want.Descriptor)
+			}
+			if got.Out != tc.want.Out {
+				t.Errorf("Out = %q, want %q", got.Out, tc.want.Out)
+			}
+			if len(got.Options) != len(tc.want.Options) {
+				t.Fatalf("got %d options, want %d", len(got.Options), len(tc.want.Options))
+			}
+			for i, opt := range got.Options {
+				if !proto.Equal(opt, tc.want.Options[i]) {
+					t.Errorf("option %d = %v, want %v", i, opt, tc.want.Options[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseArgsRejects(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "nothing at all", args: nil},
+		{name: "no descriptor", args: []string{"--out", "o"}},
+		{name: "no output directory", args: []string{"--descriptor", "d"}},
+		{name: "a descriptor with no value", args: []string{"--out", "o", "--descriptor"}},
+		{name: "an output directory with no value", args: []string{"--descriptor", "d", "--out"}},
+		{name: "an option with no value", args: []string{"--descriptor", "d", "--out", "o", "--opt"}},
+		{name: "two descriptors", args: []string{"--descriptor", "a", "--descriptor", "b", "--out", "o"}},
+		{name: "two output directories", args: []string{"--descriptor", "d", "--out", "a", "--out", "b"}},
+		{name: "an unknown option", args: []string{"--descriptor", "d", "--out", "o", "--verbose"}},
+		{name: "an operand", args: []string{"--descriptor", "d", "--out", "o", "schema.avdl"}},
+		{name: "an operand after --", args: []string{"--descriptor", "d", "--out", "o", "--", "schema.avdl"}},
+		{name: "an option that is not k=v", args: []string{"--descriptor", "d", "--out", "o", "--opt", "k"}},
+		{name: "an option with an empty key", args: []string{"--descriptor", "d", "--out", "o", "--opt", "=v"}},
+		{
+			// The joined form is one a plugin MAY accept and avroc never emits,
+			// so accepting it here would be surface with nothing behind it.
+			name: "the joined form",
+			args: []string{"--descriptor=d", "--out=o"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseArgs(tc.args); err == nil {
+				t.Errorf("ParseArgs(%q) accepted a vector the contract does not define", tc.args)
+			}
+		})
+	}
+}
+
+func testDescriptor() *avrocpb.GenerateRequest {
+	return &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{
+			{
+				Namespace: proto.String("com.example"),
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:     proto.String("User"),
+							FullName: proto.String("com.example.User"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestReadDescriptor(t *testing.T) {
+	desc := testDescriptor()
+	// The options on the wire are deliberately different from the ones on the
+	// command line, so the test can tell which of the two was believed.
+	desc.Options = []*avrocpb.Option{option("stale", "yes")}
+
+	b, err := proto.Marshal(desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("from a file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "descriptor.binpb")
+		if err := os.WriteFile(path, b, 0o444); err != nil {
+			t.Fatal(err)
+		}
+
+		inv, err := ParseArgs([]string{"--descriptor", path, "--out", t.TempDir(), "--opt", "package_name=gen"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := inv.ReadDescriptor(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.GetVersion() != ir.Version {
+			t.Errorf("version = %d, want %d", got.GetVersion(), ir.Version)
+		}
+		if len(got.GetSchemas()) != 1 {
+			t.Fatalf("got %d schemas, want 1", len(got.GetSchemas()))
+		}
+		// docs/plugin/SPEC.md configures a generator through --opt, so the
+		// vector wins over whatever the encoded descriptor happens to carry.
+		want := []*avrocpb.Option{option("package_name", "gen")}
+		if len(got.GetOptions()) != 1 || !proto.Equal(got.GetOptions()[0], want[0]) {
+			t.Errorf("options = %v, want %v", got.GetOptions(), want)
+		}
+	})
+
+	t.Run("from standard input", func(t *testing.T) {
+		inv, err := ParseArgs([]string{"--descriptor", "-", "--out", t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := inv.ReadDescriptor(bytes.NewReader(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.GetVersion() != ir.Version {
+			t.Errorf("version = %d, want %d", got.GetVersion(), ir.Version)
+		}
+	})
+
+	t.Run("a descriptor that is not there", func(t *testing.T) {
+		inv, err := ParseArgs([]string{"--descriptor", filepath.Join(t.TempDir(), "absent"), "--out", t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := inv.ReadDescriptor(nil); err == nil {
+			t.Error("ReadDescriptor accepted a descriptor that does not exist")
+		}
+	})
+
+	t.Run("a descriptor that does not decode", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "descriptor.binpb")
+		if err := os.WriteFile(path, []byte("not a descriptor"), 0o444); err != nil {
+			t.Fatal(err)
+		}
+
+		inv, err := ParseArgs([]string{"--descriptor", path, "--out", t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := inv.ReadDescriptor(nil); err == nil {
+			t.Error("ReadDescriptor accepted bytes that are not a descriptor")
+		}
+	})
+}
+
+func TestOutputPath(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("resolves a relative path under the output directory", func(t *testing.T) {
+		got, err := OutputPath(root, "pkg/user.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := filepath.Join(root, "pkg", "user.go"); got != want {
+			t.Errorf("OutputPath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("refuses to leave the output directory", func(t *testing.T) {
+		for _, bad := range []string{"../escape.go", "a/../../escape.go", "/etc/evil.go", ".."} {
+			if _, err := OutputPath(root, bad); err == nil {
+				t.Errorf("OutputPath accepted %q", bad)
+			}
+		}
+	})
+}
+
+func TestWriteFile(t *testing.T) {
+	out := t.TempDir()
+	inv := &Invocation{Out: out}
+
+	if err := inv.WriteFile("pkg/user.go", []byte("package pkg\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, "pkg", "user.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "package pkg\n"; string(got) != want {
+		t.Errorf("content = %q, want %q", string(got), want)
+	}
+
+	if err := inv.WriteFile("../escape.go", []byte("package pkg\n")); err == nil {
+		t.Error("WriteFile accepted a path outside the output directory")
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(out), "escape.go")); !os.IsNotExist(err) {
+		t.Error("a file escaped the output directory")
+	}
+}
+
+// echoGenerate is a stand-in generator: it emits every schema's full name as a
+// file, in two chunks, so the reassembly the adapter performs is exercised.
+func echoGenerate(req *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+	for _, schema := range req.GetSchemas() {
+		name := schema.GetType().GetRecord().GetFullName() + ".txt"
+		for i, chunk := range [][]byte{[]byte("first\n"), []byte("second\n")} {
+			last := i == 1
+			if err := stream.Send(&avrocpb.GenerateResponse{
+				Path:    proto.String(name),
+				Content: chunk,
+				Last:    proto.Bool(last),
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func newTestCLI(args ...string) (cli.Context, *bytes.Buffer) {
+	var logs bytes.Buffer
+	return cli.Context{
+		Log:  slog.New(slog.NewTextHandler(&logs, nil)),
+		Env:  cli.EnvironmentFunc(func(string) (string, bool) { return "", false }),
+		Args: args,
+	}, &logs
+}
+
+func TestMain_WritesGeneratedFiles(t *testing.T) {
+	desc := testDescriptor()
+	b, err := proto.Marshal(desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "descriptor.binpb")
+	if err := os.WriteFile(path, b, 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	out := t.TempDir()
+	c, _ := newTestCLI("--descriptor", path, "--out", out)
+
+	if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	got, err := os.ReadFile(filepath.Join(out, "com.example.User.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "first\nsecond\n"; string(got) != want {
+		t.Errorf("content = %q, want %q", string(got), want)
+	}
+}
+
+func TestMain_Failures(t *testing.T) {
+	descriptorPath := func(t *testing.T) string {
+		t.Helper()
+		b, err := proto.Marshal(testDescriptor())
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "descriptor.binpb")
+		if err := os.WriteFile(path, b, 0o444); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	t.Run("an argument vector the contract does not define", func(t *testing.T) {
+		c, _ := newTestCLI("--out", t.TempDir())
+		if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code == 0 {
+			t.Error("exit code = 0 for a vector with no descriptor")
+		}
+	})
+
+	t.Run("a descriptor that is not there", func(t *testing.T) {
+		c, _ := newTestCLI("--descriptor", filepath.Join(t.TempDir(), "absent"), "--out", t.TempDir())
+		if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code == 0 {
+			t.Error("exit code = 0 for a descriptor that does not exist")
+		}
+	})
+
+	t.Run("a generator that fails", func(t *testing.T) {
+		out := t.TempDir()
+		c, logs := newTestCLI("--descriptor", descriptorPath(t), "--out", out)
+
+		failing := func(*avrocpb.GenerateRequest, avrocpb.Generator_GenerateServer) error {
+			return io.ErrUnexpectedEOF
+		}
+		if code := Main(t.Context(), c, "avroc-gen-test", failing); code == 0 {
+			t.Error("exit code = 0 for a generator that returned an error")
+		}
+		if !strings.Contains(logs.String(), "failed to generate") {
+			t.Errorf("the failure was not reported: %s", logs.String())
+		}
+	})
+
+	t.Run("a generator that stops with a file unterminated", func(t *testing.T) {
+		c, _ := newTestCLI("--descriptor", descriptorPath(t), "--out", t.TempDir())
+
+		halfEmitted := func(_ *avrocpb.GenerateRequest, stream avrocpb.Generator_GenerateServer) error {
+			return stream.Send(&avrocpb.GenerateResponse{
+				Path:    proto.String("user.go"),
+				Content: []byte("package pkg\n"),
+				Last:    proto.Bool(false),
+			})
+		}
+		if code := Main(t.Context(), c, "avroc-gen-test", halfEmitted); code == 0 {
+			t.Error("exit code = 0 for a generator that left a file unterminated")
+		}
+	})
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -251,29 +251,17 @@ func TestOutputPath(t *testing.T) {
 			}
 		}
 	})
-}
 
-func TestWriteFile(t *testing.T) {
-	out := t.TempDir()
-	inv := &Invocation{Out: out}
-
-	if err := inv.WriteFile("pkg/user.go", []byte("package pkg\n")); err != nil {
-		t.Fatal(err)
-	}
-	got, err := os.ReadFile(filepath.Join(out, "pkg", "user.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := "package pkg\n"; string(got) != want {
-		t.Errorf("content = %q, want %q", string(got), want)
-	}
-
-	if err := inv.WriteFile("../escape.go", []byte("package pkg\n")); err == nil {
-		t.Error("WriteFile accepted a path outside the output directory")
-	}
-	if _, err := os.Stat(filepath.Join(filepath.Dir(out), "escape.go")); !os.IsNotExist(err) {
-		t.Error("a file escaped the output directory")
-	}
+	t.Run("refuses a path that is not a file in the output directory", func(t *testing.T) {
+		// Each of these resolves to the output directory itself. Rejecting them
+		// here is what turns them into an error naming the path, rather than an
+		// "is a directory" from an open several frames away.
+		for _, bad := range []string{"", ".", "./", "a/.."} {
+			if _, err := OutputPath(root, bad); err == nil {
+				t.Errorf("OutputPath accepted %q", bad)
+			}
+		}
+	})
 }
 
 // echoGenerate is a stand-in generator: it emits every schema's full name as a

--- a/internal/plugin/stream.go
+++ b/internal/plugin/stream.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/grpc"
+)
+
+// fileStream turns the chunk stream the generators in this repository still
+// emit into files beneath --out.
+//
+// It exists because avroc no longer consumes those chunks: they used to cross a
+// socket and be written by avroc, and under docs/plugin/SPEC.md the generator
+// writes its own files. Rather than rewrite three generators' emission paths in
+// the same change that moves the invocation — that is #121, #122 and #123, each
+// of which has more to do than this — the chunks are reassembled in-process by
+// the one adapter here.
+//
+// grpc.ServerStream is embedded to satisfy avrocpb.Generator_GenerateServer and
+// is deliberately nil: no gRPC call is in flight, nothing here reads it, and a
+// method that reached for it would be asking a question this contract has no
+// answer to. Context is overridden so the one method a generator might
+// plausibly call does not panic.
+type fileStream struct {
+	grpc.ServerStream
+
+	ctx context.Context
+	inv *Invocation
+
+	// pending holds the bytes of files whose terminating chunk has not arrived.
+	pending map[string][]byte
+	// finalized names the files already written, so a chunk arriving after a
+	// file's terminating one is an error rather than a silent overwrite.
+	finalized map[string]struct{}
+	// order preserves emission order so the written paths read the way the
+	// generator produced them rather than the way a map iterates.
+	order   []string
+	written []string
+}
+
+func (s *fileStream) Context() context.Context { return s.ctx }
+
+// Send accumulates one chunk, writing the file out once its terminating chunk
+// arrives.
+func (s *fileStream) Send(msg *avrocpb.GenerateResponse) error {
+	path := msg.GetPath()
+	if path == "" {
+		return fmt.Errorf("generator emitted a chunk with no path")
+	}
+	if _, done := s.finalized[path]; done {
+		return fmt.Errorf("generator emitted a chunk for already-completed file %q", path)
+	}
+
+	if s.pending == nil {
+		s.pending = make(map[string][]byte)
+		s.finalized = make(map[string]struct{})
+	}
+	if _, open := s.pending[path]; !open {
+		s.order = append(s.order, path)
+	}
+	s.pending[path] = append(s.pending[path], msg.GetContent()...)
+
+	if !msg.GetLast() {
+		return nil
+	}
+
+	content := s.pending[path]
+	delete(s.pending, path)
+	if err := s.inv.WriteFile(path, content); err != nil {
+		return err
+	}
+	s.finalized[path] = struct{}{}
+	s.written = append(s.written, path)
+	return nil
+}
+
+// finish reports a generator that stopped with a file still unterminated. A
+// half-emitted file is a bug in the generator, and reporting it is what stops
+// the missing bytes turning up later as a compile error in the user's tree.
+func (s *fileStream) finish() error {
+	if len(s.pending) == 0 {
+		return nil
+	}
+	for _, path := range s.order {
+		if _, open := s.pending[path]; open {
+			return fmt.Errorf("generator finished with %d unterminated file(s), the first being %q", len(s.pending), path)
+		}
+	}
+	return fmt.Errorf("generator finished with %d unterminated file(s)", len(s.pending))
+}

--- a/internal/plugin/stream.go
+++ b/internal/plugin/stream.go
@@ -8,6 +8,8 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/z5labs/avroc/avrocpb"
 
@@ -21,8 +23,13 @@ import (
 // socket and be written by avroc, and under docs/plugin/SPEC.md the generator
 // writes its own files. Rather than rewrite three generators' emission paths in
 // the same change that moves the invocation — that is #121, #122 and #123, each
-// of which has more to do than this — the chunks are reassembled in-process by
-// the one adapter here.
+// of which has more to do than this — the chunks are reassembled by the one
+// adapter here.
+//
+// Each chunk is written straight through to an open file rather than
+// accumulated in memory, so peak memory does not scale with the size of a
+// generated file. Chunking exists precisely to keep it bounded, and buffering
+// would give that back while keeping the cost.
 //
 // grpc.ServerStream is embedded to satisfy avrocpb.Generator_GenerateServer and
 // is deliberately nil: no gRPC call is in flight, nothing here reads it, and a
@@ -35,21 +42,21 @@ type fileStream struct {
 	ctx context.Context
 	inv *Invocation
 
-	// pending holds the bytes of files whose terminating chunk has not arrived.
-	pending map[string][]byte
-	// finalized names the files already written, so a chunk arriving after a
-	// file's terminating one is an error rather than a silent overwrite.
+	// open holds the files whose terminating chunk has not arrived.
+	open map[string]*os.File
+	// finalized names the files already closed, so a chunk arriving after a
+	// file's terminating one is an error rather than a silent append.
 	finalized map[string]struct{}
-	// order preserves emission order so the written paths read the way the
-	// generator produced them rather than the way a map iterates.
+	// order preserves emission order, so a report about an unterminated file
+	// names the first one the generator started rather than whichever the map
+	// happens to yield.
 	order   []string
 	written []string
 }
 
 func (s *fileStream) Context() context.Context { return s.ctx }
 
-// Send accumulates one chunk, writing the file out once its terminating chunk
-// arrives.
+// Send writes one chunk, closing the file once its terminating chunk arrives.
 func (s *fileStream) Send(msg *avrocpb.GenerateResponse) error {
 	path := msg.GetPath()
 	if path == "" {
@@ -59,40 +66,77 @@ func (s *fileStream) Send(msg *avrocpb.GenerateResponse) error {
 		return fmt.Errorf("generator emitted a chunk for already-completed file %q", path)
 	}
 
-	if s.pending == nil {
-		s.pending = make(map[string][]byte)
+	if s.open == nil {
+		s.open = make(map[string]*os.File)
 		s.finalized = make(map[string]struct{})
 	}
-	if _, open := s.pending[path]; !open {
+
+	f, ok := s.open[path]
+	if !ok {
+		dst, err := OutputPath(s.inv.Out, path)
+		if err != nil {
+			return fmt.Errorf("refusing to write %q: %w", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("failed to create output directory for %q: %w", dst, err)
+		}
+		f, err = os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("failed to create %q: %w", dst, err)
+		}
+		s.open[path] = f
 		s.order = append(s.order, path)
 	}
-	s.pending[path] = append(s.pending[path], msg.GetContent()...)
+
+	if _, err := f.Write(msg.GetContent()); err != nil {
+		return fmt.Errorf("failed to write %q: %w", f.Name(), err)
+	}
 
 	if !msg.GetLast() {
 		return nil
 	}
 
-	content := s.pending[path]
-	delete(s.pending, path)
-	if err := s.inv.WriteFile(path, content); err != nil {
-		return err
-	}
+	name := f.Name()
+	delete(s.open, path)
 	s.finalized[path] = struct{}{}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close %q: %w", name, err)
+	}
 	s.written = append(s.written, path)
 	return nil
 }
 
-// finish reports a generator that stopped with a file still unterminated. A
-// half-emitted file is a bug in the generator, and reporting it is what stops
-// the missing bytes turning up later as a compile error in the user's tree.
+// discard closes and removes every file whose terminating chunk never arrived,
+// so a half-written file is not left behind for a compiler to find later. It is
+// idempotent, and is deferred by Main so that it also covers a generator that
+// returned an error partway through.
+func (s *fileStream) discard() {
+	for path, f := range s.open {
+		name := f.Name()
+		_ = f.Close()
+		_ = os.Remove(name)
+		delete(s.open, path)
+	}
+}
+
+// finish reports a generator that stopped with a file still unterminated, and
+// discards it. A half-emitted file is a bug in the generator, and reporting it
+// is what stops the missing bytes turning up later as a compile error in the
+// user's tree.
 func (s *fileStream) finish() error {
-	if len(s.pending) == 0 {
+	if len(s.open) == 0 {
 		return nil
 	}
+
+	n := len(s.open)
+	var first string
 	for _, path := range s.order {
-		if _, open := s.pending[path]; open {
-			return fmt.Errorf("generator finished with %d unterminated file(s), the first being %q", len(s.pending), path)
+		if _, open := s.open[path]; open {
+			first = path
+			break
 		}
 	}
-	return fmt.Errorf("generator finished with %d unterminated file(s)", len(s.pending))
+	s.discard()
+
+	return fmt.Errorf("generator finished with %d unterminated file(s), the first being %q", n, first)
 }

--- a/internal/plugin/stream_test.go
+++ b/internal/plugin/stream_test.go
@@ -127,13 +127,44 @@ func TestFileStream(t *testing.T) {
 		}
 	})
 
-	t.Run("reports a file left unterminated", func(t *testing.T) {
-		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: t.TempDir()}}
+	t.Run("reports and discards a file left unterminated", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
 		if err := s.Send(chunk("user.go", "package pkg\n", false)); err != nil {
 			t.Fatal(err)
 		}
 		if err := s.finish(); err == nil {
 			t.Error("finish accepted a stream that left a file unterminated")
+		}
+
+		// The partial must not survive: a half-written source file in the
+		// output tree is a compile error a user would have to trace back here.
+		if _, err := os.Stat(filepath.Join(out, "user.go")); !os.IsNotExist(err) {
+			t.Errorf("the partial file was not discarded: %v", err)
+		}
+	})
+
+	t.Run("discard removes a partial file and is idempotent", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
+		if err := s.Send(chunk("a.go", "package pkg\n", false)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Send(chunk("b.go", "package pkg\n", true)); err != nil {
+			t.Fatal(err)
+		}
+
+		s.discard()
+		s.discard()
+
+		if _, err := os.Stat(filepath.Join(out, "a.go")); !os.IsNotExist(err) {
+			t.Errorf("the partial file was not discarded: %v", err)
+		}
+		// A file that was terminated is output, and discard must not touch it.
+		if _, err := os.Stat(filepath.Join(out, "b.go")); err != nil {
+			t.Errorf("discard removed a completed file: %v", err)
 		}
 	})
 

--- a/internal/plugin/stream_test.go
+++ b/internal/plugin/stream_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func chunk(path, content string, last bool) *avrocpb.GenerateResponse {
+	return &avrocpb.GenerateResponse{
+		Path:    proto.String(path),
+		Content: []byte(content),
+		Last:    proto.Bool(last),
+	}
+}
+
+func TestFileStream(t *testing.T) {
+	t.Run("reassembles a file from its chunks", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
+		for _, msg := range []*avrocpb.GenerateResponse{
+			chunk("pkg/user.go", "package pkg\n", false),
+			chunk("pkg/user.go", "// trailer\n", true),
+		} {
+			if err := s.Send(msg); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := s.finish(); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(out, "pkg", "user.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "package pkg\n// trailer\n"; string(got) != want {
+			t.Errorf("content = %q, want %q", string(got), want)
+		}
+	})
+
+	t.Run("interleaves two files", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
+		for _, msg := range []*avrocpb.GenerateResponse{
+			chunk("a.go", "a1", false),
+			chunk("b.go", "b1", false),
+			chunk("a.go", "a2", true),
+			chunk("b.go", "b2", true),
+		} {
+			if err := s.Send(msg); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := s.finish(); err != nil {
+			t.Fatal(err)
+		}
+
+		for name, want := range map[string]string{"a.go": "a1a2", "b.go": "b1b2"} {
+			got, err := os.ReadFile(filepath.Join(out, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != want {
+				t.Errorf("%s = %q, want %q", name, string(got), want)
+			}
+		}
+	})
+
+	t.Run("an empty file is one terminating chunk", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
+		if err := s.Send(chunk("empty.go", "", true)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.finish(); err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := os.Stat(filepath.Join(out, "empty.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("size = %d, want 0", info.Size())
+		}
+	})
+
+	t.Run("rejects a chunk with no path", func(t *testing.T) {
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: t.TempDir()}}
+		if err := s.Send(chunk("", "package pkg\n", true)); err == nil {
+			t.Error("Send accepted a chunk with no path")
+		}
+	})
+
+	t.Run("rejects a chunk after a file was terminated", func(t *testing.T) {
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: t.TempDir()}}
+		if err := s.Send(chunk("user.go", "package pkg\n", true)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Send(chunk("user.go", "// extra\n", true)); err == nil {
+			t.Error("Send accepted a chunk for an already-completed file")
+		}
+	})
+
+	t.Run("rejects a path outside the output directory", func(t *testing.T) {
+		out := t.TempDir()
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: out}}
+
+		if err := s.Send(chunk("../escape.go", "package pkg\n", true)); err == nil {
+			t.Error("Send accepted a path outside the output directory")
+		}
+		if _, err := os.Stat(filepath.Join(filepath.Dir(out), "escape.go")); !os.IsNotExist(err) {
+			t.Error("a file escaped the output directory")
+		}
+	})
+
+	t.Run("reports a file left unterminated", func(t *testing.T) {
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: t.TempDir()}}
+		if err := s.Send(chunk("user.go", "package pkg\n", false)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.finish(); err == nil {
+			t.Error("finish accepted a stream that left a file unterminated")
+		}
+	})
+
+	t.Run("nothing sent is not a failure", func(t *testing.T) {
+		s := &fileStream{ctx: t.Context(), inv: &Invocation{Out: t.TempDir()}}
+		if err := s.finish(); err != nil {
+			t.Errorf("finish reported a failure for a generator that emitted nothing: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #114

Replaces the socket rendezvous and gRPC client in `internal/avroc` with fork/exec and an
argument vector. A generator is an executable, not a server: avroc writes the descriptor,
runs `avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]`, and waits for it
to exit.

## Acceptance criteria

- [x] **avroc runs `avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]`.**
      `generatorArgs` builds exactly that vector and nothing else; both paths are absolute,
      so two runs from different working directories are the same invocation.
- [x] **No temporary socket is created; `grpc.NewClient`, the passthrough resolver and the
      custom Unix dialer are gone from the invocation path.** `internal/avroc` no longer
      imports `net`, `grpc` or `credentials/insecure`, and `writeStream`/`startGenerator`
      are deleted.
- [x] **Generators still run concurrently.** `runGenerate` is unchanged: one
      `sourcegraph/conc` pool task per generator.
- [x] **Cancellation still flows from the signal-based parent context to the child process,
      and children are reaped on success, failure and cancellation.** `exec.CommandContext`
      with the parent context kills the child when it is done, and `cmd.Run` waits on it in
      every case. `TestGeneratorGenerateCancellation` drives a live child and asserts it.
- [x] **`AVROC_GENERATOR_ARGS` is re-evaluated: either specified in `docs/plugin/SPEC.md` or
      removed.** Removed — the spec already records it as removed under this issue's number,
      so no spec change was needed. The `env` field on `generator` goes with it.
- [x] **The invocation matches `docs/plugin/SPEC.md` exactly.** Separated form only, options
      in the order the manifest fixed, nothing taken from the environment, descriptor written
      in full and closed before the child starts and removed once it has exited.
- [x] **`go test -race ./...` passes.**

## The defect this turned up

`lookupGenerators` assigned into the index unconditionally as it walked `PATH`, so the
**last** entry won. `docs/plugin/SPEC.md`'s Discovery section — which this issue implements —
requires the earliest match to win, "exactly as it does for a shell resolving a command
name", precisely so that prepending a directory shadows an installed generator with one
under development. It bit this branch immediately: the example round-trip ran stale
generators out of `~/go/bin` while `$PWD/bin` was first on `PATH`. Fixed, with a test. An
empty `PATH` element is now skipped rather than resolving to the working directory, which
the same section forbids.

## Judgment calls

**The generators had to move too, and this keeps that minimal.** `--descriptor`/`--out` is
useless if nothing accepts it, and the example round-trip in the verify list is an
end-to-end test of exactly that. `internal/plugin` is the generator's half of the contract:
`ParseArgs`, `ReadDescriptor` (including `-` for stdin) and a write beneath `--out`. Each
generator's `Main` becomes one line through it, and the Unix listener and gRPC server go
with the socket that required them. What is deliberately **not** done here is the rest of
#121–#123: the generators still emit chunks internally through the `Generator` service's
stream type, reassembled in-process by one adapter (`internal/plugin/stream.go`), so those
stories keep their substance — `--plugin-info`, the diagnostic format, deleting the
independent resolver, determinism — rather than being half-landed under this number.

**Options travel twice, and the command line wins.** `docs/ir/SPEC.md` puts the option pairs
in the descriptor; `docs/plugin/SPEC.md` says a generator is configured through `--opt`.
avroc emits the same pairs in the same order in both places, so they never disagree; the
plugin helper believes the vector, which is what keeps a descriptor saved from a failing run
re-runnable by hand with the options changed.

**`--out` is the project's own output directory, not a private empty scratch directory.**
avroc creates it and nothing more. Making it empty and private, enforcing the boundary and
merging into the project tree is #117's, as the spec's mapping table assigns it — so
`safeOutputPath` stays in `internal/avroc` for that story. In the meantime the plugin helper
refuses a path that would leave `--out`, so the generators in this repository cannot break
the rule while avroc is not yet watching.

**The stand-in generator in the tests is a shell script.** The old tests re-invoked the test
binary through `AVROC_GENERATOR_ARGS`, which this change removes. A script is the better
replacement anyway: the spec claims the contract is "small enough that a generator can be a
shell script", and a test driving one holds avroc to that.

## Verification

All four `.claude/backlog.json` verify commands, locally:

- `go build ./...`
- `go test -race -cover ./...` — `internal/avroc` 83.6%, new `internal/plugin` 94.8%
- `golangci-lint run` — 0 issues
- the example round-trip: build the four binaries, `avroc generate` in `example/`,
  `git diff --exit-code -- example` clean

Docs updated where they described the socket as current: `CLAUDE.md`, the architecture and
"Writing a Custom Generator" sections of `README.md` (the full rewrite is #131), and the
stale note in `CONTRIBUTING.md` about why the round-trip is not yet in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)