### PR TITLE
story(plugin): define exit codes and the stderr diagnostic format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,14 @@ go test -v ./...
 
 1. avroc writes the descriptor into a directory created for that one invocation.
 2. avroc forks and execs `avroc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]`, both paths absolute, and waits for it to exit. Nothing else is on the vector, and in particular nothing comes from the environment — `AVROC_GENERATOR_ARGS` is gone.
-3. The generator writes its own files beneath `--out` and reports on stderr. A zero exit is the whole of the success signal.
+3. The generator writes its own files beneath `--out` and reports on stderr. A zero exit is the whole of the success signal; anything else fails the run, and nothing the generator left behind is adopted as output.
 4. Generators run concurrently via `sourcegraph/conc` pools. Cancellation flows from the signal-based parent context through `exec.CommandContext`, and every child is waited on — on success, on failure and on cancellation.
+
+### Diagnostics and the exit status
+
+Standard error is the diagnostic channel, and avroc reads it rather than inheriting it. Every line lands in avroc's structured log attributed to the generator: a `<severity>: <message>` line at the level its severity names — `error`, `warning`, `note` — carrying a `severity` attribute, and **any other line verbatim at warning level**, as it arrives rather than held until the process exits. `internal/avroc/diagnostic.go` is the parser; `internal/plugin.DiagnosticHandler` is the producer every generator here logs through, so a generator in this repository is held to the format a third-party one is held to.
+
+A failed invocation is reported as one of three things, because they need different responses: a generator that never ran, one that **exited non-zero** (a bug in the generator — the code is reported and nothing is concluded from its value), and one **terminated by a signal**, named as such (usually the run being cancelled or the machine running out of memory).
 
 Discovery is a `PATH` search in order, and **the earliest match wins**, exactly as it does for a shell: prepending a directory is how an author shadows an installed generator with one under development. An empty `PATH` element is not the working directory.
 

--- a/cmd/avroc-gen-go/main.go
+++ b/cmd/avroc-gen-go/main.go
@@ -14,6 +14,7 @@ import (
 
 	avrocgengo "github.com/z5labs/avroc/internal/avroc-gen-go"
 	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
 func main() {
@@ -21,9 +22,10 @@ func main() {
 	defer cancel()
 
 	code := avrocgengo.Main(ctx, cli.Context{
-		Log: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			AddSource: true,
-		})),
+		// Diagnostics go to standard error in docs/plugin/SPEC.md's format, so
+		// that avroc parses them back into its own structured log at the level
+		// the generator meant rather than surfacing a slog dump verbatim.
+		Log: slog.New(plugin.NewDiagnosticHandler(os.Stderr, nil)),
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),

--- a/cmd/avroc-gen-json/main.go
+++ b/cmd/avroc-gen-json/main.go
@@ -14,6 +14,7 @@ import (
 
 	avrocgenjson "github.com/z5labs/avroc/internal/avroc-gen-json"
 	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
 func main() {
@@ -21,9 +22,10 @@ func main() {
 	defer cancel()
 
 	code := avrocgenjson.Main(ctx, cli.Context{
-		Log: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			AddSource: true,
-		})),
+		// Diagnostics go to standard error in docs/plugin/SPEC.md's format, so
+		// that avroc parses them back into its own structured log at the level
+		// the generator meant rather than surfacing a slog dump verbatim.
+		Log: slog.New(plugin.NewDiagnosticHandler(os.Stderr, nil)),
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),

--- a/cmd/avroc-gen-pcf/main.go
+++ b/cmd/avroc-gen-pcf/main.go
@@ -14,6 +14,7 @@ import (
 
 	avrocgenpcf "github.com/z5labs/avroc/internal/avroc-gen-pcf"
 	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/plugin"
 )
 
 func main() {
@@ -21,9 +22,10 @@ func main() {
 	defer cancel()
 
 	code := avrocgenpcf.Main(ctx, cli.Context{
-		Log: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			AddSource: true,
-		})),
+		// Diagnostics go to standard error in docs/plugin/SPEC.md's format, so
+		// that avroc parses them back into its own structured log at the level
+		// the generator meant rather than surfacing a slog dump verbatim.
+		Log: slog.New(plugin.NewDiagnosticHandler(os.Stderr, nil)),
 		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
 			return os.LookupEnv(key)
 		}),

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -370,6 +370,13 @@ diagnostic that needs more than one line **MUST** be written as one `error:` or
 fully-qualified name of the schema or field it is about, because that is the
 only location a plugin has: it never sees the `.avdl` a user wrote.
 
+The severity **MUST** open the line, the separator **MUST** be a colon and a
+single space, and the message **MUST NOT** be empty. Each of those is what tells
+a diagnostic from the ordinary output of a program that also writes to standard
+error: a line indented under a stack trace, an `error:something` with no space,
+and a bare `error: ` say nothing a level could be attached to, and avroc treats
+all three as text rather than guessing (#115).
+
 ```
 error: com.example.User.created_at: logical type "duration" is not supported
 note: com.example.User.created_at: declared as fixed(12)
@@ -382,6 +389,13 @@ discarded and never held back until the process exits: an unrecognised line is
 usually a panic, a stack trace or a library writing to stderr on its own
 account, and those are exactly what a user needs to see when a generator fails
 in a way its author did not anticipate.
+
+The levels are `error:` to error, `warning:` to warning and `note:` to info. A
+line that is not a diagnostic is recorded at **warning**, one level above the
+`note:` a plugin writes deliberately — info is where a log is ordinarily
+threshold-ed, so a handler configured a notch above it would drop exactly the
+panic this rule exists to surface, and a line avroc could not classify is not one
+to file under the mildest severity it has.
 
 A plugin that writes an `error:` diagnostic **MUST** exit non-zero, and a plugin
 that exits non-zero **SHOULD** write at least one `error:` diagnostic saying

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/z5labs/avroc/avrocpb"
@@ -186,6 +187,11 @@ const generatorWaitDelay = 5 * time.Second
 // There is no socket, no client and no stream. The generator writes its own
 // files beneath output and says what went wrong on stderr; a zero exit is the
 // whole of the success signal.
+//
+// Anything else fails the run, and nothing the generator left behind is adopted
+// as output. Discarding a private scratch directory rather than merging it is
+// that same rule once #117 gives a generator one; today --out is the project's
+// own directory and there is no merge step to withhold.
 func (g generator) generate(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (err error) {
 	desc := newDescriptor(options, schemas)
 
@@ -246,16 +252,68 @@ func (g generator) generate(ctx context.Context, output string, options []*avroc
 	// never through the "-" form the contract also allows.
 	cmd.Stdin = nil
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// Standard error is the diagnostic channel, so it is read rather than
+	// inherited: every line lands in avroc's structured log, attributed to the
+	// generator that wrote it. An io.Writer rather than a StderrPipe on purpose
+	// — exec copies into it from a goroutine that WaitDelay bounds, where a pipe
+	// read of avroc's own would hang on a grandchild holding the descriptor open
+	// and never reach the Wait that gives up on it.
+	stderr := newStderrDiagnostics(ctx, g.log, g.name)
+	cmd.Stderr = stderr
 	cmd.WaitDelay = generatorWaitDelay
 
-	if err := cmd.Run(); err != nil {
-		g.log.ErrorContext(ctx, "generator failed", slog.String("generator", g.name), slog.Any("error", err))
-		return fmt.Errorf("generator %q failed: %w", g.name, err)
+	runErr := cmd.Run()
+	// After the wait, so that the copy is finished and the last line — which a
+	// generator killed mid-write may have left without its newline — is recorded
+	// rather than being the one thing avroc swallows.
+	stderr.flush()
+	if runErr != nil {
+		return g.reportFailure(ctx, runErr)
 	}
 
 	g.log.InfoContext(ctx, "generated output", slog.String("generator", g.name), slog.String("out", outputDir))
 	return nil
+}
+
+// reportFailure logs and describes an invocation that did not succeed, telling
+// docs/plugin/SPEC.md's three cases apart.
+//
+// A generator terminated by a signal is named as terminated by that signal, and
+// distinguishably from one that exited non-zero, because the two need different
+// responses: a non-zero exit is a bug in the generator, while a signal is
+// usually the run being cancelled or the machine running out of memory. A report
+// that flattened them would send the user looking in the wrong place. The third
+// case is a generator that never ran at all — a file that lost its execute bit
+// between discovery and invocation — which is neither.
+//
+// No meaning is attached to a particular non-zero value beyond failure. The
+// small integers are already spoken for by parties this contract does not
+// control, so the code is reported and nothing is concluded from it.
+func (g generator) reportFailure(ctx context.Context, runErr error) error {
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) {
+		g.log.ErrorContext(ctx, "failed to run generator",
+			slog.String("generator", g.name),
+			slog.Any("error", runErr),
+		)
+		return fmt.Errorf("generator %q failed to run: %w", g.name, runErr)
+	}
+
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		signal := status.Signal()
+		g.log.ErrorContext(ctx, "generator terminated by signal",
+			slog.String("generator", g.name),
+			slog.String("signal", signal.String()),
+			slog.Int("signal_number", int(signal)),
+		)
+		return fmt.Errorf("generator %q was terminated by signal %s (%d): %w", g.name, signal, int(signal), runErr)
+	}
+
+	g.log.ErrorContext(ctx, "generator exited non-zero",
+		slog.String("generator", g.name),
+		slog.Int("exit_code", exitErr.ExitCode()),
+	)
+	return fmt.Errorf("generator %q exited with status %d: %w", g.name, exitErr.ExitCode(), runErr)
 }
 
 // generatorArgs builds the argument vector docs/plugin/SPEC.md specifies:

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -450,21 +450,78 @@ func TestGeneratorGenerate(t *testing.T) {
 }
 
 // TestGeneratorGenerateNonZeroExit is the whole of the failure signal: a
-// non-zero exit fails the run, and the descriptor is still removed.
+// non-zero exit fails the run whatever the generator left on disk, the status is
+// reported without anything being concluded from its value, and the descriptor
+// is still removed.
 func TestGeneratorGenerateNonZeroExit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	g := testGenerator(t, writeShellGenerator(t, "echo 'error: nope' >&2\nexit 3\n"))
+	log, records := recordingLogger()
+	// Partial output before the failure, because a plugin MAY exit non-zero with
+	// files already written: what avroc does with them is decided by the exit
+	// status and not by their presence.
+	g := testGenerator(t, writeShellGenerator(t, `set -e
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) out=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf 'package half\n' > "$out/half.go"
+echo 'error: com.example.User: nope' >&2
+exit 3
+`))
+	g.log = log
 
 	before := descriptorDirs(t)
 
-	err := g.generate(ctx, t.TempDir(), nil, testSchema("User"))
+	outputDir := t.TempDir()
+	err := g.generate(ctx, outputDir, nil, testSchema("User"))
 	if err == nil {
 		t.Fatal("generate accepted a generator that exited non-zero")
 	}
 	if !strings.Contains(err.Error(), testGeneratorName) {
 		t.Errorf("error %q does not name the generator", err)
+	}
+	// Distinguishable from the signal case, which is the whole point of
+	// reporting them separately.
+	if !strings.Contains(err.Error(), "exited with status 3") {
+		t.Errorf("error %q does not report the exit status", err)
+	}
+	if strings.Contains(err.Error(), "signal") {
+		t.Errorf("error %q reports a generator that exited as one that was signalled", err)
+	}
+
+	var reported bool
+	for _, r := range records() {
+		switch r.message {
+		case "generator exited non-zero":
+			reported = true
+			if r.attrs["exit_code"] != "3" {
+				t.Errorf("exit_code attribute = %q, want %q", r.attrs["exit_code"], "3")
+			}
+			if r.attrs["generator"] != testGeneratorName {
+				t.Errorf("generator attribute = %q, want %q", r.attrs["generator"], testGeneratorName)
+			}
+		case "generated output":
+			t.Error("a failed invocation was reported as having generated output")
+		}
+	}
+	if !reported {
+		t.Errorf("nothing in the log reports the exit status: %v", records())
+	}
+
+	// The generator's diagnostic still reached the log: a failing run is the one
+	// where its explanation matters most.
+	var diagnosed bool
+	for _, r := range records() {
+		if r.message == "com.example.User: nope" && r.attrs["severity"] == "error" {
+			diagnosed = true
+		}
+	}
+	if !diagnosed {
+		t.Errorf("the failing generator's diagnostic is not in the log: %v", records())
 	}
 
 	for dir := range descriptorDirs(t) {

--- a/internal/avroc/diagnostic.go
+++ b/internal/avroc/diagnostic.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// severityLevel maps one of docs/plugin/SPEC.md's three severities onto the
+// level avroc records it at, reporting whether the string is a severity at all.
+//
+// The set is closed and matched case-sensitively, exactly as the contract writes
+// it: a generator emitting "Error:" has not written a diagnostic, and guessing
+// that it meant to would make the set open in practice while the spec calls it
+// closed.
+func severityLevel(severity string) (slog.Level, bool) {
+	switch severity {
+	case "error":
+		return slog.LevelError, true
+	case "warning":
+		return slog.LevelWarn, true
+	case "note":
+		return slog.LevelInfo, true
+	default:
+		return 0, false
+	}
+}
+
+// diagnosticSeparator is what stands between a severity and its message.
+//
+// A colon and a single space, because that is the form docs/plugin/SPEC.md
+// writes and the one a generator copying the example produces. Accepting a bare
+// colon as well would make "error:no such type" a diagnostic whose message
+// begins mid-word, and accepting arbitrary spacing would make two generators
+// that agree on the format disagree on the message.
+const diagnosticSeparator = ": "
+
+// parseDiagnostic splits one line of a generator's standard error into the
+// severity and message docs/plugin/SPEC.md specifies:
+//
+//	<severity>: <message>
+//
+// It reports false for anything else, which is never an error: an unrecognised
+// line is surfaced verbatim rather than discarded, so the only thing riding on
+// this decision is whether the line carries a level avroc can believe.
+//
+// The severity occupies the start of the line — a line opening with whitespace
+// is not a diagnostic — and the message runs to the end of it. A message may
+// contain further colons, which is what the leading "com.example.User.field:"
+// the contract asks for is made of, so the split is at the first separator and
+// not the last.
+func parseDiagnostic(line string) (severity, message string, ok bool) {
+	severity, message, found := strings.Cut(line, diagnosticSeparator)
+	if !found {
+		return "", "", false
+	}
+	if _, known := severityLevel(severity); !known {
+		return "", "", false
+	}
+	// A severity with nothing after it says nothing. Reporting it as a
+	// diagnostic would produce an empty log record where the line was; failing
+	// the match surfaces the line as it was written, which loses less.
+	if message == "" {
+		return "", "", false
+	}
+	return severity, message, true
+}
+
+// maxDiagnosticLine bounds how much of an unterminated line avroc buffers before
+// it gives up waiting for the newline and records what it has.
+//
+// A generator that writes without ever terminating a line is misbehaving, but
+// avroc holding its output in memory until it stops is avroc's bug rather than
+// the generator's: the contract says nothing about how much a generator may
+// write. The bound turns that into a long line recorded in pieces, which is
+// still every byte the generator wrote, in order.
+const maxDiagnosticLine = 1 << 20 // 1 MiB
+
+// stderrDiagnostics is the io.Writer avroc hands a generator's standard error.
+// It splits the stream into lines and records each one in avroc's structured
+// log, attributed to the generator: a line of docs/plugin/SPEC.md's diagnostic
+// form at the level its severity names, carrying a "severity" attribute, and
+// anything else verbatim at warning level without one.
+//
+// Warning is the level for a line that is not a diagnostic because the line is
+// most often a panic, a stack trace, or a library writing to standard error on
+// its own account — what a user needs to see when a generator fails in a way its
+// author did not anticipate. Info is the level an ordinary handler is configured
+// at, so a handler set one notch above would drop exactly that.
+//
+// Lines are recorded as they arrive rather than held until the process exits,
+// which is what makes a generator that hangs after complaining still tell the
+// user what it complained about.
+type stderrDiagnostics struct {
+	// ctx is the invocation's context, held because io.Writer has no parameter
+	// to pass one through and this writer's lifetime is exactly that of the
+	// generator whose stream it is reading.
+	ctx       context.Context
+	log       *slog.Logger
+	generator string
+
+	// mu guards line. exec's copy goroutine is the only ordinary writer, but
+	// flush runs on the goroutine that waited on the process, and a WaitDelay
+	// that expires lets Wait return while that copy is still in progress.
+	mu   sync.Mutex
+	line []byte
+}
+
+func newStderrDiagnostics(ctx context.Context, log *slog.Logger, generator string) *stderrDiagnostics {
+	return &stderrDiagnostics{
+		ctx:       ctx,
+		log:       log,
+		generator: generator,
+	}
+}
+
+// Write consumes whatever part of the stream it is given, which may be any
+// number of whole lines, part of one, or several of each. It never reports an
+// error: refusing bytes here would make the generator's own writes to standard
+// error fail, and a diagnostic avroc could not record is still one the generator
+// was entitled to write.
+func (w *stderrDiagnostics) Write(p []byte) (int, error) {
+	n := len(p)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for len(p) > 0 {
+		// Never more than the bound in one go, so that a generator writing a
+		// megabyte in a single call is held to the same limit as one writing it
+		// a byte at a time.
+		chunk := p
+		if room := maxDiagnosticLine - len(w.line); len(chunk) > room {
+			chunk = chunk[:room]
+		}
+
+		if i := bytes.IndexByte(chunk, '\n'); i >= 0 {
+			w.line = append(w.line, chunk[:i]...)
+			w.emitLocked()
+			p = p[i+1:]
+			continue
+		}
+
+		w.line = append(w.line, chunk...)
+		p = p[len(chunk):]
+		if len(w.line) >= maxDiagnosticLine {
+			w.emitLocked()
+		}
+	}
+
+	return n, nil
+}
+
+// flush records a final line that arrived without a trailing newline. It is
+// called once the process has been waited on, so that a generator whose last
+// diagnostic lacked its newline is not the one line avroc swallows.
+func (w *stderrDiagnostics) flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.emitLocked()
+}
+
+// emitLocked records the buffered line and resets the buffer. It must be called
+// with mu held, and does nothing when there is nothing buffered — an empty line
+// on standard error carries no information and a log record made of one is
+// noise.
+func (w *stderrDiagnostics) emitLocked() {
+	if len(w.line) == 0 {
+		return
+	}
+	line := string(w.line)
+	w.line = w.line[:0]
+
+	if severity, message, ok := parseDiagnostic(line); ok {
+		level, _ := severityLevel(severity)
+		w.log.LogAttrs(w.ctx, level, message,
+			slog.String("generator", w.generator),
+			slog.String("severity", severity),
+		)
+		return
+	}
+
+	w.log.LogAttrs(w.ctx, slog.LevelWarn, line,
+		slog.String("generator", w.generator),
+	)
+}

--- a/internal/avroc/diagnostic_test.go
+++ b/internal/avroc/diagnostic_test.go
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/z5labs/avroc/internal/plugin"
+)
+
+// TestParseDiagnostic pins docs/plugin/SPEC.md's diagnostic format: the closed
+// set of three severities, matched case-sensitively, a colon and a space, and a
+// message that runs to the end of the line.
+func TestParseDiagnostic(t *testing.T) {
+	testCases := []struct {
+		name         string
+		line         string
+		wantSeverity string
+		wantMessage  string
+		wantOK       bool
+	}{
+		{
+			name:         "an error naming the field it is about",
+			line:         `error: com.example.User.created_at: logical type "duration" is not supported`,
+			wantSeverity: "error",
+			wantMessage:  `com.example.User.created_at: logical type "duration" is not supported`,
+			wantOK:       true,
+		},
+		{
+			name:         "a warning",
+			line:         "warning: com.example.User: field order is ignored",
+			wantSeverity: "warning",
+			wantMessage:  "com.example.User: field order is ignored",
+			wantOK:       true,
+		},
+		{
+			name:         "a note continuing a diagnostic",
+			line:         "note: com.example.User.created_at: declared as fixed(12)",
+			wantSeverity: "note",
+			wantMessage:  "com.example.User.created_at: declared as fixed(12)",
+			wantOK:       true,
+		},
+		{
+			name:        "a severity is matched case-sensitively",
+			line:        "Error: something went wrong",
+			wantMessage: "",
+		},
+		{
+			name: "a severity outside the closed set of three",
+			line: "fatal: something went wrong",
+		},
+		{
+			name: "a colon with no space after it",
+			line: "error:something went wrong",
+		},
+		{
+			name: "a severity with no message",
+			line: "error: ",
+		},
+		{
+			name: "a line opening with whitespace is not a diagnostic",
+			line: "  error: indented by a stack trace",
+		},
+		{
+			name: "a panic",
+			line: "panic: runtime error: invalid memory address or nil pointer dereference",
+		},
+		{
+			name: "a line with no colon at all",
+			line: "goroutine 1 [running]:",
+		},
+		{
+			name: "an empty line",
+			line: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			severity, message, ok := parseDiagnostic(tc.line)
+			if ok != tc.wantOK {
+				t.Fatalf("parseDiagnostic(%q) ok = %t, want %t", tc.line, ok, tc.wantOK)
+			}
+			if severity != tc.wantSeverity {
+				t.Errorf("severity = %q, want %q", severity, tc.wantSeverity)
+			}
+			if message != tc.wantMessage {
+				t.Errorf("message = %q, want %q", message, tc.wantMessage)
+			}
+		})
+	}
+}
+
+// TestSeverityLevel is the mapping avroc records each severity at, and the
+// closedness of the set on the other side of it.
+func TestSeverityLevel(t *testing.T) {
+	testCases := []struct {
+		severity string
+		want     slog.Level
+		wantOK   bool
+	}{
+		{severity: "error", want: slog.LevelError, wantOK: true},
+		{severity: "warning", want: slog.LevelWarn, wantOK: true},
+		{severity: "note", want: slog.LevelInfo, wantOK: true},
+		{severity: "fatal"},
+		{severity: "ERROR"},
+		{severity: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.severity, func(t *testing.T) {
+			level, ok := severityLevel(tc.severity)
+			if ok != tc.wantOK {
+				t.Fatalf("severityLevel(%q) ok = %t, want %t", tc.severity, ok, tc.wantOK)
+			}
+			if ok && level != tc.want {
+				t.Errorf("level = %v, want %v", level, tc.want)
+			}
+		})
+	}
+}
+
+// TestStderrDiagnostics is what avroc does with a generator's standard error:
+// every line recorded, a diagnostic at the level its severity names, anything
+// else verbatim, and nothing held back or discarded.
+func TestStderrDiagnostics(t *testing.T) {
+	t.Run("a diagnostic is recorded at the level its severity names", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		writeAll(t, w, "error: com.example.User: no\nwarning: com.example.User: hmm\nnote: because\n")
+
+		got := records()
+		if len(got) != 3 {
+			t.Fatalf("recorded %d lines, want 3: %v", len(got), got)
+		}
+
+		wantLevels := []slog.Level{slog.LevelError, slog.LevelWarn, slog.LevelInfo}
+		wantSeverities := []string{"error", "warning", "note"}
+		wantMessages := []string{"com.example.User: no", "com.example.User: hmm", "because"}
+		for i, r := range got {
+			if r.level != wantLevels[i] {
+				t.Errorf("line %d level = %v, want %v", i, r.level, wantLevels[i])
+			}
+			if r.message != wantMessages[i] {
+				t.Errorf("line %d message = %q, want %q", i, r.message, wantMessages[i])
+			}
+			if r.attrs["severity"] != wantSeverities[i] {
+				t.Errorf("line %d severity attribute = %q, want %q", i, r.attrs["severity"], wantSeverities[i])
+			}
+			// Attributed to the generator that wrote it, which is the only thing
+			// that tells two generators' output apart in one log.
+			if r.attrs["generator"] != testGeneratorName {
+				t.Errorf("line %d generator attribute = %q, want %q", i, r.attrs["generator"], testGeneratorName)
+			}
+		}
+	})
+
+	t.Run("an unparseable line is surfaced verbatim", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		const panicLine = "panic: runtime error: index out of range [3] with length 2"
+		writeAll(t, w, panicLine+"\ngoroutine 1 [running]:\n")
+
+		got := records()
+		if len(got) != 2 {
+			t.Fatalf("recorded %d lines, want 2: %v", len(got), got)
+		}
+		if got[0].message != panicLine {
+			t.Errorf("message = %q, want the line unchanged %q", got[0].message, panicLine)
+		}
+		// Warning, because a line that is not a diagnostic is most often what a
+		// user most needs to see, and info is the level a handler is ordinarily
+		// configured at.
+		if got[0].level != slog.LevelWarn {
+			t.Errorf("level = %v, want %v", got[0].level, slog.LevelWarn)
+		}
+		if _, ok := got[0].attrs["severity"]; ok {
+			t.Error("a line that is not a diagnostic was given a severity")
+		}
+		if got[0].attrs["generator"] != testGeneratorName {
+			t.Errorf("generator attribute = %q, want %q", got[0].attrs["generator"], testGeneratorName)
+		}
+	})
+
+	t.Run("a line split across writes is one line", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		for _, chunk := range []string{"err", "or: com.exa", "mple.User: no\nnote: ", "and here is why\n"} {
+			writeAll(t, w, chunk)
+		}
+
+		got := records()
+		if len(got) != 2 {
+			t.Fatalf("recorded %d lines, want 2: %v", len(got), got)
+		}
+		if got[0].message != "com.example.User: no" || got[0].level != slog.LevelError {
+			t.Errorf("first record = %v, want the reassembled error", got[0])
+		}
+		if got[1].message != "and here is why" || got[1].level != slog.LevelInfo {
+			t.Errorf("second record = %v, want the note", got[1])
+		}
+	})
+
+	t.Run("a last line without its newline is not swallowed", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		writeAll(t, w, "error: killed before the newline")
+		if got := records(); len(got) != 0 {
+			t.Fatalf("recorded %d lines before the flush, want 0: %v", len(got), got)
+		}
+
+		w.flush()
+
+		got := records()
+		if len(got) != 1 {
+			t.Fatalf("recorded %d lines, want 1: %v", len(got), got)
+		}
+		if got[0].message != "killed before the newline" {
+			t.Errorf("message = %q, want the unterminated line", got[0].message)
+		}
+
+		// Flushing again records nothing: the buffer is empty and a repeated
+		// line would be a diagnostic the generator never wrote.
+		w.flush()
+		if got := records(); len(got) != 1 {
+			t.Errorf("recorded %d lines after a second flush, want 1", len(got))
+		}
+	})
+
+	t.Run("an empty line records nothing", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		writeAll(t, w, "\n\n")
+		w.flush()
+
+		if got := records(); len(got) != 0 {
+			t.Errorf("recorded %d lines for blank input, want 0: %v", len(got), got)
+		}
+	})
+
+	t.Run("a line that never ends is recorded in pieces", func(t *testing.T) {
+		log, records := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		writeAll(t, w, strings.Repeat("x", maxDiagnosticLine+10))
+
+		got := records()
+		if len(got) != 1 {
+			t.Fatalf("recorded %d lines, want the buffer to have been given up on once", len(got))
+		}
+		if len(got[0].message) != maxDiagnosticLine {
+			t.Errorf("recorded %d bytes, want the %d-byte bound", len(got[0].message), maxDiagnosticLine)
+		}
+
+		w.flush()
+		if got := records(); len(got) != 2 || len(got[1].message) != 10 {
+			t.Errorf("the remainder of an unterminated line was lost: %v", got)
+		}
+	})
+
+	t.Run("Write reports every byte consumed", func(t *testing.T) {
+		log, _ := recordingLogger()
+		w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+
+		const p = "error: one\npartial"
+		n, err := w.Write([]byte(p))
+		if err != nil {
+			t.Fatalf("Write returned an error, which would fail the generator's own write: %v", err)
+		}
+		if n != len(p) {
+			t.Errorf("Write returned %d, want %d", n, len(p))
+		}
+	})
+}
+
+// TestGeneratorGenerateDiagnostics is the parsing on the real fork/exec path:
+// what a generator writes to standard error reaches avroc's structured log,
+// classified, attributed, and with the lines it could not classify intact.
+func TestGeneratorGenerateDiagnostics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	log, records := recordingLogger()
+	g := testGenerator(t, writeShellGenerator(t, `
+echo 'warning: com.example.User.id: field order is ignored' >&2
+echo 'note: com.example.User.id: declared as int' >&2
+echo 'Traceback (most recent call last):' >&2
+printf 'error: com.example.User: unterminated' >&2
+`))
+	g.log = log
+
+	if err := g.generate(ctx, t.TempDir(), nil, testSchema("User")); err != nil {
+		t.Fatalf("a generator that exited zero after complaining failed the run: %v", err)
+	}
+
+	byMessage := make(map[string]recordedLine)
+	for _, r := range records() {
+		byMessage[r.message] = r
+	}
+
+	testCases := []struct {
+		message      string
+		wantLevel    slog.Level
+		wantSeverity string
+	}{
+		{
+			message:      "com.example.User.id: field order is ignored",
+			wantLevel:    slog.LevelWarn,
+			wantSeverity: "warning",
+		},
+		{
+			message:      "com.example.User.id: declared as int",
+			wantLevel:    slog.LevelInfo,
+			wantSeverity: "note",
+		},
+		{
+			// Not a diagnostic, and surfaced rather than swallowed.
+			message:   "Traceback (most recent call last):",
+			wantLevel: slog.LevelWarn,
+		},
+		{
+			// The generator exited without terminating its last line.
+			message:      "com.example.User: unterminated",
+			wantLevel:    slog.LevelError,
+			wantSeverity: "error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.message, func(t *testing.T) {
+			got, ok := byMessage[tc.message]
+			if !ok {
+				t.Fatalf("nothing in the log carries %q", tc.message)
+			}
+			if got.level != tc.wantLevel {
+				t.Errorf("level = %v, want %v", got.level, tc.wantLevel)
+			}
+			if got.attrs["severity"] != tc.wantSeverity {
+				t.Errorf("severity attribute = %q, want %q", got.attrs["severity"], tc.wantSeverity)
+			}
+			if got.attrs["generator"] != testGeneratorName {
+				t.Errorf("generator attribute = %q, want %q", got.attrs["generator"], testGeneratorName)
+			}
+		})
+	}
+}
+
+// TestGeneratorGenerateSignal is docs/plugin/SPEC.md's other failure: a
+// generator killed by a signal is reported as killed by that signal, naming it,
+// and distinguishably from one that exited non-zero.
+func TestGeneratorGenerateSignal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	log, records := recordingLogger()
+	g := testGenerator(t, writeShellGenerator(t, "kill -TERM $$\n"))
+	g.log = log
+
+	err := g.generate(ctx, t.TempDir(), nil, testSchema("User"))
+	if err == nil {
+		t.Fatal("generate reported success for a generator killed by a signal")
+	}
+	if !strings.Contains(err.Error(), "terminated by signal") {
+		t.Errorf("error %q does not say the generator was terminated by a signal", err)
+	}
+	if !strings.Contains(err.Error(), "terminated") {
+		t.Errorf("error %q does not name the signal", err)
+	}
+	if !strings.Contains(err.Error(), testGeneratorName) {
+		t.Errorf("error %q does not name the generator", err)
+	}
+
+	var reported bool
+	for _, r := range records() {
+		if r.message != "generator terminated by signal" {
+			continue
+		}
+		reported = true
+		if r.attrs["signal"] != "terminated" {
+			t.Errorf("signal attribute = %q, want %q", r.attrs["signal"], "terminated")
+		}
+		if r.attrs["generator"] != testGeneratorName {
+			t.Errorf("generator attribute = %q, want %q", r.attrs["generator"], testGeneratorName)
+		}
+		if _, ok := r.attrs["exit_code"]; ok {
+			t.Error("a generator killed by a signal was reported with an exit code")
+		}
+	}
+	if !reported {
+		t.Errorf("nothing in the log reports the signal: %v", records())
+	}
+}
+
+// TestDiagnosticAgreement holds the two halves of the format to each other: what
+// internal/plugin writes for a generator is what avroc parses back, at the level
+// the generator meant.
+//
+// The two are separate packages either side of a process boundary and neither
+// imports the other, so nothing but a test like this notices when one of them
+// moves. A drift here is a generator whose errors reach the user as unclassified
+// lines — visible, which is why it would survive a long time.
+func TestDiagnosticAgreement(t *testing.T) {
+	testCases := []struct {
+		name         string
+		log          func(*slog.Logger)
+		wantSeverity string
+		wantLevel    slog.Level
+		wantMessage  string
+	}{
+		{
+			name:         "an error a generator refused work with",
+			log:          func(l *slog.Logger) { l.Error("com.example.User: package_name option is required") },
+			wantSeverity: "error",
+			wantLevel:    slog.LevelError,
+			wantMessage:  "com.example.User: package_name option is required",
+		},
+		{
+			name:         "a warning",
+			log:          func(l *slog.Logger) { l.Warn("com.example.User: field order is ignored") },
+			wantSeverity: "warning",
+			wantLevel:    slog.LevelWarn,
+			wantMessage:  "com.example.User: field order is ignored",
+		},
+		{
+			name:         "a note carrying attributes",
+			log:          func(l *slog.Logger) { l.Info("descriptor read", slog.Int("schemas", 2)) },
+			wantSeverity: "note",
+			wantLevel:    slog.LevelInfo,
+			wantMessage:  "descriptor read schemas=2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var written strings.Builder
+			tc.log(slog.New(plugin.NewDiagnosticHandler(&written, nil)))
+
+			log, records := recordingLogger()
+			w := newStderrDiagnostics(context.Background(), log, testGeneratorName)
+			writeAll(t, w, written.String())
+			w.flush()
+
+			got := records()
+			if len(got) != 1 {
+				t.Fatalf("%q parsed into %d records, want 1: %v", written.String(), len(got), got)
+			}
+			if got[0].attrs["severity"] != tc.wantSeverity {
+				t.Errorf("severity = %q, want %q", got[0].attrs["severity"], tc.wantSeverity)
+			}
+			if got[0].level != tc.wantLevel {
+				t.Errorf("level = %v, want %v", got[0].level, tc.wantLevel)
+			}
+			if got[0].message != tc.wantMessage {
+				t.Errorf("message = %q, want %q", got[0].message, tc.wantMessage)
+			}
+		})
+	}
+}
+
+// recordedLine is one slog record, reduced to what these tests assert on.
+type recordedLine struct {
+	level   slog.Level
+	message string
+	attrs   map[string]string
+}
+
+func (r recordedLine) String() string {
+	return fmt.Sprintf("%v %q %v", r.level, r.message, r.attrs)
+}
+
+// recordingLogger returns a logger that keeps every record, and the accessor
+// that reads them back. The accessor copies, so a caller ranging over it cannot
+// race the generator's stderr goroutine still writing into the handler.
+func recordingLogger() (*slog.Logger, func() []recordedLine) {
+	h := &recordingHandler{}
+	return slog.New(h), h.records
+}
+
+type recordingHandler struct {
+	mu    sync.Mutex
+	lines []recordedLine
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	line := recordedLine{
+		level:   r.Level,
+		message: r.Message,
+		attrs:   make(map[string]string),
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		line.attrs[a.Key] = a.Value.String()
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lines = append(h.lines, line)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) records() []recordedLine {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]recordedLine(nil), h.lines...)
+}
+
+func writeAll(t *testing.T, w *stderrDiagnostics, s string) {
+	t.Helper()
+
+	if _, err := w.Write([]byte(s)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/plugin/diagnostic.go
+++ b/internal/plugin/diagnostic.go
@@ -104,17 +104,30 @@ func (h *DiagnosticHandler) Handle(_ context.Context, r slog.Record) error {
 	severity := severityFor(r.Level)
 
 	var out strings.Builder
-	for i, line := range strings.Split(msg.String(), "\n") {
-		// The first line carries the record's severity and the rest continue it.
-		// A record split this way is one diagnostic, which is why the notes are
-		// written in the same call as the line they belong to.
-		if i > 0 {
-			severity = SeverityNote
+	for _, line := range strings.Split(msg.String(), "\n") {
+		// A blank line is not a diagnostic: the contract requires a message, and
+		// "note: " with nothing after it is a line avroc surfaces verbatim
+		// because it cannot classify it. Dropping it loses nothing — a trailing
+		// newline on a message and a blank line inside one are both formatting.
+		if line == "" {
+			continue
 		}
+
 		out.WriteString(severity)
 		out.WriteString(": ")
 		out.WriteString(line)
 		out.WriteString("\n")
+		// The first line carries the record's severity and the rest continue it.
+		// A record split this way is one diagnostic, which is why the notes are
+		// written in the same call as the line they belong to.
+		severity = SeverityNote
+	}
+
+	// A record with nothing to say is not written at all rather than as a
+	// severity with an empty message, which is the one form of the line the
+	// contract does not allow.
+	if out.Len() == 0 {
+		return nil
 	}
 
 	h.mu.Lock()
@@ -193,5 +206,10 @@ func writeAttr(msg *strings.Builder, groups []string, a slog.Attr) {
 	}
 
 	a = qualify(groups, a)
-	fmt.Fprintf(msg, " %s=%s", a.Key, a.Value.String())
+	// The separator goes between, not before: a record with an empty message and
+	// one attribute would otherwise render as a message opening with a space.
+	if msg.Len() > 0 {
+		msg.WriteByte(' ')
+	}
+	fmt.Fprintf(msg, "%s=%s", a.Key, a.Value.String())
 }

--- a/internal/plugin/diagnostic.go
+++ b/internal/plugin/diagnostic.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// Severity is one of docs/plugin/SPEC.md's three diagnostic severities. The set
+// is closed, and the spellings are the ones avroc matches, case-sensitively.
+const (
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+	SeverityNote    = "note"
+)
+
+// severityFor maps a log level onto the severity a generator writes it as.
+//
+// Everything below warning is a note, which is what the contract leaves for a
+// line that explains rather than complains. Nothing maps to no severity at all:
+// a record a generator chose to emit is one avroc should record, and dropping it
+// here would make the level threshold two decisions instead of one.
+func severityFor(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return SeverityError
+	case level >= slog.LevelWarn:
+		return SeverityWarning
+	default:
+		return SeverityNote
+	}
+}
+
+// DiagnosticHandler writes a generator's structured log to standard error in the
+// diagnostic format docs/plugin/SPEC.md specifies:
+//
+//	<severity>: <message>
+//
+// It is the producing half of a format avroc parses back into its own structured
+// log, and it exists so that a generator in this repository is held to the
+// contract a third-party generator is held to: a diagnostic is a line, not a
+// slog dump, and a user reading avroc's output sees the generator's error at
+// error level rather than a verbatim line avroc could not classify.
+//
+// A record whose message or attributes contain a newline becomes one severity
+// line followed by note: lines, which is the continuation the contract defines —
+// a message MUST NOT contain a newline, and a diagnostic needing more than one
+// line is written as one error: or warning: line and then notes.
+type DiagnosticHandler struct {
+	// mu guards w, and is shared with every handler derived from this one by
+	// WithAttrs or WithGroup: they write to the same file descriptor, and a
+	// diagnostic interleaved with another is a line neither avroc nor a person
+	// can read.
+	mu *sync.Mutex
+	w  io.Writer
+
+	level  slog.Leveler
+	attrs  []slog.Attr
+	groups []string
+}
+
+// NewDiagnosticHandler returns a handler writing diagnostics to w. A nil level
+// means slog's own default, which records everything from info upwards: debug
+// output is the generator author's, and a user running avroc has not asked for
+// it.
+func NewDiagnosticHandler(w io.Writer, level slog.Leveler) *DiagnosticHandler {
+	if level == nil {
+		level = slog.LevelInfo
+	}
+	return &DiagnosticHandler{
+		mu:    &sync.Mutex{},
+		w:     w,
+		level: level,
+	}
+}
+
+func (h *DiagnosticHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level.Level()
+}
+
+func (h *DiagnosticHandler) Handle(_ context.Context, r slog.Record) error {
+	var msg strings.Builder
+	msg.WriteString(r.Message)
+
+	// The handler's own attributes were qualified by the groups open when they
+	// were added, so they carry no groups now; the record's are qualified here
+	// by the groups open at the call.
+	for _, a := range h.attrs {
+		writeAttr(&msg, nil, a)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		writeAttr(&msg, h.groups, a)
+		return true
+	})
+
+	severity := severityFor(r.Level)
+
+	var out strings.Builder
+	for i, line := range strings.Split(msg.String(), "\n") {
+		// The first line carries the record's severity and the rest continue it.
+		// A record split this way is one diagnostic, which is why the notes are
+		// written in the same call as the line they belong to.
+		if i > 0 {
+			severity = SeverityNote
+		}
+		out.WriteString(severity)
+		out.WriteString(": ")
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	_, err := io.WriteString(h.w, out.String())
+	return err
+}
+
+func (h *DiagnosticHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	derived := h.clone()
+	for _, a := range attrs {
+		derived.attrs = append(derived.attrs, qualify(h.groups, a))
+	}
+	return derived
+}
+
+func (h *DiagnosticHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	derived := h.clone()
+	derived.groups = append(derived.groups, name)
+	return derived
+}
+
+func (h *DiagnosticHandler) clone() *DiagnosticHandler {
+	return &DiagnosticHandler{
+		mu:     h.mu,
+		w:      h.w,
+		level:  h.level,
+		attrs:  append([]slog.Attr(nil), h.attrs...),
+		groups: append([]string(nil), h.groups...),
+	}
+}
+
+// qualify prefixes an attribute's key with the groups open when it was added, so
+// that a handler holding it has already resolved where it came from.
+func qualify(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 {
+		return a
+	}
+	return slog.Attr{Key: strings.Join(groups, ".") + "." + a.Key, Value: a.Value}
+}
+
+// writeAttr appends one attribute to a diagnostic's message as " key=value",
+// flattening a group into one attribute per member.
+//
+// Empty attributes are skipped, as slog requires of a handler. The rendering is
+// deliberately plain: the message is what a person reads in avroc's log, and a
+// generator with something structured to say has the message itself to say it
+// in.
+func writeAttr(msg *strings.Builder, groups []string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+
+	if a.Value.Kind() == slog.KindGroup {
+		members := a.Value.Group()
+		if len(members) == 0 {
+			return
+		}
+		// A group attribute's own key opens a group for its members, and an
+		// empty key adds no level at all.
+		if a.Key != "" {
+			groups = append(append([]string(nil), groups...), a.Key)
+		}
+		for _, member := range members {
+			writeAttr(msg, groups, member)
+		}
+		return
+	}
+
+	a = qualify(groups, a)
+	fmt.Fprintf(msg, " %s=%s", a.Key, a.Value.String())
+}

--- a/internal/plugin/diagnostic_test.go
+++ b/internal/plugin/diagnostic_test.go
@@ -95,6 +95,38 @@ func TestDiagnosticHandler(t *testing.T) {
 			want: []string{"error: nope"},
 		},
 		{
+			// A message MUST NOT be empty, so a trailing newline is formatting
+			// rather than a second, blank diagnostic.
+			name: "a trailing newline does not become an empty note",
+			log:  func(l *slog.Logger) { l.Error("com.example.User: no\n") },
+			want: []string{"error: com.example.User: no"},
+		},
+		{
+			name: "a blank line inside a message is dropped",
+			log:  func(l *slog.Logger) { l.Error("first\n\nsecond") },
+			want: []string{
+				"error: first",
+				"note: second",
+			},
+		},
+		{
+			name: "a leading newline does not become an empty error",
+			log:  func(l *slog.Logger) { l.Error("\ncom.example.User: no") },
+			want: []string{"error: com.example.User: no"},
+		},
+		{
+			name: "an empty message with an attribute opens with the attribute",
+			log:  func(l *slog.Logger) { l.Error("", slog.String("generator", "avroc-gen-go")) },
+			want: []string{"error: generator=avroc-gen-go"},
+		},
+		{
+			// Nothing to say, so nothing written: a severity with an empty
+			// message is the one form of the line the contract does not allow.
+			name: "a record with nothing in it writes nothing",
+			log:  func(l *slog.Logger) { l.Error("") },
+			want: nil,
+		},
+		{
 			name: "debug is below the default level",
 			log:  func(l *slog.Logger) { l.Debug("generated output") },
 			want: nil,

--- a/internal/plugin/diagnostic_test.go
+++ b/internal/plugin/diagnostic_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestDiagnosticHandler is the format docs/plugin/SPEC.md specifies, from the
+// producing side: one line per record, opening with one of the three
+// severities, and a message that never carries a newline.
+func TestDiagnosticHandler(t *testing.T) {
+	testCases := []struct {
+		name string
+		log  func(*slog.Logger)
+		want []string
+	}{
+		{
+			name: "an error",
+			log: func(l *slog.Logger) {
+				l.Error("com.example.User.created_at: logical type is not supported")
+			},
+			want: []string{"error: com.example.User.created_at: logical type is not supported"},
+		},
+		{
+			name: "a warning",
+			log:  func(l *slog.Logger) { l.Warn("com.example.User: field order is ignored") },
+			want: []string{"warning: com.example.User: field order is ignored"},
+		},
+		{
+			name: "info is a note",
+			log:  func(l *slog.Logger) { l.Info("wrote 3 files") },
+			want: []string{"note: wrote 3 files"},
+		},
+		{
+			name: "attributes are appended to the message",
+			log: func(l *slog.Logger) {
+				l.Error("failed to generate",
+					slog.String("generator", "avroc-gen-go"),
+					slog.Any("error", errors.New("package_name option is required")),
+				)
+			},
+			want: []string{"error: failed to generate generator=avroc-gen-go error=package_name option is required"},
+		},
+		{
+			name: "a multi-line message continues as notes",
+			log:  func(l *slog.Logger) { l.Error("first\nsecond\nthird") },
+			want: []string{
+				"error: first",
+				"note: second",
+				"note: third",
+			},
+		},
+		{
+			name: "an attribute value with a newline continues as a note",
+			log: func(l *slog.Logger) {
+				l.Error("failed to generate", slog.Any("error", errors.New("no such type:\n\twanted int")))
+			},
+			want: []string{
+				"error: failed to generate error=no such type:",
+				"note: \twanted int",
+			},
+		},
+		{
+			name: "handler attributes precede the record's",
+			log: func(l *slog.Logger) {
+				l.With(slog.String("generator", "avroc-gen-pcf")).Warn("slow", slog.Int("schemas", 400))
+			},
+			want: []string{"warning: slow generator=avroc-gen-pcf schemas=400"},
+		},
+		{
+			name: "a group qualifies the keys beneath it",
+			log: func(l *slog.Logger) {
+				l.WithGroup("descriptor").Error("unreadable", slog.Int("version", 2))
+			},
+			want: []string{"error: unreadable descriptor.version=2"},
+		},
+		{
+			name: "a group attribute is flattened into its members",
+			log: func(l *slog.Logger) {
+				l.Error("unreadable", slog.Group("descriptor", slog.Int("version", 2), slog.String("path", "/tmp/d")))
+			},
+			want: []string{"error: unreadable descriptor.version=2 descriptor.path=/tmp/d"},
+		},
+		{
+			name: "an empty attribute is skipped",
+			log:  func(l *slog.Logger) { l.Error("nope", slog.Attr{}) },
+			want: []string{"error: nope"},
+		},
+		{
+			name: "debug is below the default level",
+			log:  func(l *slog.Logger) { l.Debug("generated output") },
+			want: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			tc.log(slog.New(NewDiagnosticHandler(&buf, nil)))
+
+			var got []string
+			if out := buf.String(); out != "" {
+				if !strings.HasSuffix(out, "\n") {
+					t.Errorf("output %q does not end in a newline; a diagnostic is a whole line", out)
+				}
+				got = strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("wrote %q, want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("line %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestDiagnosticHandlerLevel is the threshold a generator can lower when its own
+// author wants the notes it writes at debug.
+func TestDiagnosticHandlerLevel(t *testing.T) {
+	var buf strings.Builder
+	log := slog.New(NewDiagnosticHandler(&buf, slog.LevelDebug))
+
+	log.Debug("descriptor read", slog.Int("schemas", 2))
+
+	if want := "note: descriptor read schemas=2\n"; buf.String() != want {
+		t.Errorf("wrote %q, want %q", buf.String(), want)
+	}
+}
+
+// TestDiagnosticHandlerConcurrentWrites is why the mutex is shared with every
+// derived handler: two goroutines logging through handlers that differ only in
+// their attributes still write to one file descriptor, and a diagnostic
+// interleaved with another is a line neither avroc nor a person can read.
+func TestDiagnosticHandlerConcurrentWrites(t *testing.T) {
+	var buf syncBuffer
+	log := slog.New(NewDiagnosticHandler(&buf, nil))
+
+	const goroutines, perGoroutine = 8, 50
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				log.With(slog.Int("worker", i)).Error("com.example.User: no")
+			}
+		}()
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(lines) != goroutines*perGoroutine {
+		t.Fatalf("wrote %d lines, want %d", len(lines), goroutines*perGoroutine)
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "error: com.example.User: no worker=") {
+			t.Fatalf("line %q is not a whole diagnostic", line)
+		}
+	}
+}
+
+// syncBuffer is an io.Writer whose writes may overlap, so that a handler that
+// did not serialise them would produce interleaved lines rather than a data
+// race the test could only sometimes catch.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
Closes #115

With no structured response, the exit code and stderr are the entire error channel. This
gives both a shape avroc can act on: standard error is read rather than inherited, and a
failed invocation is classified instead of being reported as one undifferentiated failure.

## Acceptance criteria

- [x] **Zero and non-zero exit statuses have specified meanings, documented in `docs/plugin/SPEC.md`.**
  The *Exit codes and diagnostics* section already carried them from #106; this adds what
  the implementation needed pinned — the separator is a colon and a single space, the
  severity opens the line, an empty message is not a diagnostic, and the levels avroc
  records each severity at.
- [x] **A diagnostic format is specified, and avroc parses it into its structured log.**
  `internal/avroc/diagnostic.go`. `cmd.Stderr` is now a writer that splits the stream into
  lines and records each one as it arrives, attributed to the generator: `error:` at error,
  `warning:` at warning, `note:` at info, each carrying a `severity` attribute.
- [x] **A generator that exits non-zero fails the run, and its scratch directory is discarded rather than merged.**
  A non-zero exit fails the run and nothing the generator left behind is adopted as output —
  asserted by a test whose generator writes a file *and then* exits 3. The private scratch
  directory and the merge step it would be discarded from are #117's; today `--out` is the
  project's own directory and there is no merge to withhold, which the code comment says
  rather than leaving it to be inferred.
- [x] **Unparseable stderr is still surfaced verbatim rather than swallowed.**
  Recorded with its text unchanged, at warning level, including a final line that arrived
  without its newline.
- [x] **A generator killed by a signal is reported distinguishably from one that exited non-zero.**
  Three cases now, not one: a generator that never ran, one that `exited with status N`, and
  one `terminated by signal <name> (<n>)`.
- [x] **`go test -race ./...` passes.**

## Judgment calls

- **An `io.Writer`, not a `StderrPipe`.** exec copies into a writer from a goroutine that
  `WaitDelay` bounds. A pipe read of avroc's own would block before `Wait` is ever called,
  so a grandchild holding stderr open would hang the run — the exact case
  `generatorWaitDelay` exists to cover.
- **A line that is not a diagnostic is recorded at warning, one level above the `note:` a
  plugin writes deliberately.** Info is where a log is ordinarily threshold-ed, so a handler
  configured a notch above it would drop exactly the panic this rule exists to surface.
- **A bare `error: ` is not a diagnostic.** A severity with nothing after it would produce an
  empty log record where the line was; failing the match surfaces the line as written, which
  loses less. Same reasoning for a line indented under a stack trace and for `error:something`
  with no space.
- **The buffered line is bounded at 1 MiB.** The contract says nothing about how much a
  generator may write, so a generator that never terminates a line is avroc's memory problem;
  the bound turns it into a long line recorded in pieces, with every byte still in order.
- **`internal/plugin.DiagnosticHandler`, and the three generator mains wired to it.** The
  format needed a producer: without one, no generator in this repository writes a conforming
  diagnostic, and a real `avroc-gen-go` error would reach a user as a verbatim slog line at
  warning rather than as the error it is. It is the same argument the spec makes for holding
  a first-party generator to the contract a third-party one is held to.
  `TestDiagnosticAgreement` holds the two halves together, since neither package imports the
  other.
- **Unknown `--opt` keys are left alone.** `docs/plugin/SPEC.md` marks that requirement
  `(#115)`, but it is a rule on a *plugin*, and the three generators here are rewritten
  against the contract by #121–#123. Doing it now would mean editing generators about to be
  replaced.

## Verification

All four of `.claude/backlog.json`'s verify commands, from the worktree:

- `go build ./...`
- `go test -race -cover ./...` — `internal/avroc` 84.5%, `internal/plugin` 94.3%
- `golangci-lint run` — 0 issues
- the example round-trip: build all four binaries, `avroc generate` in `example/`, `git diff --exit-code -- example`

New tests: `parseDiagnostic` and `severityLevel` tables, the stderr writer (split writes,
unterminated last line, blank lines, the 1 MiB bound, `Write` returning every byte),
diagnostics over the real fork/exec path, a generator that `kill -TERM $$`es itself, the
non-zero exit path extended to assert the status is reported and nothing is logged as
generated output, the handler's own format table, and the producer/parser agreement test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)