### PR TITLE
story(plugin): enforce byte-identical regeneration

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -216,6 +216,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Fmt(&parent, ctx)
+		case "IrDescriptorSet":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Avroc).IrDescriptorSet(&parent), nil
 		case "Lint":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -223,6 +230,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Lint(&parent, ctx)
+		case "Regeneration":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return nil, (*Avroc).Regeneration(&parent, ctx, platform)
 		case "Test":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -60,6 +60,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
 
 	"dagger/avroc/internal/dagger"
 )
@@ -195,6 +198,246 @@ func (m *Avroc) IrDescriptorSet() *dagger.File {
 		Container(m.Source).
 		WithExec([]string{"go", "run", "./internal/tools/ir-descriptor-set", "-o", out}).
 		File(out)
+}
+
+// Regeneration is docs/plugin/SPEC.md's determinism requirement, checked
+// rather than asserted (#120): it builds the four binaries, runs
+// `avroc generate` over the worked example in example/ twice, and requires the
+// two trees to be byte-identical — and identical to what is committed.
+//
+// Two comparisons, one function, because they need the same binaries and the
+// same worked example and two functions would drift:
+//
+//   - The two runs against each other. This is the determinism check. Generated
+//     code is a thing a project commits, so output that changes when nothing
+//     changed turns every regeneration into a diff and makes the output useless
+//     as a thing to commit. The property holds until nobody is looking, which is
+//     why it is a stage and not a paragraph.
+//   - The first run against the committed tree. This is the round-trip
+//     CONTRIBUTING.md used to run only locally. It fails when example/ was not
+//     regenerated after a change to a generator, which is the other way the
+//     committed output stops meaning anything.
+//
+// The runs deliberately disagree about everything docs/plugin/SPEC.md says a
+// generator's output must not vary with: the absolute paths in --descriptor and
+// --out, the working directory, the temporary directory, PATH beyond the entry
+// that resolves the generators, the user, the hostname, the locale and the time
+// zone. They agree about SOURCE_DATE_EPOCH, because that one is an input rather
+// than an accident of the machine — a run that varied it would be asking two
+// different questions and calling the difference a bug.
+//
+// What this cannot catch is a generator reading the clock: two runs a moment
+// apart agree on the date. internal/plugin.TestNoGeneratorReadsTheClock is the
+// static half that closes it, and internal/plugin.SourceDateEpoch is the one
+// sanctioned way to get a timestamp at all.
+//
+// platform restricts the check to one of the platforms below; empty runs every
+// one of them.
+//
+// +check
+// +cache="session"
+func (m *Avroc) Regeneration(
+	ctx context.Context,
+	// Run the check on this platform alone, as `GOOS/GOARCH` — one of the
+	// platforms the check otherwise covers. Empty covers all of them.
+	// +optional
+	platform string,
+) error {
+	platforms := regenerationPlatforms()
+	if platform != "" {
+		if !slices.Contains(platforms, dagger.Platform(platform)) {
+			return fmt.Errorf("platform %q is not one this repository targets: %v", platform, platforms)
+		}
+		platforms = []dagger.Platform{dagger.Platform(platform)}
+	}
+
+	// Every platform is checked and every failure reported, rather than
+	// stopping at the first: "it is deterministic on amd64 and not on arm64" is
+	// the finding, and a run that stopped early would hide half of it.
+	var errs []error
+	for _, p := range platforms {
+		if err := m.regenerationOn(ctx, p); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// regenerationPlatforms is every platform Regeneration covers, and it is
+// docs/container/SPEC.md's published set rather than a list invented here.
+//
+// docs/plugin/SPEC.md's "Host platform" targets POSIX hosts and distinguishes
+// nothing between Linux, macOS and the other Unixes. Neither distribution path
+// puts any of them in the position of running a generator: the image runs Linux
+// containers, and so does the companion Dagger module, whatever the host they
+// are driven from. So the platforms a generator executable actually runs on are
+// the image's, and those are the two below.
+//
+// The two share a data model — both are 64-bit and little-endian — so this is
+// not a check for an endianness bug. It is a check that the executable actually
+// published for each platform is the one that behaves, which is a different
+// claim and the only one worth making about a binary somebody else will run. A
+// contributor on macOS covers the remaining ground with `go test ./...`: the
+// per-generator determinism tests run natively on the host they are actually
+// on, which is the only way that host is ever covered at all.
+func regenerationPlatforms() []dagger.Platform {
+	return []dagger.Platform{"linux/amd64", "linux/arm64"}
+}
+
+// regenerationOn runs both generations for one platform and compares the trees.
+//
+// The comparison is `diff --recursive` in a container of the pipeline's own
+// platform rather than a digest of the two directories, for two reasons: a
+// digest reports only that something differs, where diff names the file and
+// prints the lines; and a directory digest covers metadata that two runs are
+// entitled to disagree about, which would fail the check for reasons that are
+// not the property under test.
+func (m *Avroc) regenerationOn(ctx context.Context, platform dagger.Platform) error {
+	// One build per platform, cross-compiled by the toolchain container rather
+	// than compiled under emulation, so only the generation itself runs on the
+	// target platform. CGO is off because the run container below is scratch:
+	// there is no libc in it, and nothing in avroc needs one.
+	binaries := dag.Go().Build(m.Source, dagger.GoBuildOpts{
+		Pkg:        "./cmd/...",
+		Platform:   string(platform),
+		DisableCgo: true,
+	})
+
+	committed := m.Source.Directory("example")
+	first := generateWorkedExample(binaries, committed, platform, firstRun())
+	second := generateWorkedExample(binaries, committed, platform, secondRun())
+
+	const (
+		committedAt = "/regeneration/committed"
+		firstAt     = "/regeneration/first"
+		secondAt    = "/regeneration/second"
+	)
+
+	// --text because every file either generator writes is text, and a diff that
+	// said only "binary files differ" would report the failure without reporting
+	// what it was.
+	diff := func(a, b string) []string {
+		return []string{"diff", "--recursive", "--unified", "--text", a, b}
+	}
+
+	_, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(committedAt, committed).
+		WithMountedDirectory(firstAt, first).
+		WithMountedDirectory(secondAt, second).
+		WithExec(diff(firstAt, secondAt)).
+		WithExec(diff(committedAt, firstAt)).
+		Sync(ctx)
+	return err
+}
+
+// generateWorkedExample runs `avroc generate` once over a pristine copy of the
+// worked example and returns the tree it left behind.
+//
+// The container is scratch, holding the four statically linked binaries, an
+// empty temporary directory and the example: nothing else is in it, so nothing
+// else can be what the output depended on. It is also the shape
+// docs/container/SPEC.md publishes — the CLI and the generators on PATH, no
+// shell — so a generation that needs anything more than that is a finding about
+// the image as much as about determinism.
+func generateWorkedExample(
+	binaries *dagger.Directory,
+	example *dagger.Directory,
+	platform dagger.Platform,
+	run regenerationRun,
+) *dagger.Directory {
+	c := dag.Container(dagger.ContainerOpts{Platform: platform}).
+		WithDirectory(pluginDir, binaries).
+		WithDirectory(run.tmp, dag.Directory()).
+		WithDirectory(run.root, example).
+		WithWorkdir(run.root)
+
+	// Applied in order from a slice rather than a map: the environment is part
+	// of the container's identity, and a map would vary it between two calls of
+	// this function for no reason but Go's iteration order — which is the very
+	// thing being checked for downstream.
+	for _, v := range run.env {
+		c = c.WithEnvVariable(v.name, v.value)
+	}
+
+	// The executable by absolute path, because PATH is a variable of this run
+	// rather than a thing to rely on; PATH is what avroc searches to find the
+	// generators, and that is the one job it has here.
+	return c.
+		WithExec([]string{pluginDir + "/avroc", "generate"}).
+		Directory(run.root)
+}
+
+// pluginDir is where the binaries go, and it is docs/container/SPEC.md's plugin
+// directory rather than an arbitrary one: avroc discovers generators on PATH, so
+// the run container's layout is the published image's layout.
+const pluginDir = "/usr/local/bin"
+
+// regenerationRun is one generation's arrangement of everything the output must
+// not depend on.
+type regenerationRun struct {
+	// root is the directory the worked example is copied to, and so the prefix
+	// of every absolute path avroc passes a generator in --out.
+	root string
+	// tmp is TMPDIR, and so where the descriptor avroc passes in --descriptor is
+	// written.
+	tmp string
+	env []envVar
+}
+
+type envVar struct {
+	name  string
+	value string
+}
+
+// sourceDateEpoch is the one part of the environment both runs agree on: an
+// input to generation rather than a property of the machine, so varying it
+// would make a generator that correctly honoured it fail this check. The
+// instant itself is arbitrary and fixed — 2024-06-03T00:00:00Z.
+const sourceDateEpoch = "1717372800"
+
+// firstRun and secondRun disagree about everything else. Where a value has a
+// plausible-looking default, the second run deliberately does not use it: a
+// generator that read HOME and got the same answer both times would pass a
+// check that was not looking.
+func firstRun() regenerationRun {
+	return regenerationRun{
+		root: "/work",
+		tmp:  "/tmp",
+		env: []envVar{
+			{"PATH", pluginDir},
+			{"TMPDIR", "/tmp"},
+			{"HOME", "/root"},
+			{"USER", "root"},
+			{"LOGNAME", "root"},
+			{"HOSTNAME", "builder-one"},
+			{"TZ", "UTC"},
+			{"LANG", "C"},
+			{"LC_ALL", "C"},
+			{"SOURCE_DATE_EPOCH", sourceDateEpoch},
+		},
+	}
+}
+
+func secondRun() regenerationRun {
+	return regenerationRun{
+		// Longer than the first, and at a different depth, because a path that
+		// leaked into the output would most plausibly leak as its own text.
+		root: "/srv/a-considerably-longer-project-directory",
+		tmp:  "/var/tmp/second",
+		env: []envVar{
+			{"PATH", "/nonexistent:" + pluginDir + ":/also-nonexistent"},
+			{"TMPDIR", "/var/tmp/second"},
+			{"HOME", "/home/somebody-else"},
+			{"USER", "somebody-else"},
+			{"LOGNAME", "somebody-else"},
+			{"HOSTNAME", "builder-two"},
+			{"TZ", "Pacific/Kiritimati"},
+			{"LANG", "en_US.UTF-8"},
+			{"LC_ALL", "en_US.UTF-8"},
+			{"SOURCE_DATE_EPOCH", sourceDateEpoch},
+		},
+	}
 }
 
 // stage returns the check builder the standard pipeline builds on, bound to

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,18 +28,14 @@ jobs:
   #
   # Repo-specific verification lands in this workflow the same way: as another
   # function on the root module invoked by another `dagger call`, never as raw
-  # Go steps beside it. Two things this file used to do are therefore not here:
-  #
-  #   - the example round-trip (build the four binaries, `avroc generate` in
-  #     example/, `git diff --exit-code -- example`). It stays in the local
-  #     verify list; it comes back to CI as a function on the root module once
-  #     the plugin-contract stories settle how generators are invoked at all,
-  #     because writing it against today's gRPC socket model would be writing it
-  #     twice.
-  #   - the ubuntu/macos/windows matrix. Dagger runs Linux containers, so a
-  #     matrix over runners buys nothing once the pipeline is a container, and
-  #     the Windows half of it has no target left to check: avroc targets POSIX
-  #     hosts, as docs/plugin/SPEC.md records.
+  # Go steps beside it. That is why the example round-trip is the
+  # `dagger call regeneration` step below rather than a handful of `go build`
+  # steps here, and why the ubuntu/macos/windows matrix this file used to carry
+  # is gone: Dagger runs Linux containers, so a matrix over runners buys nothing
+  # once the pipeline is a container, and the Windows half of it has no target
+  # left to check — avroc targets POSIX hosts, as docs/plugin/SPEC.md records.
+  # The platforms that do still differ are covered inside the module, by the
+  # regeneration stage, which runs on each of them.
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -81,6 +77,21 @@ jobs:
       # while CI fails.
       - name: Run the pipeline
         run: dagger call ci
+
+      # docs/plugin/SPEC.md's determinism requirement, checked rather than
+      # asserted (#120). It builds the four binaries for each platform the image
+      # ships on, generates the worked example twice under deliberately
+      # different surroundings — different absolute paths, working directory,
+      # temporary directory, user, hostname, locale and time zone — and requires
+      # the two trees to be byte-identical, and identical to what is committed.
+      #
+      # It is a separate call rather than part of `ci` because `ci` is the
+      # Z5Labs standard pipeline and this is avroc's own, not a stage every
+      # Z5Labs repository has. Determinism is the kind of property that holds
+      # until nobody is looking, and generated code that changes when nothing
+      # changed makes the committed output worthless.
+      - name: Check that regeneration is byte-identical
+        run: dagger call regeneration
 
       # The one artifact this repository builds, built on every pull request
       # rather than only at release time. Its contents are asserted by the tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,38 @@ it to each release, and `docs/container/SPEC.md` fixes the path it ships at
 inside the image. `avrocpb/descriptor_set_test.go` is the staleness gate: a new
 `.proto` that nothing in the descriptor's import graph reaches fails there.
 
+### Determinism
+
+Two runs of a generator over the same descriptor produce byte-identical output
+(`docs/plugin/SPEC.md`, "Determinism", #120). Generated code is a thing a project
+commits, so output that changes when nothing changed turns every regeneration
+into a diff. It holds regardless of the clock, the hostname, the user, the
+working directory, the locale, the absolute paths in `--descriptor` and `--out`,
+filesystem order and any concurrency — everything except `SOURCE_DATE_EPOCH`,
+which is an input rather than an accident of the machine.
+
+Three checks, because no one of them sees all of it:
+
+- **`dagger call regeneration`** (`.dagger/main.go`) builds the four binaries and
+  generates `example/` twice, in scratch containers that disagree about every one
+  of those, then byte-compares the trees. Its second comparison is the first run
+  against the committed `example/`, which is the round-trip that catches output
+  nobody regenerated; both need the same binaries and worked example, so they are
+  one function. It runs on every platform `docs/container/SPEC.md` publishes.
+- **`TestGenerateIsDeterministic`** in each generator package runs the generation
+  many times in one process. That is what exercises Go's randomised map iteration
+  order, which is the usual way the rule gets broken and the one that breaks
+  intermittently.
+- **`internal/plugin.TestNoGeneratorReadsTheClock`** parses every generator's
+  source and fails on a call that could not give the same answer twice —
+  `time.Now`, `os.Hostname`, `os.Getenv`, `os/user`, either random. Repetition
+  cannot catch a clock read, because two runs a moment apart agree on the date.
+
+`internal/plugin.SourceDateEpoch` is the only sanctioned way to get a timestamp:
+it reads `SOURCE_DATE_EPOCH`, returns UTC, and reports a malformed value rather
+than falling back to the clock. Nothing here needs it yet, and a generator that
+grows a timestamp uses it rather than inventing its own.
+
 ### Key Dependencies
 
 - `github.com/z5labs/avro-go` — Avro IDL parser

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,9 +171,10 @@ Three checks, because no one of them sees all of it:
   order, which is the usual way the rule gets broken and the one that breaks
   intermittently.
 - **`internal/plugin.TestNoGeneratorReadsTheClock`** parses every generator's
-  source and fails on a call that could not give the same answer twice —
-  `time.Now`, `os.Hostname`, `os.Getenv`, `os/user`, either random. Repetition
-  cannot catch a clock read, because two runs a moment apart agree on the date.
+  source and fails on any *reference* — called, assigned or passed — to
+  something that could not give the same answer twice: `time.Now`,
+  `os.Hostname`, `os.Getenv`, `os/user`, either random. Repetition cannot catch
+  a clock read, because two runs a moment apart agree on the date.
 
 `internal/plugin.SourceDateEpoch` is the only sanctioned way to get a timestamp:
 it reads `SOURCE_DATE_EPOCH`, returns UTC, and reports a malformed value rather

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,21 @@ These are not a second definition of the pipeline. Each drives the same builder
 `ci` drives with one stage enabled instead of four, against the same lint
 configuration, so a stage that passes on its own passes inside `ci`.
 
-`dagger check` runs all five as a checklist, if you would rather see them
-together than pick one.
+`dagger check` runs them as a checklist, if you would rather see them together
+than pick one.
+
+### Regeneration
+
+```sh
+dagger call regeneration                          # every platform
+dagger call regeneration --platform linux/arm64   # one of them
+```
+
+`regeneration` is avroc's own stage rather than part of the Z5Labs standard, so
+CI runs it as a second `dagger call` beside `ci`. It builds the four binaries,
+generates [`example/`](example/) twice, and requires the two trees to be
+byte-identical — and identical to what is committed. See
+[Determinism](#determinism) below for why both comparisons are one function.
 
 ### Getting the tools
 
@@ -136,19 +149,47 @@ schema's version, not the tool pin; the pin lives in
 [`github.com/z5labs/devex/daggerverse/go`](https://github.com/z5labs/devex/tree/main/daggerverse/go),
 which is where a bump belongs.
 
-## What the pipeline does not check yet
+## Determinism
 
-The example round-trip — build the four binaries, run `avroc generate` in
-[`example/`](example/), and confirm the committed output is unchanged — is not
-part of `dagger call ci`. It runs in the repository's local verify list instead.
+Two runs of a generator over the same descriptor produce byte-identical output.
+[`docs/plugin/SPEC.md`](docs/plugin/SPEC.md)'s *Determinism* is normative and
+binds third-party generators too; generated code is a thing a project commits,
+so output that changes when nothing changed turns every regeneration into a diff
+and makes the output useless as a thing to commit.
 
-It comes back to CI the same way everything else does: as another function on the
-root module invoked by another `dagger call`, never as raw Go steps beside it in
-[`.github/workflows/build.yaml`](.github/workflows/build.yaml). It belongs with
-the stage that generates twice and byte-compares, because that stage needs the
-same four binaries and the same worked example — one function, not two that drift.
+It is checked in three places, because no one of them can see all of it:
 
-Until then, run it by hand before pushing a change to generation:
+- **`dagger call regeneration`** generates [`example/`](example/) twice under
+  deliberately different surroundings — different absolute paths for
+  `--descriptor` and `--out`, working directory, temporary directory, `PATH`,
+  user, hostname, locale and time zone — and byte-compares the trees. It holds
+  `SOURCE_DATE_EPOCH` fixed across the two, because that one is an input to
+  generation rather than an accident of the machine. It runs on every platform
+  the image ships on.
+- **The round-trip is the same stage.** Its second comparison is the first run
+  against the committed tree, which is what fails when `example/` was not
+  regenerated after a change to a generator. Both comparisons need the same four
+  binaries and the same worked example, so they are one function rather than two
+  that drift.
+- **`go test ./...`** covers the parts a pipeline cannot. Each generator's
+  `TestGenerateIsDeterministic` runs it many times in one process, which is what
+  exercises Go's randomised map iteration order — the usual way the rule gets
+  broken, and the way that breaks intermittently rather than every time. And
+  `internal/plugin.TestNoGeneratorReadsTheClock` reads the source of every
+  generator to prove none of them can reach a clock, a hostname, a username or a
+  random value; two runs a moment apart agree on the date, so no amount of
+  repetition would catch that one.
+
+Where a generator genuinely cannot avoid a timestamp,
+`internal/plugin.SourceDateEpoch` is the only sanctioned way to get one. It
+reads `SOURCE_DATE_EPOCH` and never the clock, returns UTC because `TZ` is part
+of the environment output may not vary with, and reports a malformed value as an
+error rather than falling back — a build that quietly carries on being
+nondeterministic is the failure the whole rule exists to prevent. No generator
+here needs it yet.
+
+The round-trip is also in the local verify list, so it runs without a container
+runtime:
 
 ```sh
 go build -o ./bin/avroc ./cmd/avroc

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -523,6 +523,26 @@ The requirement is checked rather than asserted — a pipeline stage generates
 twice and byte-compares, failing on any difference (#120) — because determinism
 is the kind of property that holds until nobody is looking.
 
+That stage is `dagger call regeneration`, and the two runs it compares
+deliberately disagree about everything listed above: the absolute paths in
+`--descriptor` and `--out`, the working directory, the temporary directory,
+`PATH` beyond the entry that resolves the generators, the user, the hostname,
+the locale and the time zone. They agree about `SOURCE_DATE_EPOCH`, because
+that one is an input to generation rather than an accident of the machine. The
+stage runs on every platform avroc's image ships on
+([`../container/SPEC.md`](../container/SPEC.md)); the host platforms beyond
+those are covered by [Host platform](#host-platform) rather than by a stage,
+since neither distribution path puts one of them in the position of running a
+generator executable.
+
+Repetition catches output ordered by map iteration, because Go randomises that
+on every range. It cannot catch a clock read — two runs a moment apart agree on
+the date — so this repository's own generators are additionally held to the rule
+by a check on their source, which is what makes "no generator here can reach a
+clock, a hostname, a username or a random value" a fact rather than an
+intention. A third-party plugin is bound by the requirement above however it
+chooses to meet it.
+
 ## Capability negotiation
 
 A plugin **MUST** support being invoked as:

--- a/internal/avroc-gen-go/determinism_test.go
+++ b/internal/avroc-gen-go/determinism_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// generatedFile is one reassembled file from a generation, in the order the
+// generator emitted it.
+type generatedFile struct {
+	path    string
+	content []byte
+}
+
+// generateFiles runs one generation and reassembles the chunk stream into whole
+// files, so that a difference in chunk boundaries — which is not a difference in
+// output — cannot be mistaken for one.
+func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
+	if req.Version == nil {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := (&generatorService{}).Generate(req, cs); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	var files []generatedFile
+	index := make(map[string]int)
+	for _, msg := range cs.msgs {
+		path := msg.GetPath()
+		i, ok := index[path]
+		if !ok {
+			i = len(files)
+			index[path] = i
+			files = append(files, generatedFile{path: path})
+		}
+		files[i].content = append(files[i].content, msg.GetContent()...)
+	}
+	return files
+}
+
+// assertRepeatedGenerationsAreIdentical runs the same generation repeatedly and
+// requires every run to produce the same files with the same bytes.
+//
+// The repetition is what exercises map iteration order: Go randomises the
+// starting point of every range over a map, so a generator ordering its output
+// by one produces a different result within a handful of runs rather than
+// reliably. This is the failure docs/plugin/SPEC.md calls the usual way the rule
+// gets broken, and the one that breaks intermittently — which is worse than
+// breaking every time, because it lands in somebody else's diff.
+//
+// What it cannot catch is a clock read, since two runs a millisecond apart agree
+// on the date. internal/plugin.TestNoGeneratorReadsTheClock covers that half
+// statically.
+func assertRepeatedGenerationsAreIdentical(t *testing.T, req *avrocpb.GenerateRequest) {
+	t.Helper()
+
+	const runs = 16
+
+	first := generateFiles(t, req)
+	if len(first) == 0 {
+		t.Fatal("the generation produced no files: the case under test is empty")
+	}
+
+	for run := 1; run < runs; run++ {
+		again := generateFiles(t, req)
+		if len(again) != len(first) {
+			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
+		}
+		for i := range first {
+			if again[i].path != first[i].path {
+				t.Fatalf("run %d produced %q where run 0 produced %q", run, again[i].path, first[i].path)
+			}
+			if !bytes.Equal(again[i].content, first[i].content) {
+				t.Fatalf("run %d produced different bytes for %q:\n--- run 0 ---\n%s\n--- run %d ---\n%s",
+					run, first[i].path, first[i].content, run, again[i].content)
+			}
+		}
+	}
+}
+
+// TestGenerateIsDeterministic is #120's dynamic half for this generator: the
+// same descriptor and the same options produce the same set of paths with
+// byte-identical contents, however many times they are run.
+func TestGenerateIsDeterministic(t *testing.T) {
+	testCases := []struct {
+		name    string
+		options []*avrocpb.Option
+	}{
+		{
+			name: "plain",
+			options: []*avrocpb.Option{
+				{Name: proto.String("package_name"), Value: proto.String("avro")},
+			},
+		},
+		{
+			// The fingerprint is computed rather than copied, so it is the part of
+			// this generator's output most able to drift between two runs.
+			name: "single object encoding",
+			options: []*avrocpb.Option{
+				{Name: proto.String("encoding"), Value: proto.String("single_object")},
+				{Name: proto.String("package_name"), Value: proto.String("avro")},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRepeatedGenerationsAreIdentical(t, &avrocpb.GenerateRequest{
+				Options: tc.options,
+				Schemas: determinismSchemas(),
+			})
+		})
+	}
+}
+
+// determinismSchemas is the widest resolved input this generator has a code
+// path for: every type constructor, a named type referred to twice, and two
+// schemas, so that a run has more than one file and more than one type to order.
+func determinismSchemas() []*avrocpb.Schema {
+	const ns = "com.example"
+
+	return []*avrocpb.Schema{
+		{
+			Namespace: proto.String(ns),
+			Type: &avrocpb.Type{
+				Type: &avrocpb.Type_Record{
+					Record: &avrocpb.Record{
+						Name:      proto.String("Everything"),
+						Namespace: proto.String(ns),
+						FullName:  proto.String(ns + ".Everything"),
+						Fields: []*avrocpb.Field{
+							{
+								Name: proto.String("name"),
+								Type: primType("string"),
+							},
+							{
+								Name: proto.String("kind"),
+								Type: &avrocpb.Type{
+									Type: &avrocpb.Type_EnumType{
+										EnumType: &avrocpb.Enum{
+											Name:      proto.String("Kind"),
+											Namespace: proto.String(ns),
+											FullName:  proto.String(ns + ".Kind"),
+											Values: []*avrocpb.Ident{
+												{Value: proto.String("FOO")},
+												{Value: proto.String("BAR")},
+												{Value: proto.String("BAZ")},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: proto.String("hash"),
+								Type: &avrocpb.Type{
+									Type: &avrocpb.Type_Fixed{
+										Fixed: &avrocpb.Fixed{
+											Name:      proto.String("MD5"),
+											Namespace: proto.String(ns),
+											FullName:  proto.String(ns + ".MD5"),
+											Size:      proto.Int32(16),
+										},
+									},
+								},
+							},
+							{
+								Name: proto.String("nullableHash"),
+								Type: &avrocpb.Type{
+									Type: &avrocpb.Type_Union{
+										Union: &avrocpb.Union{
+											Types: []*avrocpb.Type{
+												primType("null"),
+												{Type: &avrocpb.Type_Reference{Reference: namedRef(ns + ".MD5")}},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: proto.String("scores"),
+								Type: &avrocpb.Type{
+									Type: &avrocpb.Type_Array{
+										Array: &avrocpb.Array{Items: primType("double")},
+									},
+								},
+							},
+							{
+								Name: proto.String("settings"),
+								Type: &avrocpb.Type{
+									Type: &avrocpb.Type_MapType{
+										MapType: &avrocpb.Map{Values: primType("string")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Namespace: proto.String(ns),
+			Type: &avrocpb.Type{
+				Type: &avrocpb.Type_Record{
+					Record: &avrocpb.Record{
+						Name:      proto.String("Simple"),
+						Namespace: proto.String(ns),
+						FullName:  proto.String(ns + ".Simple"),
+						Fields: []*avrocpb.Field{
+							{Name: proto.String("id"), Type: primType("long")},
+							{Name: proto.String("flag"), Type: primType("boolean")},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/avroc-gen-json/determinism_test.go
+++ b/internal/avroc-gen-json/determinism_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenjson
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// generatedFile is one reassembled file from a generation, in the order the
+// generator emitted it.
+type generatedFile struct {
+	path    string
+	content []byte
+}
+
+// generateFiles runs one generation and reassembles the chunk stream into whole
+// files, so that a difference in chunk boundaries — which is not a difference in
+// output — cannot be mistaken for one.
+func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
+	if req.Version == nil {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := (&generatorService{}).Generate(req, cs); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	var files []generatedFile
+	index := make(map[string]int)
+	for _, msg := range cs.msgs {
+		path := msg.GetPath()
+		i, ok := index[path]
+		if !ok {
+			i = len(files)
+			index[path] = i
+			files = append(files, generatedFile{path: path})
+		}
+		files[i].content = append(files[i].content, msg.GetContent()...)
+	}
+	return files
+}
+
+// TestGenerateIsDeterministic is #120's dynamic half for this generator: the
+// same descriptor produces the same set of paths with byte-identical contents,
+// however many times it is run.
+//
+// The repetition is what exercises map iteration order: Go randomises the
+// starting point of every range over a map, so a generator ordering its output
+// by one produces a different result within a handful of runs rather than
+// reliably. It cannot catch a clock read, since two runs a millisecond apart
+// agree on the date; internal/plugin.TestNoGeneratorReadsTheClock covers that
+// half statically.
+//
+// A JSON object is where this generator would break the rule if it were going
+// to: an Avro schema is a mapping, and emitting one from a Go map rather than
+// from the descriptor's own field order is the mistake the IR is shaped to make
+// unnecessary.
+func TestGenerateIsDeterministic(t *testing.T) {
+	const runs = 16
+
+	req := &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}
+
+	first := generateFiles(t, req)
+	if len(first) == 0 {
+		t.Fatal("the generation produced no files: the case under test is empty")
+	}
+
+	for run := 1; run < runs; run++ {
+		again := generateFiles(t, req)
+		if len(again) != len(first) {
+			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
+		}
+		for i := range first {
+			if again[i].path != first[i].path {
+				t.Fatalf("run %d produced %q where run 0 produced %q", run, again[i].path, first[i].path)
+			}
+			if !bytes.Equal(again[i].content, first[i].content) {
+				t.Fatalf("run %d produced different bytes for %q:\n--- run 0 ---\n%s\n--- run %d ---\n%s",
+					run, first[i].path, first[i].content, run, again[i].content)
+			}
+		}
+	}
+}
+
+// determinismSecondSchema is a second input, so that a run has more than one
+// file to order as well as more than one field.
+func determinismSecondSchema() *avrocpb.Schema {
+	const ns = "com.example"
+
+	return &avrocpb.Schema{
+		Namespace: proto.String(ns),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:      proto.String("Simple"),
+					Namespace: proto.String(ns),
+					FullName:  proto.String(ns + ".Simple"),
+					Fields: []*avrocpb.Field{
+						{Name: proto.String("id"), Type: primType("long")},
+						{
+							Name: proto.String("settings"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_MapType{
+									MapType: &avrocpb.Map{Values: primType("string")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/avroc-gen-pcf/determinism_test.go
+++ b/internal/avroc-gen-pcf/determinism_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenpcf
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// generatedFile is one reassembled file from a generation, in the order the
+// generator emitted it.
+type generatedFile struct {
+	path    string
+	content []byte
+}
+
+// generateFiles runs one generation and reassembles the chunk stream into whole
+// files, so that a difference in chunk boundaries — which is not a difference in
+// output — cannot be mistaken for one.
+func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
+	if req.Version == nil {
+		req = proto.CloneOf(req)
+		req.Version = proto.Int32(ir.Version)
+	}
+
+	cs := &captureStream{ctx: context.Background()}
+	if err := (&generatorService{}).Generate(req, cs); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	var files []generatedFile
+	index := make(map[string]int)
+	for _, msg := range cs.msgs {
+		path := msg.GetPath()
+		i, ok := index[path]
+		if !ok {
+			i = len(files)
+			index[path] = i
+			files = append(files, generatedFile{path: path})
+		}
+		files[i].content = append(files[i].content, msg.GetContent()...)
+	}
+	return files
+}
+
+// TestGenerateIsDeterministic is #120's dynamic half for this generator: the
+// same descriptor produces the same set of paths with byte-identical contents,
+// however many times it is run.
+//
+// The repetition is what exercises map iteration order: Go randomises the
+// starting point of every range over a map, so a generator ordering its output
+// by one produces a different result within a handful of runs rather than
+// reliably. It cannot catch a clock read, since two runs a millisecond apart
+// agree on the date; internal/plugin.TestNoGeneratorReadsTheClock covers that
+// half statically.
+//
+// Determinism matters more here than anywhere else in the repository. A Parsing
+// Canonical Form is what a schema fingerprint is computed over, so a byte that
+// moves is not a diff — it is a different fingerprint, and a reader that can no
+// longer identify a writer's messages.
+func TestGenerateIsDeterministic(t *testing.T) {
+	const runs = 16
+
+	req := &avrocpb.GenerateRequest{
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}
+
+	first := generateFiles(t, req)
+	if len(first) == 0 {
+		t.Fatal("the generation produced no files: the case under test is empty")
+	}
+
+	for run := 1; run < runs; run++ {
+		again := generateFiles(t, req)
+		if len(again) != len(first) {
+			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
+		}
+		for i := range first {
+			if again[i].path != first[i].path {
+				t.Fatalf("run %d produced %q where run 0 produced %q", run, again[i].path, first[i].path)
+			}
+			if !bytes.Equal(again[i].content, first[i].content) {
+				t.Fatalf("run %d produced different bytes for %q:\n--- run 0 ---\n%s\n--- run %d ---\n%s",
+					run, first[i].path, first[i].content, run, again[i].content)
+			}
+		}
+	}
+}
+
+// determinismSecondSchema is a second input, so that a run has more than one
+// file to order as well as more than one field.
+func determinismSecondSchema() *avrocpb.Schema {
+	const ns = "com.example"
+
+	return &avrocpb.Schema{
+		Namespace: proto.String(ns),
+		Type: &avrocpb.Type{
+			Type: &avrocpb.Type_Record{
+				Record: &avrocpb.Record{
+					Name:      proto.String("Simple"),
+					Namespace: proto.String(ns),
+					FullName:  proto.String(ns + ".Simple"),
+					Fields: []*avrocpb.Field{
+						{
+							Name: proto.String("id"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_Reference{Reference: primRef("long")},
+							},
+						},
+						{
+							Name: proto.String("settings"),
+							Type: &avrocpb.Type{
+								Type: &avrocpb.Type_MapType{
+									MapType: &avrocpb.Map{
+										Values: &avrocpb.Type{
+											Type: &avrocpb.Type_Reference{Reference: primRef("string")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// generatorPackages are the directories that make up the generator half of
+// docs/plugin/SPEC.md: the three built-in generators, the shared IR operations
+// they perform, and this package, through which all three run.
+//
+// They are named as paths rather than imported because the check below is a
+// property of the source, not of a running program.
+func generatorPackages() []string {
+	return []string{
+		".",
+		filepath.Join("..", "avroc-gen-go"),
+		filepath.Join("..", "avroc-gen-json"),
+		filepath.Join("..", "avroc-gen-pcf"),
+		filepath.Join("..", "ir"),
+	}
+}
+
+// forbiddenCalls maps an import path to the functions in it whose result
+// differs between two runs of the same executable over the same descriptor.
+// docs/plugin/SPEC.md's "Determinism" forbids their results reaching a
+// generator's output; forbidding the calls outright is the checkable form of
+// that, and costs nothing, because no generator here has a use for one.
+//
+// SourceDateEpoch is the sanctioned way to get a timestamp and it reads the
+// environment rather than the clock, which is why time.Unix is not here.
+func forbiddenCalls() map[string]map[string]string {
+	const (
+		clock   = "reads the wall clock; use plugin.SourceDateEpoch, which does not"
+		ambient = "reads the machine rather than the descriptor"
+		env     = "reads the environment; everything that configures a generator arrives as --opt"
+	)
+
+	return map[string]map[string]string{
+		"time": {
+			"Now":   clock,
+			"Since": clock,
+			"Until": clock,
+		},
+		"os": {
+			"Hostname":    ambient,
+			"Getpid":      ambient,
+			"Getppid":     ambient,
+			"Getuid":      ambient,
+			"Geteuid":     ambient,
+			"Getgid":      ambient,
+			"Getwd":       ambient,
+			"UserHomeDir": ambient,
+			"Getenv":      env,
+			"LookupEnv":   env,
+			"Environ":     env,
+		},
+	}
+}
+
+// forbiddenImports are packages with no deterministic use at all, so importing
+// one is itself the finding. os/user answers questions about the machine; both
+// randoms answer differently every time by construction.
+func forbiddenImports() map[string]string {
+	const (
+		random  = "randomness has no place in generated output"
+		ambient = "reads the machine rather than the descriptor"
+	)
+
+	return map[string]string{
+		"math/rand":    random,
+		"math/rand/v2": random,
+		"crypto/rand":  random,
+		"os/user":      ambient,
+	}
+}
+
+// TestNoGeneratorReadsTheClock is the static half of #120: no built-in
+// generator embeds a timestamp, a hostname, a username or a random value,
+// because none of them can reach one.
+//
+// It is static on purpose. The dynamic half — running a generator twice and
+// comparing the bytes, in each generator's own determinism test and in
+// `dagger call regeneration` — catches output ordered by map iteration, because
+// Go randomises that on every range. It cannot catch a clock read: two runs a
+// millisecond apart produce the same date, so a generator stamping one passes
+// every repetition test there is and turns up a year later in somebody else's
+// diff. Reading the source is what closes that gap.
+//
+// Test files are excluded. A test may read the clock freely; what it must not
+// do is put the result in a generator's output, and none does.
+func TestNoGeneratorReadsTheClock(t *testing.T) {
+	for _, dir := range generatorPackages() {
+		sources := nonTestSources(t, dir)
+		if len(sources) == 0 {
+			t.Fatalf("no non-test Go source found in %s: the check is looking in the wrong place", dir)
+		}
+
+		for _, path := range sources {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("failed to parse %s: %v", path, err)
+			}
+			for _, finding := range nondeterminismIn(fset, file) {
+				t.Errorf("%s (docs/plugin/SPEC.md, Determinism)", finding)
+			}
+		}
+	}
+}
+
+// nonTestSources lists the Go source files in dir that are compiled into the
+// generator, which is every .go file that is not a test.
+func nonTestSources(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+
+	var sources []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sources = append(sources, filepath.Join(dir, name))
+	}
+	return sources
+}
+
+// nondeterminismIn reports every forbidden import and call in one file, each as
+// a finished sentence naming the position. It returns findings rather than
+// failing a test so that the check can be tested against source that must fail
+// it.
+//
+// Local import names are resolved rather than assumed, so an aliased import
+// cannot smuggle a forbidden call past the selector check.
+func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
+	calls, imports := forbiddenCalls(), forbiddenImports()
+	var findings []string
+
+	// Local name to import path, for the packages this check has an opinion
+	// about. A dot import would bind names with no qualifier at all, putting
+	// them out of the selector check's reach; it is reported rather than
+	// resolved, because nothing here uses one.
+	watched := make(map[string]string)
+	for _, spec := range file.Imports {
+		at := fset.Position(spec.Pos())
+
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			findings = append(findings, fmt.Sprintf("%s: unparseable import path %s", at, spec.Path.Value))
+			continue
+		}
+		if why, forbidden := imports[path]; forbidden {
+			findings = append(findings, fmt.Sprintf("%s imports %q: %s", at, path, why))
+			continue
+		}
+		if _, ok := calls[path]; !ok {
+			continue
+		}
+		local := path[strings.LastIndex(path, "/")+1:]
+		if spec.Name != nil {
+			if spec.Name.Name == "." {
+				findings = append(findings, fmt.Sprintf(
+					"%s dot-imports %q, putting its names out of reach of the determinism check", at, path))
+				continue
+			}
+			local = spec.Name.Name
+		}
+		watched[local] = path
+	}
+	if len(watched) == 0 {
+		return findings
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		path, ok := watched[ident.Name]
+		if !ok {
+			return true
+		}
+		why, forbidden := calls[path][sel.Sel.Name]
+		if !forbidden {
+			return true
+		}
+		findings = append(findings, fmt.Sprintf("%s calls %s.%s: %s",
+			fset.Position(sel.Pos()), path, sel.Sel.Name, why))
+		return true
+	})
+
+	return findings
+}
+
+// TestDeterminismCheckSeesAForbiddenCall guards the check against its own worst
+// failure. A scan that reports nothing because it resolves no import, or looks
+// at the wrong identifier, passes silently and forever; feeding it source that
+// must fail is the only way to know it can fail at all.
+func TestDeterminismCheckSeesAForbiddenCall(t *testing.T) {
+	testCases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "a plain call",
+			src:  "package p\n\nimport \"time\"\n\nfunc f() any { return time.Now() }\n",
+		},
+		{
+			name: "behind an alias",
+			src:  "package p\n\nimport clock \"time\"\n\nfunc f() any { return clock.Now() }\n",
+		},
+		{
+			name: "the environment",
+			src:  "package p\n\nimport \"os\"\n\nfunc f() string { return os.Getenv(\"USER\") }\n",
+		},
+		{
+			name: "a forbidden import",
+			src:  "package p\n\nimport \"os/user\"\n\nfunc f() any { u, _ := user.Current(); return u }\n",
+		},
+		{
+			name: "a dot import of a watched package",
+			src:  "package p\n\nimport . \"time\"\n\nfunc f() any { return Now() }\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if findings := findingsFor(t, tc.src); len(findings) == 0 {
+				t.Errorf("the determinism check accepted source it must reject:\n%s", tc.src)
+			}
+		})
+	}
+}
+
+// TestDeterminismCheckAcceptsDeterministicSource is the other half: a check
+// that reported everything would be as useless as one that reported nothing,
+// and would make every deterministic use of a watched package unwritable.
+func TestDeterminismCheckAcceptsDeterministicSource(t *testing.T) {
+	testCases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "a timestamp from SOURCE_DATE_EPOCH",
+			src:  "package p\n\nimport \"time\"\n\nfunc f(sec int64) time.Time { return time.Unix(sec, 0).UTC() }\n",
+		},
+		{
+			name: "reading the descriptor from disk",
+			src:  "package p\n\nimport \"os\"\n\nfunc f(p string) ([]byte, error) { return os.ReadFile(p) }\n",
+		},
+		{
+			name: "a method that happens to be called Now",
+			src:  "package p\n\ntype c struct{}\n\nfunc (c) Now() int { return 0 }\n\nfunc f(x c) int { return x.Now() }\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if findings := findingsFor(t, tc.src); len(findings) > 0 {
+				t.Errorf("the determinism check rejected deterministic source: %v\n%s", findings, tc.src)
+			}
+		})
+	}
+}
+
+// findingsFor parses one snippet of source and runs the check over it.
+func findingsFor(t *testing.T, src string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "case.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("failed to parse the case: %v", err)
+	}
+	return nondeterminismIn(fset, file)
+}

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -33,15 +33,21 @@ func generatorPackages() []string {
 	}
 }
 
-// forbiddenCalls maps an import path to the functions in it whose result
+// forbiddenFuncs maps an import path to the functions in it whose result
 // differs between two runs of the same executable over the same descriptor.
 // docs/plugin/SPEC.md's "Determinism" forbids their results reaching a
-// generator's output; forbidding the calls outright is the checkable form of
-// that, and costs nothing, because no generator here has a use for one.
+// generator's output; forbidding them outright is the checkable form of that,
+// and costs nothing, because no generator here has a use for one.
+//
+// What is forbidden is naming one of them at all, not calling one: the check
+// below matches any reference, so `at := time.Now` is a finding as much as
+// `time.Now()` is. That is deliberate. A function value is the same clock read
+// one level of indirection away, and it is exactly what somebody reaches for
+// when they want the call to be hard to see.
 //
 // SourceDateEpoch is the sanctioned way to get a timestamp and it reads the
 // environment rather than the clock, which is why time.Unix is not here.
-func forbiddenCalls() map[string]map[string]string {
+func forbiddenFuncs() map[string]map[string]string {
 	const (
 		clock   = "reads the wall clock; use plugin.SourceDateEpoch, which does not"
 		ambient = "reads the machine rather than the descriptor"
@@ -142,15 +148,17 @@ func nonTestSources(t *testing.T, dir string) []string {
 	return sources
 }
 
-// nondeterminismIn reports every forbidden import and call in one file, each as
-// a finished sentence naming the position. It returns findings rather than
-// failing a test so that the check can be tested against source that must fail
-// it.
+// nondeterminismIn reports every forbidden import and every reference to a
+// forbidden function in one file, each as a finished sentence naming the
+// position. It returns findings rather than failing a test so that the check
+// can be tested against source that must fail it.
 //
-// Local import names are resolved rather than assumed, so an aliased import
-// cannot smuggle a forbidden call past the selector check.
+// It matches selectors, not call expressions, so a forbidden function is
+// reported wherever it is named — passed, assigned or called. Local import
+// names are resolved rather than assumed, so an aliased import cannot smuggle
+// one past either.
 func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
-	calls, imports := forbiddenCalls(), forbiddenImports()
+	funcs, imports := forbiddenFuncs(), forbiddenImports()
 	var findings []string
 
 	// Local name to import path, for the packages this check has an opinion
@@ -170,7 +178,7 @@ func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
 			findings = append(findings, fmt.Sprintf("%s imports %q: %s", at, path, why))
 			continue
 		}
-		if _, ok := calls[path]; !ok {
+		if _, ok := funcs[path]; !ok {
 			continue
 		}
 		local := path[strings.LastIndex(path, "/")+1:]
@@ -201,11 +209,11 @@ func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
 		if !ok {
 			return true
 		}
-		why, forbidden := calls[path][sel.Sel.Name]
+		why, forbidden := funcs[path][sel.Sel.Name]
 		if !forbidden {
 			return true
 		}
-		findings = append(findings, fmt.Sprintf("%s calls %s.%s: %s",
+		findings = append(findings, fmt.Sprintf("%s references %s.%s, which %s",
 			fset.Position(sel.Pos()), path, sel.Sel.Name, why))
 		return true
 	})
@@ -213,11 +221,11 @@ func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
 	return findings
 }
 
-// TestDeterminismCheckSeesAForbiddenCall guards the check against its own worst
-// failure. A scan that reports nothing because it resolves no import, or looks
-// at the wrong identifier, passes silently and forever; feeding it source that
-// must fail is the only way to know it can fail at all.
-func TestDeterminismCheckSeesAForbiddenCall(t *testing.T) {
+// TestDeterminismCheckSeesAForbiddenReference guards the check against its own
+// worst failure. A scan that reports nothing because it resolves no import, or
+// looks at the wrong identifier, passes silently and forever; feeding it source
+// that must fail is the only way to know it can fail at all.
+func TestDeterminismCheckSeesAForbiddenReference(t *testing.T) {
 	testCases := []struct {
 		name string
 		src  string
@@ -237,6 +245,16 @@ func TestDeterminismCheckSeesAForbiddenCall(t *testing.T) {
 		{
 			name: "a forbidden import",
 			src:  "package p\n\nimport \"os/user\"\n\nfunc f() any { u, _ := user.Current(); return u }\n",
+		},
+		{
+			// Named but not called: the function value is the same clock read
+			// with one more step in front of it.
+			name: "assigned rather than called",
+			src:  "package p\n\nimport \"time\"\n\nfunc f() any { at := time.Now; return at }\n",
+		},
+		{
+			name: "passed as an argument",
+			src:  "package p\n\nimport \"time\"\n\nfunc g(any) {}\n\nfunc f() { g(time.Now) }\n",
 		},
 		{
 			name: "a dot import of a watched package",

--- a/internal/plugin/sourcedateepoch.go
+++ b/internal/plugin/sourcedateepoch.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+// SourceDateEpochVar is the environment variable docs/plugin/SPEC.md's
+// "Determinism" names, and the only part of the environment a generator's
+// output may vary with.
+const SourceDateEpochVar = "SOURCE_DATE_EPOCH"
+
+// SourceDateEpoch reports the timestamp a generator must use where a timestamp
+// in its output is genuinely unavoidable, and whether there is one at all.
+//
+// It is the only clock in this repository's generator half, and it is not a
+// clock: the value comes from the environment, so two runs of the same
+// executable over the same descriptor produce the same timestamp however far
+// apart they are. docs/plugin/SPEC.md's "Determinism" (#120) is normative —
+// a plugin MUST use SOURCE_DATE_EPOCH when it is set and MUST NOT read the
+// clock — and internal/plugin.TestNoGeneratorReadsTheClock is what holds
+// every generator here to it.
+//
+// The three cases, and why each is what it is:
+//
+//   - Set to a count of seconds since the Unix epoch: that instant in UTC,
+//     with ok true. UTC rather than the local zone because TZ is part of the
+//     environment a generator's output may not vary with, and a timestamp
+//     rendered in the builder's zone varies with it.
+//   - Unset, or set to the empty string: the zero time, with ok false, and the
+//     caller SHOULD omit the timestamp rather than reach for the clock. A
+//     missing generation date costs a reader nothing and a present one costs
+//     every regeneration a diff. Empty counts as unset because an exported-but-
+//     empty variable is how a shell spells "no value", and reading it as a
+//     malformed one would fail runs that meant to set nothing.
+//   - Set to anything else: an error, which the caller reports rather than
+//     works around. Falling back to the clock on a malformed value would make
+//     the output nondeterministic exactly when somebody was trying to pin it
+//     down, which is the failure this whole rule exists to prevent. A negative
+//     count is malformed for the same reason it is in the Reproducible Builds
+//     definition: it is a typo, not a date before 1970 that anybody meant.
+//
+// No generator here currently emits a timestamp — nothing in Go source, an
+// Avro schema in JSON or a Parsing Canonical Form needs one — so this has no
+// caller in this repository yet. It exists because the alternative to one
+// tested implementation is the first generator that needs a date inventing its
+// own, and every implementation of this that reads the clock as a fallback is
+// a generator that is deterministic until the day somebody looks.
+func SourceDateEpoch(env cli.Environment) (t time.Time, ok bool, err error) {
+	raw, set := env.LookupEnv(SourceDateEpochVar)
+	if !set || raw == "" {
+		return time.Time{}, false, nil
+	}
+
+	seconds, parseErr := strconv.ParseInt(raw, 10, 64)
+	if parseErr != nil {
+		return time.Time{}, false, fmt.Errorf("%s=%q is not a decimal count of seconds since the Unix epoch", SourceDateEpochVar, raw)
+	}
+	if seconds < 0 {
+		return time.Time{}, false, fmt.Errorf("%s=%q is negative", SourceDateEpochVar, raw)
+	}
+
+	return time.Unix(seconds, 0).UTC(), true, nil
+}

--- a/internal/plugin/sourcedateepoch_test.go
+++ b/internal/plugin/sourcedateepoch_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/z5labs/avroc/internal/cli"
+)
+
+// envValue is an environment holding exactly one variable, so that a case can
+// say what SOURCE_DATE_EPOCH is without anything else being readable.
+func envValue(value string) cli.Environment {
+	return cli.EnvironmentFunc(func(key string) (string, bool) {
+		if key != SourceDateEpochVar {
+			return "", false
+		}
+		return value, true
+	})
+}
+
+func envUnset() cli.Environment {
+	return cli.EnvironmentFunc(func(string) (string, bool) { return "", false })
+}
+
+func TestSourceDateEpoch(t *testing.T) {
+	testCases := []struct {
+		name string
+		env  cli.Environment
+		want time.Time
+		ok   bool
+	}{
+		{
+			name: "unset omits the timestamp",
+			env:  envUnset(),
+			ok:   false,
+		},
+		{
+			name: "empty is unset",
+			env:  envValue(""),
+			ok:   false,
+		},
+		{
+			name: "the epoch itself is a value, not an absence",
+			env:  envValue("0"),
+			want: time.Unix(0, 0).UTC(),
+			ok:   true,
+		},
+		{
+			name: "a count of seconds",
+			env:  envValue("1717372800"),
+			want: time.Date(2024, time.June, 3, 0, 0, 0, 0, time.UTC),
+			ok:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok, err := SourceDateEpoch(tc.env)
+			if err != nil {
+				t.Fatalf("SourceDateEpoch returned an error: %v", err)
+			}
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("time = %v, want %v", got, tc.want)
+			}
+			if ok && got.Location() != time.UTC {
+				t.Errorf("location = %v, want UTC", got.Location())
+			}
+		})
+	}
+}
+
+// TestSourceDateEpochRejects covers the values that must fail the run rather
+// than fall back to the clock. A malformed value is somebody trying to pin the
+// output down and getting the spelling wrong, so the one thing that must not
+// happen is a build that quietly carries on being nondeterministic.
+func TestSourceDateEpochRejects(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{name: "not a number", value: "yesterday"},
+		{name: "an RFC 3339 timestamp", value: "2024-06-03T00:00:00Z"},
+		{name: "fractional seconds", value: "1717372800.5"},
+		{name: "surrounded by whitespace", value: " 1717372800 "},
+		{name: "hexadecimal", value: "0x665d3f00"},
+		{name: "negative", value: "-1"},
+		{name: "wider than an int64", value: "99999999999999999999"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok, err := SourceDateEpoch(envValue(tc.value))
+			if err == nil {
+				t.Fatalf("expected an error for %q, got %v (ok=%v)", tc.value, got, ok)
+			}
+			if ok {
+				t.Errorf("ok = true alongside an error")
+			}
+			if !got.IsZero() {
+				t.Errorf("time = %v, want the zero time alongside an error", got)
+			}
+		})
+	}
+}
+
+// TestSourceDateEpochReadsNothingElse pins the half of the rule that is about
+// the rest of the environment: a generator's output may vary with
+// SOURCE_DATE_EPOCH and with nothing else, so this is the only key the lookup
+// is allowed to reach for. TZ in particular would change the rendered date
+// without changing the instant.
+func TestSourceDateEpochReadsNothingElse(t *testing.T) {
+	var read []string
+	env := cli.EnvironmentFunc(func(key string) (string, bool) {
+		read = append(read, key)
+		return "1717372800", true
+	})
+
+	if _, _, err := SourceDateEpoch(env); err != nil {
+		t.Fatalf("SourceDateEpoch returned an error: %v", err)
+	}
+
+	if len(read) != 1 || read[0] != SourceDateEpochVar {
+		t.Errorf("looked up %v, want exactly [%s]", read, SourceDateEpochVar)
+	}
+}


### PR DESCRIPTION
Closes #120

Determinism was implied by a `git diff --exit-code -- example` step at the end of the local verify list — a side effect of an example round-trip rather than a stated requirement anyone designs against. This promotes it to a checked property.

## Acceptance criteria

- [x] **A pipeline stage generates twice and byte-compares, failing on any difference.** `dagger call regeneration` builds the four binaries, runs `avroc generate` over `example/` twice into two separate trees, and `diff --recursive`s them. The two runs deliberately disagree about everything `docs/plugin/SPEC.md` says output must not vary with: the absolute paths in `--descriptor` and `--out`, the working directory, `TMPDIR`, `PATH` beyond the entry that resolves the generators, `USER`/`LOGNAME`/`HOME`, `HOSTNAME`, `TZ` and the locale. They agree about `SOURCE_DATE_EPOCH`, which is an input to generation rather than an accident of the machine.
- [x] **No built-in generator embeds a timestamp, hostname, or map-iteration-ordered output.** Two checks, because neither sees the whole thing. `TestGenerateIsDeterministic` in each generator package repeats the generation 16 times in one process — that is what exercises Go's randomised map iteration order, the failure the spec calls the usual way this rule gets broken. `internal/plugin.TestNoGeneratorReadsTheClock` parses every non-test file of the three generators, `internal/ir` and `internal/plugin`, and fails on `time.Now`, `os.Hostname`, `os.Getenv`, `os/user`, either `rand` and friends — resolving import aliases, so an alias cannot smuggle one past. Repetition cannot catch a clock read: two runs a millisecond apart agree on the date.
- [x] **`SOURCE_DATE_EPOCH` is honoured where a timestamp is unavoidable.** `internal/plugin.SourceDateEpoch` is the one sanctioned way to get a timestamp. It reads the environment and never the clock, returns UTC (`TZ` is part of the environment output may not vary with), treats unset and empty as "omit the timestamp", and reports a malformed or negative value as an error rather than falling back — a build that quietly carries on being nondeterministic is the failure the rule exists to prevent. No generator here needs it yet; it exists so the first one that does has an implementation to use instead of inventing one.
- [x] **The stage is a function on the root Dagger module invoked by `dagger call`.** `Regeneration` in `.dagger/main.go`, marked `+check`. `.github/workflows/build.yaml` gains one step, `dagger call regeneration`, and no raw Go steps.
- [x] **The check covers every host platform the platform decision claims to support.** `regenerationPlatforms` is `docs/container/SPEC.md`'s published set — `linux/amd64` and `linux/arm64` — rather than a list invented in the module. `docs/plugin/SPEC.md`'s *Host platform* targets POSIX hosts and distinguishes nothing between Linux, macOS and the other Unixes, and neither distribution path (the image, the companion Dagger module) puts one of them in the position of running a generator executable, so the platforms a generator actually runs on are the image's. A contributor on macOS covers the rest with `go test ./...`, which runs the per-generator determinism tests natively.

## Judgment calls

- **The round-trip moved into the same stage.** `CONTRIBUTING.md` already recorded that it "belongs with the stage that generates twice and byte-compares, because that stage needs the same four binaries and the same worked example — one function, not two that drift". So `Regeneration` makes two comparisons: the two runs against each other (determinism) and the first run against the committed `example/` (the round-trip). The round-trip stays in the local verify list too, so it still runs without a container runtime.
- **Binaries are cross-compiled, not built under emulation.** Only the generation itself runs on the target platform, which keeps the arm64 half to seconds instead of minutes.
- **The run container is `scratch`.** The four statically linked binaries, an empty `TMPDIR` and the example, and nothing else — so nothing else can be what the output depended on. It is also the shape `docs/container/SPEC.md` publishes, so a generation needing more than that would be a finding about the image too.
- **`diff --recursive` rather than a directory digest.** A digest reports only that something differs; `diff` names the file and prints the lines. A directory digest also covers metadata two runs are entitled to disagree about.
- **New public surface:** none. `plugin.SourceDateEpoch` and `plugin.SourceDateEpochVar` are in an `internal/` package.

## Verified

All four local verify commands pass: `go build ./...`, `go test -race -cover ./...`, `golangci-lint run` (0 issues), and the example round-trip. `dagger call ci` and `dagger call regeneration` both pass locally on both platforms.

The stage was checked against failures it must catch, not only against passing:

- appending a line to the committed `example/gen/test_record.go` failed the committed-vs-first comparison with the offending diff hunk;
- temporarily making `avroc-gen-pcf` append `os.Getenv("HOSTNAME")` to its output failed the first-vs-second comparison (`…builder-one` vs `…builder-two`), proving the two runs genuinely differ in their surroundings, and failed `TestNoGeneratorReadsTheClock` at `generate.go:52:29`;
- `TestDeterminismCheckSeesAForbiddenCall` and `TestDeterminismCheckAcceptsDeterministicSource` keep the static scan honest in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
