### PR TITLE
story(plugin): add the --plugin-info handshake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,29 @@ Discovery is a `PATH` search in order, and **the earliest match wins**, exactly 
 
 What is not yet there, so that it is not mistaken for a gap: `--out` is the project's own output directory rather than a private empty scratch directory, and avroc does not yet enforce the boundary or merge — that is #117, with collisions #118 and stale files #119. The generators here still emit chunks internally through the `Generator` service's stream type, reassembled in `internal/plugin`; #121–#123 replace that with a plain write and #124 deletes the service.
 
+### The capability handshake
+
+Before any generation begins, avroc runs every generator the manifest resolved as
+`avroc-gen-<name> --plugin-info` and reads the JSON capability declaration it
+writes to standard output: `name`, `version`, `ir_version` and `options`
+(`docs/plugin/SPEC.md`, "Capability negotiation"). A run fails there — with
+nothing generated — when a generator will not answer, answers with something
+unparseable or incomplete, declares a name that is not the one avroc resolved,
+understands a lower `ir_version` than `ir.Version`, or declares a vocabulary the
+manifest's options are not in. That early failure is the whole point: without it
+a plugin too old for the IR fails late, as a confusing complaint about a type.
+
+The two halves are `internal/plugin.Info`/`WriteInfo` (the generator writes it)
+and `internal/avroc/plugininfo.go` (avroc reads it), and they deliberately share
+no code and no constant — a third-party generator implements the handshake with
+one `printf` and imports nothing from here.
+`internal/avroc.TestTheDeclarationThisRepositorysGeneratorsWriteIsOneAvrocAccepts`
+is what keeps them from drifting.
+
+`options` present-and-empty ("I accept none") is a different declaration from
+`options` absent ("you pass them, I decide"); `avroc-gen-json` and
+`avroc-gen-pcf` declare the first.
+
 ### The resolved IR
 
 Generators are handed **resolved** schemas (`docs/ir/SPEC.md`). `internal/avroc/resolve.go` is the only place that qualifies a namespace, knows Avro's primitive list, or decides where a named type is written out in full versus referred to by name. Every named type carries `full_name`; every type reference is a `Reference` stating its `kind`. A generator that re-derives any of this is a bug.

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -498,6 +498,14 @@ plugin — and a plugin that wants avroc out of the decision omits the member
 rather than writing `[]`. A plugin whose vocabulary is genuinely empty needs to
 be able to say so, which is the whole reason the two are not collapsed.
 
+Because they are opposite instructions, a third spelling is a bug rather than a
+third meaning: `"options": null` is neither an array nor an absent member, and
+avroc **MUST** reject it rather than choose one of them (#116). Reading it as
+absent is the reading that does damage — every option in the manifest then goes
+through unchecked, past a check the plugin appeared to have asked for — and a
+plugin holding an empty list in a language that renders one as `null` emits it by
+accident, which is exactly the case a guess would get wrong silently.
+
 avroc **MUST** ignore members it does not recognise, so that a plugin declaring
 more than this version of avroc reads is not thereby broken. That is the
 opposite of what avroc does with an unknown field in a project's `avroc.json`,

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -490,8 +490,20 @@ The declaration is a single JSON object on one or more lines, encoded in UTF-8:
   the plugin decides, which is the behaviour
   [Options](#options) already requires of it.
 
+avroc takes that **MAY**: it rejects a manifest option that a plugin declaring a
+vocabulary left out of it (#116). So *present and empty* and *absent* are
+different declarations rather than two spellings of one — the first says the
+plugin accepts no option at all, the second hands the decision back to the
+plugin — and a plugin that wants avroc out of the decision omits the member
+rather than writing `[]`. A plugin whose vocabulary is genuinely empty needs to
+be able to say so, which is the whole reason the two are not collapsed.
+
 avroc **MUST** ignore members it does not recognise, so that a plugin declaring
-more than this version of avroc reads is not thereby broken.
+more than this version of avroc reads is not thereby broken. That is the
+opposite of what avroc does with an unknown field in a project's `avroc.json`,
+and the two differ because their authors do: a manifest is a file a person wrote,
+where an unknown field is a typo, while a declaration is a message a program
+wrote, where an unknown member is a newer plugin.
 
 ### Why JSON, and why it is not optional
 

--- a/internal/avroc-gen-go/avroc-gen-go.go
+++ b/internal/avroc-gen-go/avroc-gen-go.go
@@ -12,7 +12,7 @@ import (
 	"github.com/z5labs/avroc/internal/plugin"
 )
 
-// Main runs one generation and returns the process exit status.
+// Main runs one invocation and returns the process exit status.
 //
 // avroc-gen-go is an executable, not a server: it is handed a descriptor and an
 // output directory on its command line, writes files, and exits. The Unix
@@ -20,6 +20,22 @@ import (
 // rendezvous that required them (#114); what remains of the service — the
 // streaming emission generatorService still implements internally — is #121's
 // to replace and #124's to delete.
+//
+// The declared option vocabulary is the one Generate reads, and the two are
+// checked against each other by TestDeclaredOptionsAreTheOnesGenerateReads: a
+// key declared here and ignored there would be a manifest line avroc lets
+// through and the generator silently drops.
 func Main(ctx context.Context, c cli.Context) int {
-	return plugin.Main(ctx, c, "avroc-gen-go", (&generatorService{}).Generate)
+	return plugin.Main(ctx, c, plugin.NewInfo("go", declaredOptions()...), (&generatorService{}).Generate)
+}
+
+// declaredOptions is the --opt vocabulary avroc-gen-go declares, in the order
+// the declaration lists it.
+//
+// A function rather than a variable so that nothing can append to it, and named
+// so that the test above has something to range over: a key added here and never
+// wired into Generate is exactly the failure the declaration is supposed to make
+// impossible.
+func declaredOptions() []string {
+	return []string{"encoding", "package_name"}
 }

--- a/internal/avroc-gen-go/plugininfo_test.go
+++ b/internal/avroc-gen-go/plugininfo_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// TestDeclaredOptionsAreTheOnesGenerateReads holds the capability declaration
+// against the generator that has to honour it.
+//
+// docs/plugin/SPEC.md lets avroc reject a manifest option the plugin did not
+// declare, which is only useful while the declared set is the set Generate
+// actually reads. The failure this catches is the quiet one in the other
+// direction: a key listed here that nothing consumes is a line in a checked-in
+// manifest that reads as configuration, passes avroc's check, and does nothing —
+// and the user finds out by noticing that the output never changed.
+//
+// Each declared key is driven through a real generation and asserted to change
+// the bytes. That is the only evidence available from outside that a key is read
+// at all.
+func TestDeclaredOptionsAreTheOnesGenerateReads(t *testing.T) {
+	baseline := generateWith(t, options("package_name", "gen"))
+
+	changed := map[string][]*avrocpb.Option{
+		"package_name": options("package_name", "other"),
+		"encoding":     options("package_name", "gen", "encoding", "single_object"),
+	}
+
+	for _, key := range declaredOptions() {
+		t.Run(key, func(t *testing.T) {
+			opts, ok := changed[key]
+			if !ok {
+				t.Fatalf("option %q is declared but this test has no case exercising it; either wire it into Generate or stop declaring it", key)
+			}
+			if got := generateWith(t, opts); bytes.Equal(got, baseline) {
+				t.Errorf("setting %q did not change the generated output, so the declaration promises avroc something Generate does not read", key)
+			}
+		})
+	}
+}
+
+func options(pairs ...string) []*avrocpb.Option {
+	opts := make([]*avrocpb.Option, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		opts = append(opts, &avrocpb.Option{
+			Name:  proto.String(pairs[i]),
+			Value: proto.String(pairs[i+1]),
+		})
+	}
+	return opts
+}
+
+// generateWith runs one generation over a fixed schema and returns the single
+// file it produced, so that two option sets can be compared as bytes.
+func generateWith(t *testing.T, opts []*avrocpb.Option) []byte {
+	t.Helper()
+
+	res, err := generateToDir(t, &generatorService{}, t.TempDir(), &avrocpb.GenerateRequest{
+		Options: opts,
+		Schemas: []*avrocpb.Schema{versionTestSchema()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.OutputFiles) != 1 {
+		t.Fatalf("generator produced %d files, want 1", len(res.OutputFiles))
+	}
+
+	b, err := os.ReadFile(res.OutputFiles[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/avroc-gen-json/avroc-gen-json.go
+++ b/internal/avroc-gen-json/avroc-gen-json.go
@@ -12,7 +12,7 @@ import (
 	"github.com/z5labs/avroc/internal/plugin"
 )
 
-// Main runs one generation and returns the process exit status.
+// Main runs one invocation and returns the process exit status.
 //
 // avroc-gen-json is an executable, not a server: it is handed a descriptor and
 // an output directory on its command line, writes files, and exits. The Unix
@@ -20,6 +20,11 @@ import (
 // rendezvous that required them (#114); what remains of the service — the
 // streaming emission generatorService still implements internally — is #122's
 // to replace and #124's to delete.
+//
+// It declares an empty option vocabulary rather than none at all: the Avro JSON
+// schema of a resolved schema is not a thing there is anything to configure
+// about, so an option in the manifest is a mistake, and declaring the emptiness
+// is what lets avroc say so before this generator is run.
 func Main(ctx context.Context, c cli.Context) int {
-	return plugin.Main(ctx, c, "avroc-gen-json", (&generatorService{}).Generate)
+	return plugin.Main(ctx, c, plugin.NewInfo("json"), (&generatorService{}).Generate)
 }

--- a/internal/avroc-gen-pcf/avroc-gen-pcf.go
+++ b/internal/avroc-gen-pcf/avroc-gen-pcf.go
@@ -12,7 +12,7 @@ import (
 	"github.com/z5labs/avroc/internal/plugin"
 )
 
-// Main runs one generation and returns the process exit status.
+// Main runs one invocation and returns the process exit status.
 //
 // avroc-gen-pcf is an executable, not a server: it is handed a descriptor and
 // an output directory on its command line, writes files, and exits. The Unix
@@ -20,6 +20,11 @@ import (
 // rendezvous that required them (#114); what remains of the service — the
 // streaming emission generatorService still implements internally — is #123's
 // to replace and #124's to delete.
+//
+// It declares an empty option vocabulary rather than none at all. Avro's
+// Parsing Canonical Form is defined by the specification and not by this
+// generator, so there is nothing here an option could configure without
+// producing bytes that no other implementation would agree with.
 func Main(ctx context.Context, c cli.Context) int {
-	return plugin.Main(ctx, c, "avroc-gen-pcf", (&generatorService{}).Generate)
+	return plugin.Main(ctx, c, plugin.NewInfo("pcf"), (&generatorService{}).Generate)
 }

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -56,6 +56,15 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 		return 1
 	}
 
+	// docs/plugin/SPEC.md's capability handshake, and it runs before the pool
+	// rather than inside it: a plugin too old for this avroc's IR must fail the
+	// run with nothing written, not after some other generator has already
+	// produced output the user now has to work out whether to keep.
+	if err := checkGenerators(ctx, cli.Log, tasks); err != nil {
+		cli.Log.ErrorContext(ctx, "generator capability handshake failed", slog.Any("error", err))
+		return 1
+	}
+
 	genPool := pool.New().WithContext(ctx)
 	for _, task := range tasks {
 		genPool.Go(func(ctx context.Context) error {

--- a/internal/avroc/plugininfo.go
+++ b/internal/avroc/plugininfo.go
@@ -47,11 +47,32 @@ const pluginInfoFlag = "--plugin-info"
 // avroc should pass whatever the manifest declared through and let the plugin
 // decide. Those are opposite instructions, and a plain []string cannot tell them
 // apart.
+//
+// This is the declaration after parsePluginInfo has validated it, not as it
+// arrived — see pluginInfoJSON.
 type pluginInfo struct {
-	Name      *string   `json:"name"`
-	Version   *string   `json:"version"`
-	IRVersion *int32    `json:"ir_version"`
-	Options   *[]string `json:"options"`
+	Name      *string
+	Version   *string
+	IRVersion *int32
+	Options   *[]string
+}
+
+// pluginInfoJSON is the declaration exactly as a plugin wrote it, before any of
+// it has been judged.
+//
+// options is held as raw bytes rather than decoded in place because the two
+// steps answer different questions and JSON's null collapses them. Unmarshalled
+// straight into a *[]string, a member written as null is indistinguishable from
+// one that was never written — and those mean opposite things here, so a plugin
+// with a nil slice and no encoder set up to omit it would silently be read as
+// declining to declare a vocabulary at all, and every option in the manifest
+// would sail past the check. Keeping the bytes is what lets "absent", "null" and
+// "an array" stay three separate answers.
+type pluginInfoJSON struct {
+	Name      *string         `json:"name"`
+	Version   *string         `json:"version"`
+	IRVersion *int32          `json:"ir_version"`
+	Options   json.RawMessage `json:"options"`
 }
 
 // checkGenerators runs docs/plugin/SPEC.md's capability handshake against every
@@ -137,8 +158,8 @@ func queryPluginInfo(ctx context.Context, name, executablePath string) (*pluginI
 func parsePluginInfo(stdout []byte) (*pluginInfo, error) {
 	dec := json.NewDecoder(bytes.NewReader(stdout))
 
-	var info pluginInfo
-	if err := dec.Decode(&info); err != nil {
+	var wire pluginInfoJSON
+	if err := dec.Decode(&wire); err != nil {
 		return nil, fmt.Errorf("it is not a JSON object: %w", err)
 	}
 	// Decode stops after the first JSON value. Standard output carries the
@@ -150,23 +171,63 @@ func parsePluginInfo(stdout []byte) (*pluginInfo, error) {
 	}
 
 	var missing []string
-	if info.Name == nil {
+	if wire.Name == nil {
 		missing = append(missing, "name")
 	}
-	if info.Version == nil {
+	if wire.Version == nil {
 		missing = append(missing, "version")
 	}
-	if info.IRVersion == nil {
+	if wire.IRVersion == nil {
 		missing = append(missing, "ir_version")
 	}
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("it is missing the required member(s) %s", strings.Join(missing, ", "))
 	}
 
-	if *info.Name == "" {
+	if *wire.Name == "" {
 		return nil, errors.New(`its "name" is empty, and a generator name never is`)
 	}
-	return &info, nil
+
+	options, err := parseDeclaredOptions(wire.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pluginInfo{
+		Name:      wire.Name,
+		Version:   wire.Version,
+		IRVersion: wire.IRVersion,
+		Options:   options,
+	}, nil
+}
+
+// parseDeclaredOptions decodes the options member, returning nil for one the
+// plugin did not write.
+//
+// null is rejected rather than read as either of the two things the member can
+// say. docs/plugin/SPEC.md makes it absent or an array of strings, and null is
+// neither; a plugin that emits it has a bug, and the useful response is to name
+// that bug rather than to guess which meaning was intended. Guessing "absent" is
+// the dangerous guess in particular — it is the reading that lets every option
+// in the manifest past a check the plugin looked like it had asked for.
+func parseDeclaredOptions(raw json.RawMessage) (*[]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	if string(bytes.TrimSpace(raw)) == "null" {
+		return nil, errors.New(`its "options" is null, which is neither an array nor an absent member: declare an array, or omit the member to leave the decision to the plugin`)
+	}
+
+	var options []string
+	if err := json.Unmarshal(raw, &options); err != nil {
+		return nil, fmt.Errorf(`its "options" is not an array of strings: %w`, err)
+	}
+	// Non-nil for an empty array, so that "I accept none" survives the decode as
+	// something other than "I did not say".
+	if options == nil {
+		options = []string{}
+	}
+	return &options, nil
 }
 
 // checkPluginInfo holds a declaration against the generator avroc resolved, the

--- a/internal/avroc/plugininfo.go
+++ b/internal/avroc/plugininfo.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+)
+
+// pluginInfoFlag is the whole of the capability-negotiation argument vector
+// avroc invokes a generator with, and docs/plugin/SPEC.md accepts no other
+// argument alongside it.
+//
+// It is written out here rather than taken from internal/plugin on purpose.
+// That package is the generator's half of the contract and this is avroc's; the
+// two sit either side of a process boundary, and a third-party generator
+// implements the flag without importing anything from this repository. What
+// keeps them honest is a test, not a shared constant — see
+// TestTheDeclarationThisRepositorysGeneratorsWriteIsOneAvrocAccepts.
+const pluginInfoFlag = "--plugin-info"
+
+// pluginInfo is docs/plugin/SPEC.md's capability declaration as avroc reads it.
+//
+// Every member is a pointer so that "the plugin did not write this" is
+// distinguishable from "the plugin wrote the zero value". Failing on a missing
+// required member is most of what the handshake is for, and a declaration with
+// no ir_version and one declaring ir_version 0 are different mistakes that would
+// otherwise arrive here looking identical.
+//
+// options is a pointer to a slice for the same reason, and it is not pedantry:
+// present-and-empty says the plugin accepts no options at all, while absent says
+// avroc should pass whatever the manifest declared through and let the plugin
+// decide. Those are opposite instructions, and a plain []string cannot tell them
+// apart.
+type pluginInfo struct {
+	Name      *string   `json:"name"`
+	Version   *string   `json:"version"`
+	IRVersion *int32    `json:"ir_version"`
+	Options   *[]string `json:"options"`
+}
+
+// checkGenerators runs docs/plugin/SPEC.md's capability handshake against every
+// generator this run resolved, before any generation begins.
+//
+// Early is the entire point. The failures it catches — a plugin too old for this
+// avroc's IR, a name on PATH that is not the generator the manifest asked for, an
+// option the plugin has never heard of — are all failures that would otherwise
+// surface as a confusing complaint about a schema, after files had already been
+// written by whichever generator happened to run first.
+//
+// "Every generator it resolved" is every generator the manifest named and avroc
+// found on PATH, not every avroc-gen-* executable discovery happened to see.
+// avroc runs the generators it was asked to run and nothing else, and a
+// handshake with an executable no task names would be avroc executing a file for
+// no reason at all.
+//
+// Sequential, in task order, so that a manifest with two broken generators
+// reports the same one every time rather than whichever process lost the race.
+func checkGenerators(ctx context.Context, log *slog.Logger, tasks []genTask) error {
+	for _, task := range tasks {
+		info, err := queryPluginInfo(ctx, task.name, task.executablePath)
+		if err != nil {
+			return err
+		}
+		if err := checkPluginInfo(task.name, task.options, info); err != nil {
+			return err
+		}
+
+		log.DebugContext(ctx, "generator declared its capabilities",
+			slog.String("generator", task.name),
+			slog.String("version", *info.Version),
+			slog.Int("ir_version", int(*info.IRVersion)),
+		)
+	}
+	return nil
+}
+
+// queryPluginInfo runs one generator's handshake and returns what it declared.
+//
+// A generator that does not implement the flag is handled here rather than
+// crashing the run: whatever it did instead — exited non-zero, printed a usage
+// line, wrote nothing — becomes a failure naming the generator and quoting what
+// it wrote, which is the difference between "this plugin is too old" and a
+// stack trace attributed to nobody.
+func queryPluginInfo(ctx context.Context, name, executablePath string) (*pluginInfo, error) {
+	cmd := exec.CommandContext(ctx, executablePath, pluginInfoFlag)
+	// No descriptor is read during a handshake, so there is nothing standard
+	// input could carry; a plugin blocking on it would otherwise hang the run
+	// before any generation had been attempted.
+	cmd.Stdin = nil
+
+	// Both streams are captured rather than inherited. Standard output is the
+	// declaration, and standard error is what a plugin that did not understand
+	// the flag wrote instead — which is exactly the text the failure below has to
+	// quote, and useless once it has scrolled past on avroc's own stderr.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = generatorWaitDelay
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("generator %q failed the %s handshake: %w%s",
+			name, pluginInfoFlag, err, quoteReceived(stderr.Bytes(), stdout.Bytes()))
+	}
+
+	info, err := parsePluginInfo(stdout.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("generator %q wrote an unusable %s declaration: %w%s",
+			name, pluginInfoFlag, err, quoteReceived(stdout.Bytes(), stderr.Bytes()))
+	}
+	return info, nil
+}
+
+// parsePluginInfo decodes the declaration a generator wrote to standard output.
+//
+// Unknown members are ignored rather than rejected, because docs/plugin/SPEC.md
+// requires it: a plugin declaring more than this version of avroc reads is not
+// thereby broken. That is the opposite of loadManifest, which does reject
+// unknown fields, and the two differ because their authors do. A manifest is a
+// file a person wrote and an unknown field in it is a typo; a declaration is a
+// message a program wrote and a member avroc does not know is a newer plugin.
+func parsePluginInfo(stdout []byte) (*pluginInfo, error) {
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+
+	var info pluginInfo
+	if err := dec.Decode(&info); err != nil {
+		return nil, fmt.Errorf("it is not a JSON object: %w", err)
+	}
+	// Decode stops after the first JSON value. Standard output carries the
+	// declaration and nothing else, so anything following it means the plugin
+	// wrote something there it should not have — most likely a generator that
+	// treated stdout as a log.
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return nil, errors.New("it is followed by trailing data, and standard output carries the declaration and nothing else")
+	}
+
+	var missing []string
+	if info.Name == nil {
+		missing = append(missing, "name")
+	}
+	if info.Version == nil {
+		missing = append(missing, "version")
+	}
+	if info.IRVersion == nil {
+		missing = append(missing, "ir_version")
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("it is missing the required member(s) %s", strings.Join(missing, ", "))
+	}
+
+	if *info.Name == "" {
+		return nil, errors.New(`its "name" is empty, and a generator name never is`)
+	}
+	return &info, nil
+}
+
+// checkPluginInfo holds a declaration against the generator avroc resolved, the
+// descriptor avroc is about to write, and the options the manifest declared.
+//
+// Each failure names the generator, because a run with several of them reports
+// one line and the user has to know which plugin to go and look at.
+func checkPluginInfo(execName string, options []*avrocpb.Option, info *pluginInfo) error {
+	if declared := "avroc-gen-" + *info.Name; declared != execName {
+		return fmt.Errorf("generator %q declares the name %q, which is %q: the file on PATH is not the generator the manifest asked for, and generating with it would attribute its output to the wrong plugin",
+			execName, *info.Name, declared)
+	}
+
+	// The descriptor's version is the one this avroc stamps on every descriptor
+	// it emits, so it is known here without building one. A plugin that
+	// understands a *higher* version than avroc writes is fine: it is newer than
+	// this avroc, and reading an older descriptor is what a monotonic version
+	// makes possible.
+	if ir.Version > *info.IRVersion {
+		return fmt.Errorf("generator %q understands IR version %d, but this avroc writes descriptors at IR version %d: the generator is too old for it",
+			execName, *info.IRVersion, ir.Version)
+	}
+
+	// An absent options member is a plugin declining to declare a vocabulary, and
+	// docs/plugin/SPEC.md leaves the decision to the plugin in that case. Present
+	// and empty is a plugin saying it accepts none, which is a declaration and not
+	// a silence.
+	if info.Options == nil {
+		return nil
+	}
+	for _, opt := range options {
+		if slices.Contains(*info.Options, opt.GetName()) {
+			continue
+		}
+		return fmt.Errorf("generator %q does not accept the option %q the manifest declares; it accepts %v",
+			execName, opt.GetName(), *info.Options)
+	}
+	return nil
+}
+
+// maxQuotedBytes bounds how much of a generator's output a failure report
+// quotes.
+//
+// A plugin that does not implement the handshake usually prints a usage line,
+// but one that ignored the flag and generated anyway can print a great deal, and
+// a diagnostic is worth nothing once it has scrolled the real one out of view.
+const maxQuotedBytes = 512
+
+// quoteReceived renders the first of streams that carried anything, for a
+// failure whose whole job is to say what avroc received instead of a
+// declaration.
+//
+// The streams are given most-likely-first by the caller, because which one holds
+// the explanation depends on how the plugin failed: a plugin that rejected the
+// flag wrote to standard error, and one that wrote something unparseable wrote
+// it to standard output.
+func quoteReceived(streams ...[]byte) string {
+	for _, s := range streams {
+		text := strings.TrimSpace(string(s))
+		if text == "" {
+			continue
+		}
+		if len(text) > maxQuotedBytes {
+			// ToValidUTF8 because the cut is at a byte offset and may land in the
+			// middle of a rune, which would otherwise be quoted as an escape that
+			// looks like the plugin's own output rather than avroc's truncation.
+			text = strings.ToValidUTF8(text[:maxQuotedBytes], "") + "..."
+		}
+		return "; it wrote " + strconv.Quote(text)
+	}
+	return "; it wrote nothing"
+}

--- a/internal/avroc/plugininfo_test.go
+++ b/internal/avroc/plugininfo_test.go
@@ -126,6 +126,26 @@ func TestParsePluginInfo(t *testing.T) {
 				stdout: `{"name":"go","version":"1","ir_version":1}` + "\ngenerating...\n",
 				names:  "trailing data",
 			},
+			{
+				// The dangerous one, and the reason options is decoded from raw
+				// bytes rather than straight into a pointer: read as an absent
+				// member, a null vocabulary lets every option in the manifest past
+				// a check the plugin looked like it had asked for. A Go plugin with
+				// a nil slice and no encoder set up to omit it emits exactly this.
+				name:   "an options member written as null",
+				stdout: `{"name":"go","version":"1","ir_version":1,"options":null}`,
+				names:  "null",
+			},
+			{
+				name:   "an options member that is not an array",
+				stdout: `{"name":"go","version":"1","ir_version":1,"options":"package_name"}`,
+				names:  "not an array of strings",
+			},
+			{
+				name:   "an options array of something other than strings",
+				stdout: `{"name":"go","version":"1","ir_version":1,"options":[1,2]}`,
+				names:  "not an array of strings",
+			},
 		}
 
 		for _, tc := range testCases {

--- a/internal/avroc/plugininfo_test.go
+++ b/internal/avroc/plugininfo_test.go
@@ -1,0 +1,517 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+	"github.com/z5labs/avroc/internal/plugin"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func TestParsePluginInfo(t *testing.T) {
+	t.Run("accepts the declaration docs/plugin/SPEC.md specifies", func(t *testing.T) {
+		info, err := parsePluginInfo([]byte(`{
+  "name": "go",
+  "version": "0.2.0",
+  "ir_version": 1,
+  "options": ["package_name", "encoding"]
+}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if *info.Name != "go" {
+			t.Errorf("name = %q, want go", *info.Name)
+		}
+		if *info.Version != "0.2.0" {
+			t.Errorf("version = %q, want 0.2.0", *info.Version)
+		}
+		if *info.IRVersion != 1 {
+			t.Errorf("ir_version = %d, want 1", *info.IRVersion)
+		}
+		if info.Options == nil || len(*info.Options) != 2 {
+			t.Errorf("options = %v, want two entries", info.Options)
+		}
+	})
+
+	t.Run("ignores a member it does not recognise", func(t *testing.T) {
+		// A plugin declaring more than this version of avroc reads is not
+		// thereby broken — the whole point of a handshake is that the two ends
+		// may be different ages.
+		if _, err := parsePluginInfo([]byte(`{"name":"go","version":"1","ir_version":1,"features":["x"]}`)); err != nil {
+			t.Errorf("an unknown member was rejected: %v", err)
+		}
+	})
+
+	t.Run("tells an absent options member from an empty one", func(t *testing.T) {
+		absent, err := parsePluginInfo([]byte(`{"name":"go","version":"1","ir_version":1}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if absent.Options != nil {
+			t.Errorf("options = %v, want absent", *absent.Options)
+		}
+
+		empty, err := parsePluginInfo([]byte(`{"name":"go","version":"1","ir_version":1,"options":[]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if empty.Options == nil {
+			t.Fatal("an empty options array was read as an absent member; those are opposite instructions")
+		}
+		if len(*empty.Options) != 0 {
+			t.Errorf("options = %v, want empty", *empty.Options)
+		}
+	})
+
+	t.Run("rejects what is not a usable declaration", func(t *testing.T) {
+		testCases := []struct {
+			name   string
+			stdout string
+			names  string // a fragment the failure has to name
+		}{
+			{
+				name:   "a plugin that wrote nothing",
+				stdout: "",
+				names:  "not a JSON object",
+			},
+			{
+				name:   "a plugin that printed a usage line instead",
+				stdout: "Usage: avroc-gen-go --descriptor <path> --out <dir>\n",
+				names:  "not a JSON object",
+			},
+			{
+				name:   "a JSON array",
+				stdout: `["go"]`,
+				names:  "not a JSON object",
+			},
+			{
+				name:   "JSON null, which parses but declares nothing",
+				stdout: `null`,
+				names:  "name, version, ir_version",
+			},
+			{
+				name:   "a declaration missing ir_version",
+				stdout: `{"name":"go","version":"1"}`,
+				names:  "ir_version",
+			},
+			{
+				name:   "a declaration missing every required member",
+				stdout: `{}`,
+				names:  "name, version, ir_version",
+			},
+			{
+				name:   "an empty name",
+				stdout: `{"name":"","version":"1","ir_version":1}`,
+				names:  "empty",
+			},
+			{
+				name:   "a declaration with something written after it",
+				stdout: `{"name":"go","version":"1","ir_version":1}` + "\ngenerating...\n",
+				names:  "trailing data",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := parsePluginInfo([]byte(tc.stdout))
+				if err == nil {
+					t.Fatalf("parsePluginInfo accepted %q", tc.stdout)
+				}
+				if !strings.Contains(err.Error(), tc.names) {
+					t.Errorf("failure %q does not name %q", err.Error(), tc.names)
+				}
+			})
+		}
+	})
+
+	t.Run("an ir_version of zero is a declaration, not an absence", func(t *testing.T) {
+		// No conforming plugin declares 0, but the two have to arrive here
+		// distinguishably: one is a plugin that is too old and the other is a
+		// plugin that never answered the question.
+		info, err := parsePluginInfo([]byte(`{"name":"go","version":"1","ir_version":0}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if *info.IRVersion != 0 {
+			t.Errorf("ir_version = %d, want 0", *info.IRVersion)
+		}
+	})
+}
+
+// declaration builds a parsed declaration for the checks below, so that a test
+// about checkPluginInfo is not also a test about JSON.
+func declaration(name string, irVersion int32, options *[]string) *pluginInfo {
+	return &pluginInfo{
+		Name:      proto.String(name),
+		Version:   proto.String("1.2.3"),
+		IRVersion: proto.Int32(irVersion),
+		Options:   options,
+	}
+}
+
+func TestCheckPluginInfo(t *testing.T) {
+	t.Run("accepts a generator that matches", func(t *testing.T) {
+		err := checkPluginInfo("avroc-gen-go", nil, declaration("go", ir.Version, nil))
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("rejects a declaration naming a different generator", func(t *testing.T) {
+		// The file on PATH is not the generator the manifest asked for, and
+		// generating with it would attribute its output to the wrong plugin.
+		err := checkPluginInfo("avroc-gen-go", nil, declaration("rust", ir.Version, nil))
+		if err == nil {
+			t.Fatal("a mismatched name was accepted")
+		}
+		for _, want := range []string{"avroc-gen-go", "rust"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("failure %q does not name %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("rejects a plugin older than the descriptor avroc writes", func(t *testing.T) {
+		err := checkPluginInfo("avroc-gen-go", nil, declaration("go", ir.Version-1, nil))
+		if err == nil {
+			t.Fatal("a plugin too old for this avroc's IR was accepted")
+		}
+		// docs/plugin/SPEC.md requires the diagnostic to name both numbers and
+		// the generator, because the user's next move depends on which end is
+		// behind.
+		for _, want := range []string{"avroc-gen-go", fmt.Sprint(ir.Version - 1), fmt.Sprint(ir.Version)} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("failure %q does not name %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("accepts a plugin newer than the descriptor avroc writes", func(t *testing.T) {
+		// A monotonic version is what makes a newer plugin able to read an older
+		// descriptor; only the other direction is a failure.
+		err := checkPluginInfo("avroc-gen-go", nil, declaration("go", ir.Version+1, nil))
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("rejects a manifest option the plugin declared no support for", func(t *testing.T) {
+		opts := []*avrocpb.Option{{Name: proto.String("packag_name"), Value: proto.String("gen")}}
+		vocabulary := []string{"package_name"}
+
+		err := checkPluginInfo("avroc-gen-go", opts, declaration("go", ir.Version, &vocabulary))
+		if err == nil {
+			t.Fatal("an undeclared option was accepted")
+		}
+		if !strings.Contains(err.Error(), "packag_name") {
+			t.Errorf("failure %q does not name the option", err.Error())
+		}
+	})
+
+	t.Run("a plugin declaring an empty vocabulary accepts no option at all", func(t *testing.T) {
+		opts := []*avrocpb.Option{{Name: proto.String("anything"), Value: proto.String("x")}}
+
+		if err := checkPluginInfo("avroc-gen-pcf", opts, declaration("pcf", ir.Version, &[]string{})); err == nil {
+			t.Fatal("a generator that accepts no options was handed one")
+		}
+	})
+
+	t.Run("a plugin declaring no vocabulary is handed the options and decides itself", func(t *testing.T) {
+		opts := []*avrocpb.Option{{Name: proto.String("anything"), Value: proto.String("x")}}
+
+		if err := checkPluginInfo("avroc-gen-go", opts, declaration("go", ir.Version, nil)); err != nil {
+			t.Errorf("an absent options member was read as an empty one: %v", err)
+		}
+	})
+
+	t.Run("accepts every option the plugin declared", func(t *testing.T) {
+		opts := []*avrocpb.Option{
+			{Name: proto.String("encoding"), Value: proto.String("single_object")},
+			{Name: proto.String("package_name"), Value: proto.String("gen")},
+		}
+		vocabulary := []string{"encoding", "package_name"}
+
+		if err := checkPluginInfo("avroc-gen-go", opts, declaration("go", ir.Version, &vocabulary)); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+// writeNamedShellGenerator writes body out as an executable shell script called
+// avroc-gen-<name> in its own directory, and returns the path.
+//
+// A shell script on purpose, as everywhere else in this package: the handshake
+// costs a conforming plugin one printf, and a test driving one is what holds
+// avroc to that.
+func writeNamedShellGenerator(t *testing.T, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "avroc-gen-"+name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// conformingHandshake is the body of the smallest plugin that can exist: one
+// printf, guarded on the flag.
+func conformingHandshake(name string, irVersion int32) string {
+	return fmt.Sprintf(`if [ "$1" = "--plugin-info" ]; then
+  printf '{"name":"%s","version":"9.9.9","ir_version":%d,"options":[]}\n'
+  exit 0
+fi
+echo "error: unexpected vector" >&2
+exit 1
+`, name, irVersion)
+}
+
+func TestQueryPluginInfo(t *testing.T) {
+	t.Run("reads what a conforming plugin declares", func(t *testing.T) {
+		path := writeNamedShellGenerator(t, "test", conformingHandshake("test", ir.Version))
+
+		info, err := queryPluginInfo(t.Context(), "avroc-gen-test", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if *info.Name != "test" {
+			t.Errorf("name = %q, want test", *info.Name)
+		}
+		if *info.Version != "9.9.9" {
+			t.Errorf("version = %q, want 9.9.9", *info.Version)
+		}
+	})
+
+	t.Run("passes the flag and nothing else", func(t *testing.T) {
+		// docs/plugin/SPEC.md gives --plugin-info a vector of its own: no
+		// descriptor is read and no other argument is accepted, so a plugin that
+		// checks is entitled to fail one that carried more.
+		recorded := filepath.Join(t.TempDir(), "args")
+		path := writeNamedShellGenerator(t, "test", fmt.Sprintf(`: > '%s'
+for a in "$@"; do printf '%%s\n' "$a" >> '%s'; done
+printf '{"name":"test","version":"1","ir_version":%d}\n'
+`, recorded, recorded, ir.Version))
+
+		if _, err := queryPluginInfo(t.Context(), "avroc-gen-test", path); err != nil {
+			t.Fatal(err)
+		}
+
+		args := readLines(t, recorded)
+		if len(args) != 1 || args[0] != "--plugin-info" {
+			t.Errorf("argument vector = %q, want just --plugin-info", args)
+		}
+	})
+
+	t.Run("a plugin that does not implement the handshake fails the run rather than crashing it", func(t *testing.T) {
+		// The case the acceptance criteria name: an older plugin that has never
+		// heard of the flag. It exits non-zero with a usage line, and what a user
+		// needs back is the generator's name and that line — not a stack trace
+		// attributed to nobody.
+		path := writeNamedShellGenerator(t, "old", `echo "avroc-gen-old: unknown option $1" >&2
+exit 2
+`)
+
+		_, err := queryPluginInfo(t.Context(), "avroc-gen-old", path)
+		if err == nil {
+			t.Fatal("a plugin that rejected the flag was accepted")
+		}
+		for _, want := range []string{"avroc-gen-old", "unknown option"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("failure %q does not carry %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("a plugin that exits zero with nothing to say", func(t *testing.T) {
+		path := writeNamedShellGenerator(t, "silent", "exit 0\n")
+
+		_, err := queryPluginInfo(t.Context(), "avroc-gen-silent", path)
+		if err == nil {
+			t.Fatal("a silent plugin was accepted")
+		}
+		if !strings.Contains(err.Error(), "wrote nothing") {
+			t.Errorf("failure %q does not say the plugin wrote nothing", err.Error())
+		}
+	})
+
+	t.Run("quotes what it received, bounded", func(t *testing.T) {
+		// A plugin that ignored the flag and generated anyway can print a great
+		// deal, and a diagnostic is worth nothing once it has scrolled the real
+		// one out of view.
+		path := writeNamedShellGenerator(t, "loud", `awk 'BEGIN { while (i++ < 200) printf "not-a-declaration " }'
+exit 0
+`)
+
+		_, err := queryPluginInfo(t.Context(), "avroc-gen-loud", path)
+		if err == nil {
+			t.Fatal("a plugin writing prose to standard output was accepted")
+		}
+		if !strings.Contains(err.Error(), "...") {
+			t.Errorf("failure %q was not truncated", err.Error())
+		}
+		if len(err.Error()) > 4*maxQuotedBytes {
+			t.Errorf("failure is %d bytes long", len(err.Error()))
+		}
+	})
+
+	t.Run("an executable that is not there", func(t *testing.T) {
+		_, err := queryPluginInfo(t.Context(), "avroc-gen-absent", filepath.Join(t.TempDir(), "avroc-gen-absent"))
+		if err == nil {
+			t.Fatal("a generator that could not be run was accepted")
+		}
+		if !strings.Contains(err.Error(), "avroc-gen-absent") {
+			t.Errorf("failure %q does not name the generator", err.Error())
+		}
+	})
+}
+
+func TestCheckGenerators(t *testing.T) {
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("accepts a run whose generators all conform", func(t *testing.T) {
+		tasks := []genTask{
+			{name: "avroc-gen-a", executablePath: writeNamedShellGenerator(t, "a", conformingHandshake("a", ir.Version))},
+			{name: "avroc-gen-b", executablePath: writeNamedShellGenerator(t, "b", conformingHandshake("b", ir.Version))},
+		}
+
+		if err := checkGenerators(t.Context(), discard, tasks); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("reports the first failing generator in task order", func(t *testing.T) {
+		// Sequential and ordered so that a manifest with two broken generators
+		// reports the same one every time, rather than whichever process lost the
+		// race.
+		tasks := []genTask{
+			{name: "avroc-gen-a", executablePath: writeNamedShellGenerator(t, "a", conformingHandshake("a", ir.Version-1))},
+			{name: "avroc-gen-b", executablePath: writeNamedShellGenerator(t, "b", conformingHandshake("b", ir.Version-1))},
+		}
+
+		for range 5 {
+			err := checkGenerators(t.Context(), discard, tasks)
+			if err == nil {
+				t.Fatal("two generators too old for this avroc's IR were accepted")
+			}
+			if !strings.Contains(err.Error(), "avroc-gen-a") {
+				t.Fatalf("failure %q is not about the first generator", err.Error())
+			}
+		}
+	})
+
+	t.Run("rejects an option no generator declared", func(t *testing.T) {
+		tasks := []genTask{{
+			name:           "avroc-gen-a",
+			executablePath: writeNamedShellGenerator(t, "a", conformingHandshake("a", ir.Version)),
+			options:        []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+		}}
+
+		if err := checkGenerators(t.Context(), discard, tasks); err == nil {
+			t.Fatal("an option a generator declared no support for was accepted")
+		}
+	})
+}
+
+// TestTheDeclarationThisRepositorysGeneratorsWriteIsOneAvrocAccepts is the
+// agreement test across the process boundary.
+//
+// internal/plugin is the generator's half of docs/plugin/SPEC.md and this
+// package is avroc's; they share no code and no constant on purpose, so that a
+// third-party generator implements the contract without importing anything from
+// this repository. That leaves nothing but a test to notice if the two halves
+// drift apart, and this is it: the exact bytes a generator built here writes,
+// parsed and checked by the exact code that reads a stranger's.
+func TestTheDeclarationThisRepositorysGeneratorsWriteIsOneAvrocAccepts(t *testing.T) {
+	for _, generator := range []struct {
+		name    string
+		options []string
+	}{
+		{name: "go", options: []string{"encoding", "package_name"}},
+		{name: "json"},
+		{name: "pcf"},
+	} {
+		t.Run(generator.name, func(t *testing.T) {
+			var declared bytes.Buffer
+			if err := plugin.WriteInfo(&declared, plugin.NewInfo(generator.name, generator.options...)); err != nil {
+				t.Fatal(err)
+			}
+
+			info, err := parsePluginInfo(declared.Bytes())
+			if err != nil {
+				t.Fatalf("avroc cannot read what a generator here writes: %v\n%s", err, declared.String())
+			}
+
+			options := make([]*avrocpb.Option, 0, len(generator.options))
+			for _, key := range generator.options {
+				options = append(options, &avrocpb.Option{Name: proto.String(key), Value: proto.String("v")})
+			}
+
+			if err := checkPluginInfo("avroc-gen"+"-"+generator.name, options, info); err != nil {
+				t.Errorf("avroc rejects a generator built from this repository: %v", err)
+			}
+		})
+	}
+}
+
+// TestRunGenerateStopsAtTheHandshake is the whole cycle: a manifest, a generator
+// on PATH that is too old for this avroc's IR, and no output.
+//
+// Failing early is the entire justification for the handshake, and the only
+// evidence that it happened early is that nothing was generated.
+func TestRunGenerateStopsAtTheHandshake(t *testing.T) {
+	workingDir := t.TempDir()
+	writeIDL(t, workingDir, "schema.avdl")
+
+	manifest := `{"inputs":["schema.avdl"],"generators":[{"name":"old","out":"gen"}]}`
+	if err := os.WriteFile(filepath.Join(workingDir, manifestFilename), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A generator that answers the handshake honestly and would happily generate
+	// if it were ever asked to. It is not asked to.
+	binDir := t.TempDir()
+	body := conformingHandshake("old", ir.Version-1) + fmt.Sprintf("mkdir -p '%s'\ntouch '%s'\n",
+		filepath.Join(workingDir, "gen"), filepath.Join(workingDir, "gen", "generated.txt"))
+	if err := os.WriteFile(filepath.Join(binDir, "avroc-gen-old"), []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	c := cli.Context{
+		Log: slog.New(slog.NewTextHandler(&logs, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			if key == "PATH" {
+				return binDir, true
+			}
+			return "", false
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: workingDir,
+	}
+
+	if code := runGenerate(t.Context(), c); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(logs.String(), "IR version") {
+		t.Errorf("the failure does not name the IR version: %s", logs.String())
+	}
+	if _, err := os.Stat(filepath.Join(workingDir, "gen", "generated.txt")); err == nil {
+		t.Error("the generator ran after failing the handshake; the point of the handshake is that it does not")
+	}
+}

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"encoding/json"
+	"io"
+	"runtime/debug"
+
+	"github.com/z5labs/avroc/internal/ir"
+)
+
+// PluginInfoFlag is the whole of the capability-negotiation argument vector:
+//
+//	avroc-gen-<name> --plugin-info
+//
+// docs/plugin/SPEC.md accepts no other argument alongside it, so a vector
+// carrying one is an error rather than something to ignore. avroc's half — the
+// flag it passes and the declaration it reads back — is internal/avroc's.
+const PluginInfoFlag = "--plugin-info"
+
+// Info is the capability declaration docs/plugin/SPEC.md's "Capability
+// negotiation" specifies: what a plugin supports, said before it is handed any
+// work, so that a mismatch fails early and by name instead of halfway through a
+// generation that was never going to succeed.
+//
+// It is JSON while the descriptor is protobuf, and the split is deliberate.
+// This is the one message a plugin has to produce before it has demonstrated
+// any tooling at all, and a shell script emits it with a single printf;
+// requiring protobuf here would mean a plugin needed a protobuf runtime in
+// order to say that it does not have one.
+type Info struct {
+	// Name is the generator's <name> — the suffix of the avroc-gen-<name>
+	// executable avroc resolved, not the whole filename. avroc fails the run
+	// when the two disagree, because a mismatch means the file on PATH is not
+	// the generator the manifest asked for and its output would be attributed to
+	// the wrong plugin.
+	Name string `json:"name"`
+
+	// Version is the plugin's own version, in whatever scheme its author uses.
+	// avroc never interprets it, compares it or decides anything from it: it
+	// exists to be reported in a log and quoted in a bug report.
+	Version string `json:"version"`
+
+	// IRVersion is the highest IR version this plugin understands, in the sense
+	// of docs/ir/SPEC.md's version field. avroc compares it against the version
+	// of the descriptor it is about to write and fails the run before generating
+	// anything when the descriptor's is higher.
+	//
+	// It does not relieve the plugin of the check ir.CheckVersion performs at
+	// generation time: a plugin is entitled to be run by something other than
+	// this version of avroc.
+	IRVersion int32 `json:"ir_version"`
+
+	// Options are the --opt keys the plugin accepts.
+	//
+	// Present and empty says the plugin accepts none, which lets avroc reject a
+	// misplaced manifest option before anything runs. Absent says avroc should
+	// pass the manifest's options through and let the plugin decide, which is
+	// what the contract already requires of it. Those are opposite instructions,
+	// so the member is always written by the generators here — every one of them
+	// knows its own vocabulary, and a generator that accepts no options has to
+	// be able to say so rather than fall into the other case by writing nothing.
+	Options []string `json:"options"`
+}
+
+// NewInfo is the declaration for a generator built from this repository: its
+// own name and option vocabulary, this build's version, and the IR version
+// internal/ir pins.
+//
+// name is the generator's <name> and not the executable's filename — "go", not
+// "avroc-gen-go". The two are connected by nothing but that suffix, in either
+// direction, so deriving the filename here (see Executable) is what keeps the
+// declaration and the executable that wrote it from being able to disagree.
+func NewInfo(name string, options ...string) Info {
+	return Info{
+		Name:      name,
+		Version:   pluginVersion(),
+		IRVersion: ir.Version,
+		Options:   normalizeOptions(options),
+	}
+}
+
+// Executable is the filename avroc resolves this generator's name to.
+func (i Info) Executable() string {
+	return "avroc-gen-" + i.Name
+}
+
+// normalizeOptions turns a generator that declared no options into an empty
+// declared vocabulary rather than an absent one.
+//
+// The distinction survives all the way to avroc's reader, and a nil slice would
+// marshal to JSON null — which is neither of the two things the member can say.
+func normalizeOptions(options []string) []string {
+	if options == nil {
+		return []string{}
+	}
+	return options
+}
+
+// pluginVersion is the version a generator built from this repository declares.
+//
+// It is read out of the build rather than written down as a constant here,
+// because a constant is a second place to remember on release day and goes
+// stale silently — and a version quoted in a bug report is worth nothing once it
+// has. It is fixed for a given executable, which is the whole of what
+// docs/plugin/SPEC.md asks of it: the declaration must be identical across
+// invocations of the same executable.
+func pluginVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok || bi.Main.Version == "" {
+		return "(devel)"
+	}
+	return bi.Main.Version
+}
+
+// WriteInfo writes the declaration to w as a single JSON object and nothing
+// else.
+//
+// docs/plugin/SPEC.md gives standard output to this one message during the
+// whole of a plugin's life, which is what makes the declaration parseable
+// without a mode flag and a generation invocation safe to put in a pipeline.
+func WriteInfo(w io.Writer, info Info) error {
+	info.Options = normalizeOptions(info.Options)
+
+	// Indented because a person runs --plugin-info by hand more often than a
+	// program does, and the field order is the struct's either way — the
+	// declaration has to be byte-identical across invocations, so nothing here
+	// may range over a map.
+	b, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(append(b, '\n'))
+	return err
+}

--- a/internal/plugin/info_test.go
+++ b/internal/plugin/info_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// testInfo is the declaration the tests in this package drive Main with. Its
+// name is the suffix, not the filename: "test", which resolves to
+// avroc-gen-test.
+func testInfo(options ...string) Info {
+	return NewInfo("test", options...)
+}
+
+func TestNewInfo(t *testing.T) {
+	t.Run("declares the name it was given and the executable that carries it", func(t *testing.T) {
+		info := NewInfo("go")
+
+		if info.Name != "go" {
+			t.Errorf("Name = %q, want go", info.Name)
+		}
+		if info.Executable() != "avroc-gen-go" {
+			t.Errorf("Executable() = %q, want avroc-gen-go", info.Executable())
+		}
+	})
+
+	t.Run("declares the IR version this build understands", func(t *testing.T) {
+		if got := NewInfo("go").IRVersion; got != ir.Version {
+			t.Errorf("IRVersion = %d, want %d", got, ir.Version)
+		}
+	})
+
+	t.Run("declares a version for a bug report to quote", func(t *testing.T) {
+		// Nothing asserts *which* version: avroc never interprets it, and the
+		// value depends on how the executable was built. What the contract asks
+		// of it is that it is there and does not change, both of which a caller
+		// would notice the absence of and no test upstream of avroc would.
+		if NewInfo("go").Version == "" {
+			t.Error("Version is empty; it exists to be quoted in a bug report")
+		}
+	})
+
+	t.Run("a generator with no options declares an empty vocabulary, not an absent one", func(t *testing.T) {
+		// The distinction survives to avroc's reader: present-and-empty is "I
+		// accept none", absent is "pass them through and I will decide". A
+		// generator built here always knows which of those it means.
+		info := NewInfo("pcf")
+		if info.Options == nil {
+			t.Fatal("Options is nil, which marshals to JSON null — neither thing the member can say")
+		}
+		if len(info.Options) != 0 {
+			t.Errorf("Options = %v, want empty", info.Options)
+		}
+	})
+}
+
+func TestWriteInfo(t *testing.T) {
+	t.Run("writes the members docs/plugin/SPEC.md requires", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteInfo(&buf, NewInfo("go", "encoding", "package_name")); err != nil {
+			t.Fatal(err)
+		}
+
+		var got struct {
+			Name      *string   `json:"name"`
+			Version   *string   `json:"version"`
+			IRVersion *int32    `json:"ir_version"`
+			Options   *[]string `json:"options"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("declaration is not a JSON object: %v\n%s", err, buf.String())
+		}
+
+		if got.Name == nil || *got.Name != "go" {
+			t.Errorf("name = %v, want go", got.Name)
+		}
+		if got.Version == nil || *got.Version == "" {
+			t.Errorf("version = %v, want a non-empty string", got.Version)
+		}
+		if got.IRVersion == nil || *got.IRVersion != ir.Version {
+			t.Errorf("ir_version = %v, want %d", got.IRVersion, ir.Version)
+		}
+		if got.Options == nil {
+			t.Fatal("options is absent; this generator has a vocabulary and declares it")
+		}
+		if want := []string{"encoding", "package_name"}; strings.Join(*got.Options, ",") != strings.Join(want, ",") {
+			t.Errorf("options = %v, want %v", *got.Options, want)
+		}
+	})
+
+	t.Run("an empty vocabulary is written as an empty array, never as null", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteInfo(&buf, NewInfo("pcf")); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(buf.String(), `"options": []`) {
+			t.Errorf("declaration does not carry an empty options array:\n%s", buf.String())
+		}
+	})
+
+	t.Run("a hand-built Info with no options is written the same way", func(t *testing.T) {
+		// WriteInfo normalizes rather than trusting its argument, because Info is
+		// an ordinary struct a caller may build without NewInfo, and a nil slice
+		// would otherwise reach avroc as JSON null.
+		var buf bytes.Buffer
+		if err := WriteInfo(&buf, Info{Name: "x", Version: "1", IRVersion: ir.Version}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(buf.String(), `"options": []`) {
+			t.Errorf("nil Options was not normalized:\n%s", buf.String())
+		}
+	})
+
+	t.Run("the same executable writes the same bytes every time", func(t *testing.T) {
+		// docs/plugin/SPEC.md requires the declaration to be identical across
+		// invocations, for Determinism's reasons. Ranging over a map is how that
+		// gets broken, and it breaks intermittently.
+		var first, second bytes.Buffer
+		for _, buf := range []*bytes.Buffer{&first, &second} {
+			if err := WriteInfo(buf, NewInfo("go", "encoding", "package_name")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if first.String() != second.String() {
+			t.Errorf("two declarations differ:\n%s\n%s", first.String(), second.String())
+		}
+	})
+}
+
+func TestMain_PluginInfo(t *testing.T) {
+	t.Run("writes the declaration to standard output and exits zero", func(t *testing.T) {
+		c, _ := newTestCLI(PluginInfoFlag)
+
+		var stdout bytes.Buffer
+		generated := false
+		record := func(*avrocpb.GenerateRequest, avrocpb.Generator_GenerateServer) error {
+			generated = true
+			return nil
+		}
+
+		if code := run(t.Context(), c, testInfo("k"), record, &stdout); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if generated {
+			t.Error("the handshake ran the generator; it reads no descriptor and writes no file")
+		}
+
+		var got Info
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("standard output is not the declaration: %v\n%s", err, stdout.String())
+		}
+		if got.Name != "test" {
+			t.Errorf("name = %q, want test", got.Name)
+		}
+	})
+
+	t.Run("rejects any other argument alongside it", func(t *testing.T) {
+		// The flag is the whole of its vector. Accepting a generation vector
+		// beside it would mean a plugin could be asked to do both at once, and
+		// the contract gives standard output to the declaration alone.
+		for _, args := range [][]string{
+			{PluginInfoFlag, "--out", "/tmp"},
+			{"--descriptor", "d", "--out", "o", PluginInfoFlag},
+		} {
+			var stdout bytes.Buffer
+			c, _ := newTestCLI(args...)
+
+			if code := run(t.Context(), c, testInfo(), echoGenerate, &stdout); code == 0 {
+				t.Errorf("exit code = 0 for %v", args)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("a rejected handshake still wrote to standard output: %s", stdout.String())
+			}
+		}
+	})
+
+	t.Run("a generation invocation writes nothing to standard output", func(t *testing.T) {
+		// Standard output carries exactly one thing in this contract, which is
+		// what makes the declaration parseable without a mode flag.
+		b, err := proto.Marshal(testDescriptor())
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "descriptor.binpb")
+		if err := os.WriteFile(path, b, 0o444); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		c, _ := newTestCLI("--descriptor", path, "--out", t.TempDir())
+
+		if code := run(t.Context(), c, testInfo(), echoGenerate, &stdout); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("a generation wrote to standard output: %s", stdout.String())
+		}
+	})
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/z5labs/avroc/avrocpb"
@@ -134,10 +135,11 @@ func parseOption(s string) (*avrocpb.Option, error) {
 	}, nil
 }
 
-// Usage is the one-line usage every generator in this repository prints, with
-// name the executable's own.
+// Usage is the usage every generator in this repository prints, with name the
+// executable's own. Both vectors the contract defines are listed: a generation,
+// and the capability handshake that precedes one.
 func Usage(name string) string {
-	return fmt.Sprintf("Usage: %s --descriptor <path> --out <dir> [--opt k=v ...]\n", name)
+	return fmt.Sprintf("Usage: %s --descriptor <path> --out <dir> [--opt k=v ...]\n       %s %s\n", name, name, PluginInfoFlag)
 }
 
 // ReadDescriptor reads and decodes the descriptor this invocation names,
@@ -226,15 +228,51 @@ func OutputPath(out, p string) (string, error) {
 // over a socket, and the chunks never leave the process.
 type GenerateFunc func(*avrocpb.GenerateRequest, avrocpb.Generator_GenerateServer) error
 
-// Main runs one generation from an argument vector and returns the process
-// exit status: parse the vector, read the descriptor, run generate, and write
-// what it produced beneath --out.
+// Main runs one invocation from an argument vector and returns the process exit
+// status.
+//
+// There are two vectors the contract defines. --plugin-info writes info to
+// standard output and exits zero, having read no descriptor and written no
+// file. Anything else is a generation: parse the vector, read the descriptor,
+// run generate, and write what it produced beneath --out.
 //
 // Diagnostics go to the logger, which every generator's main wires to standard
 // error. Standard output carries nothing during a generation invocation, which
-// is what keeps it free for the --plugin-info declaration (#116) and makes an
-// invocation safe to put in a pipeline.
-func Main(ctx context.Context, c cli.Context, name string, generate GenerateFunc) int {
+// is what keeps it free for the declaration and makes an invocation safe to put
+// in a pipeline.
+func Main(ctx context.Context, c cli.Context, info Info, generate GenerateFunc) int {
+	return run(ctx, c, info, generate, os.Stdout)
+}
+
+// run is Main with the declaration's destination passed in, so that a test can
+// read what a generator would have written to standard output without replacing
+// the process's own.
+func run(ctx context.Context, c cli.Context, info Info, generate GenerateFunc, stdout io.Writer) int {
+	name := info.Executable()
+
+	// Checked before the vector is parsed, and by membership rather than by
+	// position: --plugin-info accepts no other argument, so a vector carrying one
+	// is a mistake to report rather than a generation to attempt with a flag
+	// ParseArgs would call unknown.
+	if slices.Contains(c.Args, PluginInfoFlag) {
+		if len(c.Args) != 1 {
+			c.Log.ErrorContext(ctx, "invalid arguments",
+				slog.String("generator", name),
+				slog.Any("error", fmt.Errorf("%s takes no other arguments, got %v", PluginInfoFlag, c.Args)),
+			)
+			_, _ = io.WriteString(os.Stderr, Usage(name))
+			return 1
+		}
+		if err := WriteInfo(stdout, info); err != nil {
+			c.Log.ErrorContext(ctx, "failed to write the capability declaration",
+				slog.String("generator", name),
+				slog.Any("error", err),
+			)
+			return 1
+		}
+		return 0
+	}
+
 	inv, err := ParseArgs(c.Args)
 	if err != nil {
 		c.Log.ErrorContext(ctx, "invalid arguments", slog.String("generator", name), slog.Any("error", err))

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -306,7 +306,7 @@ func TestMain_WritesGeneratedFiles(t *testing.T) {
 	out := t.TempDir()
 	c, _ := newTestCLI("--descriptor", path, "--out", out)
 
-	if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code != 0 {
+	if code := Main(t.Context(), c, testInfo(), echoGenerate); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
 
@@ -335,14 +335,14 @@ func TestMain_Failures(t *testing.T) {
 
 	t.Run("an argument vector the contract does not define", func(t *testing.T) {
 		c, _ := newTestCLI("--out", t.TempDir())
-		if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code == 0 {
+		if code := Main(t.Context(), c, testInfo(), echoGenerate); code == 0 {
 			t.Error("exit code = 0 for a vector with no descriptor")
 		}
 	})
 
 	t.Run("a descriptor that is not there", func(t *testing.T) {
 		c, _ := newTestCLI("--descriptor", filepath.Join(t.TempDir(), "absent"), "--out", t.TempDir())
-		if code := Main(t.Context(), c, "avroc-gen-test", echoGenerate); code == 0 {
+		if code := Main(t.Context(), c, testInfo(), echoGenerate); code == 0 {
 			t.Error("exit code = 0 for a descriptor that does not exist")
 		}
 	})
@@ -354,7 +354,7 @@ func TestMain_Failures(t *testing.T) {
 		failing := func(*avrocpb.GenerateRequest, avrocpb.Generator_GenerateServer) error {
 			return io.ErrUnexpectedEOF
 		}
-		if code := Main(t.Context(), c, "avroc-gen-test", failing); code == 0 {
+		if code := Main(t.Context(), c, testInfo(), failing); code == 0 {
 			t.Error("exit code = 0 for a generator that returned an error")
 		}
 		if !strings.Contains(logs.String(), "failed to generate") {
@@ -372,7 +372,7 @@ func TestMain_Failures(t *testing.T) {
 				Last:    proto.Bool(false),
 			})
 		}
-		if code := Main(t.Context(), c, "avroc-gen-test", halfEmitted); code == 0 {
+		if code := Main(t.Context(), c, testInfo(), halfEmitted); code == 0 {
 			t.Error("exit code = 0 for a generator that left a file unterminated")
 		}
 	})


### PR DESCRIPTION
Closes #116

Let a plugin declare what it supports before it is handed work — most
importantly the maximum IR version it understands, so a mismatch fails early
with a clear message instead of after a confusing failed generation.

## Acceptance Criteria

- [x] **`--plugin-info` emits a machine-readable capability declaration and exits zero.**
  `internal/plugin.Info` + `WriteInfo` write the JSON object `docs/plugin/SPEC.md`
  specifies — `name`, `version`, `ir_version`, `options` — to standard output.
  `plugin.Main` routes the flag before the argument vector is parsed, reads no
  descriptor, writes no file, and rejects any argument given alongside it.
- [x] **avroc queries it before generating and fails early on an IR version mismatch.**
  `checkGenerators` runs in `runGenerate` between planning and the generator pool.
  It also fails on a declaration naming a different generator, an unparseable or
  incomplete one, and a manifest option outside a declared vocabulary.
- [x] **All three built-in generators implement it.** `avroc-gen-go` declares
  `["encoding","package_name"]`; `avroc-gen-json` and `avroc-gen-pcf` declare `[]`.
- [x] **The declaration's shape is specified in `docs/plugin/SPEC.md`.** It already
  was; this adds the two things implementing it settled — that avroc takes the
  `options` **MAY**, and why present-and-empty is not the same declaration as absent.
- [x] **A plugin that does not implement `--plugin-info` is handled per the spec
  rather than crashing the run.** Both streams are captured; a non-zero exit,
  silence, or prose on stdout becomes a run failure naming the generator and
  quoting (bounded) what it wrote.
- [x] **`go test -race ./...` passes.**

## Judgment calls that shaped the public surface

- **`plugin.Main` now takes an `Info` rather than a name string.** The declaration's
  `name` is the generator's `<name>` (`go`), not the executable's filename, and
  `Info.Executable()` derives the second from the first — so the declaration and the
  executable that wrote it cannot disagree about which generator this is.
- **avroc takes the spec's `options` **MAY** and rejects an undeclared option.**
  That makes *present-and-empty* and *absent* opposite instructions rather than two
  spellings of one, so `pluginInfo.Options` is a `*[]string` and every required
  member is a pointer — a missing `ir_version` and a declared `ir_version: 0` are
  different mistakes and must not arrive looking identical.
- **`version` is read from `runtime/debug.ReadBuildInfo`,** not a constant: avroc
  never interprets it, it only has to be fixed per executable, and a constant is a
  second place to remember on release day that goes stale silently.
- **The two halves share no code and no constant.** `internal/plugin` is the
  generator's side and `internal/avroc/plugininfo.go` is avroc's, either side of a
  process boundary, so a third-party generator implements the handshake with one
  `printf`. `TestTheDeclarationThisRepositorysGeneratorsWriteIsOneAvrocAccepts` is
  what stops them drifting.
- **Handshakes run sequentially in task order,** so a manifest with two broken
  generators reports the same one every time.

## Verification

All four of `.claude/backlog.json`'s verify commands, from the worktree:

- `go build ./...`
- `go test -race -cover ./...` — `internal/plugin` 93.3%, `internal/avroc` 85.8%
- `golangci-lint run` — 0 issues (first run reported two hits in a *deleted* sibling
  worktree from a stale lint cache; `golangci-lint cache clean` cleared it — no code
  was changed for it)
- the example round trip — the three real generators answer the handshake and
  `git diff --exit-code -- example` is clean

New tests cover the declaration's shape and determinism, the flag's routing in
`Main`, the parse (unknown members ignored, missing members, trailing data, null,
absent vs empty `options`), the checks, and the handshake over real `/bin/sh`
plugins — conforming, one that rejects the flag, one that is silent, one that
floods stdout. `TestRunGenerateStopsAtTheHandshake` drives the whole cycle and
asserts nothing was generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)