### PR TITLE
story(container): publish the avroc base image

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -216,6 +216,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Fmt(&parent, ctx)
+		case "Image":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return (*Avroc).Image(&parent, ctx, platform)
+		case "ImageContract":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return nil, (*Avroc).ImageContract(&parent, ctx, platform)
 		case "IrDescriptorSet":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -230,6 +258,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Lint(&parent, ctx)
+		case "Publish":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			var username string
+			if inputArgs["username"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			return (*Avroc).Publish(&parent, ctx, address, username, password)
 		case "Regeneration":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -1,0 +1,622 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// This file builds and checks the published base image — the one
+// docs/container/SPEC.md describes and strangers' Dockerfiles name paths inside
+// (#126).
+//
+// # Why the image is built here rather than by the GoApp archetype
+//
+// The base-image story opened with a blocker and three ways out: extend the
+// devex GoApp archetype upstream to accept image customization, build the image
+// in this module, or accept a non-scratch base. This file is the second, and the
+// reason is that the first two are not alternatives at the same level.
+//
+// GoApp's imageForPlatform produces a scratch image holding one binary at
+// /app/<binaryName>, with that path as the entrypoint and nothing else set: no
+// PATH, no USER, no working directory, no second binary, no data file. avroc's
+// image has to promise all six, because it is a base that other people build
+// FROM — and four of the six are not settings GoApp is missing so much as a
+// different shape of image. avroc publishes one image containing four binaries,
+// three of which are plugins found by a PATH search rather than run as the
+// entrypoint; GoApp publishes one image per binary. Teaching GoApp that shape
+// would be teaching it avroc's plugin model, which is a contract in this
+// repository's docs/ and belongs nowhere else. What would be left upstream after
+// the customization was general enough to keep — a settable USER, WORKDIR and
+// PATH — is a handful of Container calls, which is precisely what is below.
+//
+// The third way out, a non-scratch base, was rejected on the contract rather
+// than on size. docs/container/SPEC.md's "No shell" is a load-bearing promise:
+// it is what makes extension COPY-only, and what makes the image's contents
+// exactly the executables somebody deliberately put there. A distroless or
+// busybox base would be a smaller change here and a larger one there.
+//
+// What is *not* rebuilt here is anything about what "checked" means. fmt, vet,
+// lint and `go test -race` still route through the Z5Labs standard by way of Ci,
+// the binaries are still built by the shared devex Go module's Build, and this
+// file adds only the image layout the standard has no opinion about. That is the
+// split main.go's package comment anticipated, and no upstream devex change was
+// needed to reach it.
+//
+// # Why the contract is a check rather than a comment
+//
+// Every promise docs/container/SPEC.md makes is a value in an OCI image
+// configuration or a file in the filesystem it describes, so every one of them
+// is machine-checkable — and each is the kind of promise that breaks silently.
+// A base image whose PATH lost /usr/local/bin still runs avroc perfectly and
+// fails only in somebody else's repository, at the point where their generator
+// is not found. ImageContract is that document's Compatibility guarantees table
+// executed rather than read.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"dagger/avroc/internal/dagger"
+)
+
+// The published image's contract, as constants. Each one is a row of
+// docs/container/SPEC.md's compatibility guarantees table, and changing one here
+// without changing it there is the drift ImageContract exists to catch.
+//
+// pluginDir lives in main.go, because the regeneration stage's scratch container
+// is deliberately the same layout as the published image and both read it.
+const (
+	// workDir is the working directory a caller mounts a project at.
+	workDir = "/work"
+
+	// tmpDir is a writable temporary directory, and it is the one thing in the
+	// image that docs/container/SPEC.md does not name — deliberately, since that
+	// document lists it under everything in the filesystem that is
+	// implementation detail rather than a covered guarantee.
+	//
+	// It is here because avroc writes each invocation's descriptor into a
+	// directory it creates under os.TempDir, so a scratch image without one
+	// fails every generation with `stat /tmp: no such file or directory` — the
+	// first thing ImageContract caught. tmpDirMode is 1777, root-owned,
+	// world-writable and sticky, which is the ordinary arrangement and the one
+	// that keeps working when a caller overrides the UID with
+	// `--user $(id -u):$(id -g)`.
+	tmpDir     = "/tmp"
+	tmpDirMode = 0o1777
+
+	// imageUID and imageGID are the pinned non-root identity the image runs as.
+	// They are numbers rather than a name because the image has no /etc/passwd
+	// for a name to resolve against, and because a derived Dockerfile's
+	// COPY --chown and a Kubernetes securityContext are both written against
+	// the number.
+	imageUID = 65532
+	imageGID = 65532
+
+	// imageUser is that identity in the form the OCI configuration's User field
+	// and Dagger's owner arguments both take.
+	imageUser = "65532:65532"
+
+	// descriptorSetPath is where the IR FileDescriptorSet ships, for a plugin
+	// author whose language has no protobuf code generation in the build.
+	descriptorSetPath = "/usr/local/share/avroc/ir.binpb"
+)
+
+// imagePlatforms is the set of platforms the image is published for, and the
+// single definition of it in this module — the regeneration stage covers the
+// same set, because the platforms a generator executable actually runs on are
+// the image's.
+func imagePlatforms() []dagger.Platform {
+	return []dagger.Platform{"linux/amd64", "linux/arm64"}
+}
+
+// Image builds the published base image for one platform.
+//
+// It is the image docs/container/SPEC.md describes, and every promise that
+// document makes is made here: the CLI and the three generators in
+// /usr/local/bin with that directory on PATH, the CLI as the entrypoint with an
+// empty Cmd, /work as the working directory, UID and GID 65532 owning both
+// directories and running the process, the IR FileDescriptorSet at its
+// documented path, and nothing else in the filesystem at all.
+//
+// platform defaults to the engine's own, which is what makes
+// `dagger call image` useful from a checkout; a value must be one of the
+// published platforms, so a typo is an error rather than an image nobody
+// publishes.
+func (m *Avroc) Image(
+	ctx context.Context,
+	// Build for this platform, as `GOOS/GOARCH` — one of the published
+	// platforms. Empty builds for the engine's own platform.
+	// +optional
+	platform string,
+) (*dagger.Container, error) {
+	p, err := imagePlatform(ctx, platform)
+	if err != nil {
+		return nil, err
+	}
+	return m.image(p), nil
+}
+
+// Publish pushes the image to address as a multi-platform index covering every
+// platform in imagePlatforms, and returns the digest-qualified reference it
+// pushed.
+//
+// address carries the tag, because which tags exist and when each one moves is
+// docs/container/SPEC.md's "Tags and what pinning one buys" rather than this
+// function's: a function that assembled a tag from the refs at HEAD would be a
+// second place the tag scheme is written down. The caller names the reference
+// and this pushes exactly it.
+//
+// One index rather than one image per platform, so that a `FROM` line naming the
+// tag resolves to the manifest for whatever platform the builder is on, which is
+// what makes the published set of platforms invisible to a derived Dockerfile.
+func (m *Avroc) Publish(
+	ctx context.Context,
+	// The full image reference to push, including the tag.
+	address string,
+	// The registry username to authenticate as. Both this and password are
+	// needed for a registry that requires authentication, which is every
+	// registry this project publishes to.
+	// +optional
+	username string,
+	// The registry password or token to authenticate with.
+	// +optional
+	password *dagger.Secret,
+) (string, error) {
+	platforms := imagePlatforms()
+	variants := make([]*dagger.Container, 0, len(platforms))
+	for _, p := range platforms {
+		variants = append(variants, m.image(p))
+	}
+
+	c := dag.Container()
+	if username != "" && password != nil {
+		c = c.WithRegistryAuth(address, username, password)
+	}
+	return c.Publish(ctx, address, dagger.ContainerPublishOpts{PlatformVariants: variants})
+}
+
+// ImageContract checks the published image against every promise
+// docs/container/SPEC.md makes about it (#126).
+//
+// It is a check rather than a paragraph because each promise is depended on from
+// a repository this project cannot see and breaks without breaking anything
+// here: an image whose PATH lost the plugin directory runs avroc perfectly and
+// fails at the point where somebody else's generator is not found.
+//
+// Three groups, all on the real image rather than on a description of it:
+//
+//   - The OCI configuration — Entrypoint, Cmd, User, WorkingDir and PATH.
+//   - The filesystem, as an exact list of every path in it with its owner and
+//     mode. Exact rather than a spot check, because "the base is scratch plus
+//     the files this document names" is the promise, and it is the same
+//     assertion as no shell, no libc and no package manager.
+//   - The image actually generating the worked example, run through its own
+//     entrypoint with the example mounted at the working directory and no
+//     arguments beyond `generate` — which is the invocation the document gives.
+//     It runs twice, as the image's own UID and as an overridden one, because
+//     "an overridden UID is an ordinary configuration, not a workaround" is
+//     itself a promise, and because output owned by whichever UID wrote it is
+//     what makes `--user $(id -u):$(id -g)` the recommended invocation.
+//
+// platform restricts the check to one of the published platforms; empty runs
+// every one of them, and every failure is reported rather than the first,
+// because "it holds on amd64 and not on arm64" is the finding.
+//
+// +check
+// +cache="session"
+func (m *Avroc) ImageContract(
+	ctx context.Context,
+	// Run the check on this platform alone, as `GOOS/GOARCH` — one of the
+	// published platforms. Empty covers all of them.
+	// +optional
+	platform string,
+) error {
+	platforms := imagePlatforms()
+	if platform != "" {
+		if !slices.Contains(platforms, dagger.Platform(platform)) {
+			return fmt.Errorf("platform %q is not one this repository publishes: %v", platform, platforms)
+		}
+		platforms = []dagger.Platform{dagger.Platform(platform)}
+	}
+
+	var errs []error
+	for _, p := range platforms {
+		if err := m.imageContractOn(ctx, p); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// image is the base image for one platform, and the one definition of it: Image
+// and Publish both come through here, so there is no arrangement in which the
+// image a check passed is not the image that was pushed.
+//
+// The binaries are cross-compiled by the toolchain container rather than
+// compiled under emulation, and CGO is off because the image is scratch: there
+// is no libc in it, and a dynamically linked executable would find no loader and
+// fail with `no such file or directory` naming a file that is plainly there.
+//
+// The order of the calls below is the order docs/container/SPEC.md states the
+// promises in, which is not an accident worth preserving so much as one worth
+// not breaking: WithEntrypoint clears Cmd, so it comes before the WithoutDefaultArgs
+// that asserts Cmd is empty rather than after it.
+func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
+	binaries := dag.Go().Build(m.Source, dagger.GoBuildOpts{
+		Pkg:        "./cmd/...",
+		Platform:   string(platform),
+		DisableCgo: true,
+	})
+
+	return dag.Container(dagger.ContainerOpts{Platform: platform}).
+		// The plugin directory, owned by the image's user so that a generator
+		// copied in by a derived image lands somewhere that user can execute
+		// from. The CLI goes here too; its path is explicitly not part of the
+		// contract, and this is simply the one directory the image has.
+		WithDirectory(pluginDir, binaries, dagger.ContainerWithDirectoryOpts{
+			Owner: imageUser,
+		}).
+		// The FileDescriptorSet, world-readable because a caller who overrides
+		// the UID reads the same file.
+		WithFile(descriptorSetPath, m.IrDescriptorSet(), dagger.ContainerWithFileOpts{
+			Owner:       imageUser,
+			Permissions: 0o644,
+		}).
+		// The working directory has to exist in the base image and be owned by
+		// the image's user: a caller who mounts over it inherits nothing
+		// surprising, and one who does not can still generate into it.
+		WithDirectory(workDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{
+			Owner: imageUser,
+		}).
+		// A temporary directory, because avroc writes each invocation's
+		// descriptor into one. Not owned by the image's user: 1777 is what makes
+		// it usable by whichever UID the container is actually running as.
+		WithDirectory("/", tmpDirectory()).
+		// PATH is set outright rather than appended to, because a scratch image
+		// has no PATH to append to. Only the guarantee that it contains the
+		// plugin directory is covered; the rest of the value is not.
+		WithEnvVariable("PATH", pluginDir).
+		WithWorkdir(workDir).
+		WithUser(imageUser).
+		WithEntrypoint([]string{pluginDir + "/avroc"}).
+		WithoutDefaultArgs()
+}
+
+// tmpDirectory is a directory holding nothing but `tmp`, with mode 1777, for
+// grafting onto the image's root.
+//
+// It is staged by a real mkdir in a container that has one rather than by
+// WithDirectory's permissions argument, because that argument sets the mode of
+// the files copied *into* a directory and not the mode of the directory itself
+// — which leaves /tmp root-owned at 0755, and every generation failing with
+// `permission denied` the moment the process is not root. That was the second
+// thing ImageContract caught, and it is the reason the check runs the image
+// rather than only reading its configuration.
+func tmpDirectory() *dagger.Directory {
+	const staging = "/staging"
+
+	return dag.Go().
+		Container(dag.Directory()).
+		WithExec([]string{"install", "-d", "-m", "1777", staging + tmpDir}).
+		Directory(staging)
+}
+
+// imageContractOn checks one platform's image.
+//
+// Every group is run and every failure collected rather than stopping at the
+// first: a change that broke the entrypoint most likely broke the user and the
+// working directory too, and one run should say so.
+func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) error {
+	image := m.image(platform)
+
+	errs := m.checkImageConfig(ctx, image)
+	errs = append(errs, m.checkImageFilesystem(ctx, image)...)
+	errs = append(errs, m.checkImageGenerates(ctx, image)...)
+	return errors.Join(errs...)
+}
+
+// checkImageConfig checks the fields of the OCI image configuration a derived
+// image inherits.
+func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) []error {
+	var errs []error
+
+	entrypoint, err := image.Entrypoint(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading Entrypoint: %w", err))
+	case len(entrypoint) == 0:
+		errs = append(errs, errors.New("the image's Entrypoint is empty: a derived image inherits no program"))
+	}
+
+	args, err := image.DefaultArgs(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading Cmd: %w", err))
+	case len(args) != 0:
+		errs = append(errs, fmt.Errorf("the image's Cmd is %v, want empty: a caller's arguments are avroc's arguments", args))
+	}
+
+	user, err := image.User(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading User: %w", err))
+	case user != imageUser:
+		errs = append(errs, fmt.Errorf("the image's User is %q, want %q", user, imageUser))
+	}
+
+	workdir, err := image.Workdir(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading WorkingDir: %w", err))
+	case workdir != workDir:
+		errs = append(errs, fmt.Errorf("the image's WorkingDir is %q, want %q", workdir, workDir))
+	}
+
+	path, err := image.EnvVariable(ctx, "PATH")
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading PATH: %w", err))
+	case !slices.Contains(strings.Split(path, ":"), pluginDir):
+		errs = append(errs, fmt.Errorf("PATH is %q, which does not contain the plugin directory %q", path, pluginDir))
+	}
+
+	return errs
+}
+
+// imageContents is every path the image is allowed to contain, with the owner
+// and mode each one must have.
+//
+// It is exhaustive on purpose. docs/container/SPEC.md's "No shell" says the base
+// is scratch plus the files that document names, and an exhaustive list is the
+// only form of that claim which stays true when somebody adds a file: a spot
+// check for /bin/sh passes on an image carrying a busybox under another name.
+//
+// The parent directories are root-owned and that is intentional — only the
+// plugin directory and the working directory are promised to the image's user,
+// and a root-owned parent with mode 0755 is what stops the running user
+// replacing the tree above them.
+func imageContents() map[string]imageEntry {
+	const (
+		dirMode        = 0o755
+		executableMode = 0o755
+		dataMode       = 0o644
+	)
+
+	contents := map[string]imageEntry{
+		"/usr":                   {0, 0, dirMode},
+		"/usr/local":             {0, 0, dirMode},
+		"/usr/local/share":       {0, 0, dirMode},
+		"/usr/local/share/avroc": {0, 0, dirMode},
+		descriptorSetPath:        {imageUID, imageGID, dataMode},
+		pluginDir:                {imageUID, imageGID, dirMode},
+		workDir:                  {imageUID, imageGID, dirMode},
+		tmpDir:                   {0, 0, tmpDirMode},
+	}
+	for _, name := range imageExecutables() {
+		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
+	}
+	return contents
+}
+
+// imageExecutables is what ships in the plugin directory: the CLI, and avroc's
+// own generators as the first consumers of the contract every third-party
+// generator image is built against.
+func imageExecutables() []string {
+	return []string{"avroc", "avroc-gen-go", "avroc-gen-json", "avroc-gen-pcf"}
+}
+
+// imageEntry is one path's expected ownership and mode.
+type imageEntry struct {
+	uid  int
+	gid  int
+	mode int
+}
+
+func (e imageEntry) String() string {
+	return fmt.Sprintf("%d:%d %04o", e.uid, e.gid, e.mode)
+}
+
+// checkImageFilesystem compares every path in the image against imageContents.
+//
+// The listing is produced by one `find` in a container that has one, over the
+// image's root filesystem mounted as data. It cannot be produced by running
+// anything *in* the image, which is the point of the image having no shell, and
+// a Dagger Entries walk would report the paths without their owners — and
+// ownership is half of what is being checked.
+func (m *Avroc) checkImageFilesystem(ctx context.Context, image *dagger.Container) []error {
+	const mountedAt = "/image"
+
+	// Numeric %U and %G rather than %u and %g: the listing container has no
+	// passwd entry for 65532, so the symbolic forms would print the number
+	// anyway on a good day and a name on a bad one.
+	listing, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(mountedAt, image.Rootfs()).
+		WithExec([]string{
+			"find", mountedAt, "-mindepth", "1", "-printf", `%U %G %m %p\n`,
+		}).
+		Stdout(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("listing the image filesystem: %w", err)}
+	}
+
+	want := imageContents()
+	got := make(map[string]imageEntry, len(want))
+
+	var errs []error
+	for _, line := range strings.Split(strings.TrimSpace(listing), "\n") {
+		if line == "" {
+			continue
+		}
+		entry, path, err := parseFindLine(line, mountedAt)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		got[path] = entry
+	}
+
+	for path, wantEntry := range want {
+		gotEntry, ok := got[path]
+		switch {
+		case !ok:
+			errs = append(errs, fmt.Errorf("%s: missing from the image", path))
+		case gotEntry != wantEntry:
+			errs = append(errs, fmt.Errorf("%s: is %v, want %v", path, gotEntry, wantEntry))
+		}
+	}
+	for path := range got {
+		if _, ok := want[path]; !ok {
+			errs = append(errs, fmt.Errorf("%s: present in the image and not in the contract; the base is scratch plus the files docs/container/SPEC.md names, and nothing else", path))
+		}
+	}
+
+	// Sorted, because a map walk would order the failures differently on every
+	// run and make two reports of one break look like two breaks.
+	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
+	return errs
+}
+
+// parseFindLine reads one `%U %G %m %p` line and strips the mount prefix, so
+// that the paths compared are the paths inside the image.
+func parseFindLine(line, prefix string) (imageEntry, string, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 4 {
+		return imageEntry{}, "", fmt.Errorf("unreadable listing line %q", line)
+	}
+
+	var entry imageEntry
+	if _, err := fmt.Sscanf(fields[0], "%d", &entry.uid); err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable uid in %q: %w", line, err)
+	}
+	if _, err := fmt.Sscanf(fields[1], "%d", &entry.gid); err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable gid in %q: %w", line, err)
+	}
+	if _, err := fmt.Sscanf(fields[2], "%o", &entry.mode); err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable mode in %q: %w", line, err)
+	}
+	return entry, strings.TrimPrefix(fields[3], prefix), nil
+}
+
+// checkImageGenerates runs the image the way docs/container/SPEC.md says to run
+// it, and checks both what it produced and who owns it.
+//
+// Twice, as two different users. The first run is the documented default. The
+// second overrides the UID the way a caller writing output into a bind mount is
+// told to, and is what turns "an overridden UID is an ordinary configuration"
+// from a sentence into something that fails when it stops being true.
+func (m *Avroc) checkImageGenerates(ctx context.Context, image *dagger.Container) []error {
+	committed := m.Source.Directory("example")
+
+	var errs []error
+	for _, user := range []string{imageUser, "1234:1234"} {
+		generated := generateInImage(image, committed, user)
+
+		if err := m.diffAgainstCommitted(ctx, committed, generated, user); err != nil {
+			errs = append(errs, err)
+		}
+		if err := m.checkOutputOwnership(ctx, generated, user); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// generateInImage runs `generate` through the image's own entrypoint over a
+// copy of the worked example mounted at the working directory, and returns the
+// tree it left behind.
+//
+// UseEntrypoint is what makes this the same invocation as
+// `docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc:v0 generate`: the
+// arguments are avroc's arguments, and nothing here names the CLI by path. No
+// environment is set either — the image's own PATH is what has to resolve the
+// three generators, which is the one job it has.
+func generateInImage(image *dagger.Container, example *dagger.Directory, user string) *dagger.Directory {
+	return image.
+		WithUser(user).
+		WithDirectory(workDir, example, dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Directory(workDir)
+}
+
+// diffAgainstCommitted requires the generated tree to be byte-identical to the
+// committed worked example.
+//
+// diff rather than a directory digest, for the reason the regeneration stage
+// gives: a digest reports only that something differs, and covers metadata two
+// runs are entitled to disagree about.
+func (m *Avroc) diffAgainstCommitted(
+	ctx context.Context,
+	committed, generated *dagger.Directory,
+	user string,
+) error {
+	const (
+		committedAt = "/image-contract/committed"
+		generatedAt = "/image-contract/generated"
+	)
+
+	_, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(committedAt, committed).
+		WithMountedDirectory(generatedAt, generated).
+		WithExec([]string{"diff", "--recursive", "--unified", "--text", committedAt, generatedAt}).
+		Sync(ctx)
+	if err != nil {
+		return fmt.Errorf("as user %s, the image did not reproduce the committed example: %w", user, err)
+	}
+	return nil
+}
+
+// checkOutputOwnership requires every file the run produced to be owned by the
+// UID and GID the container was running as.
+//
+// That is what makes `--user $(id -u):$(id -g)` the recommended invocation
+// rather than a workaround: a caller's host kernel sees a number, and the number
+// it sees has to be theirs.
+func (m *Avroc) checkOutputOwnership(ctx context.Context, generated *dagger.Directory, user string) error {
+	const mountedAt = "/output"
+
+	listing, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(mountedAt, generated).
+		WithExec([]string{"find", mountedAt, "-mindepth", "1", "-printf", `%U:%G %p\n`}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("listing the output of the run as user %s: %w", user, err)
+	}
+
+	var wrong []string
+	for _, line := range strings.Split(strings.TrimSpace(listing), "\n") {
+		if line == "" {
+			continue
+		}
+		owner, path, ok := strings.Cut(line, " ")
+		if !ok {
+			return fmt.Errorf("unreadable listing line %q", line)
+		}
+		if owner != user {
+			wrong = append(wrong, fmt.Sprintf("%s is owned by %s", strings.TrimPrefix(path, mountedAt), owner))
+		}
+	}
+	if len(wrong) > 0 {
+		slices.Sort(wrong)
+		return fmt.Errorf("running as user %s wrote output owned by somebody else: %s", user, strings.Join(wrong, "; "))
+	}
+	return nil
+}
+
+// imagePlatform resolves the platform argument Image takes: empty is the
+// engine's own, and anything else has to be a platform this repository actually
+// publishes, so that a typo is an error rather than an image nobody ships.
+func imagePlatform(ctx context.Context, platform string) (dagger.Platform, error) {
+	if platform == "" {
+		return dag.DefaultPlatform(ctx)
+	}
+	platforms := imagePlatforms()
+	if !slices.Contains(platforms, dagger.Platform(platform)) {
+		return "", fmt.Errorf("platform %q is not one this repository publishes: %v", platform, platforms)
+	}
+	return dagger.Platform(platform), nil
+}

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -170,8 +170,20 @@ func (m *Avroc) Publish(
 		variants = append(variants, m.image(p))
 	}
 
+	// Half a credential is refused rather than quietly dropped. Skipping the
+	// auth because one of the two is missing turns a typo into an anonymous
+	// push, which fails at the registry with a message about permissions rather
+	// than about the argument that was actually wrong — and on a registry that
+	// happened to allow it, would not fail at all.
+	switch {
+	case username != "" && password == nil:
+		return "", errors.New("username was given without password: both are needed to authenticate, and publishing with neither pushes anonymously")
+	case username == "" && password != nil:
+		return "", errors.New("password was given without username: both are needed to authenticate, and publishing with neither pushes anonymously")
+	}
+
 	c := dag.Container()
-	if username != "" && password != nil {
+	if username != "" {
 		c = c.WithRegistryAuth(address, username, password)
 	}
 	return c.Publish(ctx, address, dagger.ContainerPublishOpts{PlatformVariants: variants})
@@ -322,12 +334,30 @@ func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) e
 func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) []error {
 	var errs []error
 
+	// The structural half of the entrypoint guarantee. Exactly one element,
+	// because "the arguments a caller passes to docker run are avroc's
+	// arguments" is only true when there is nothing in Entrypoint for them to
+	// arrive after; and that element has to be an executable the image actually
+	// ships, because Entrypoint is otherwise free to name a path that is not
+	// there and fail at run time in somebody else's pipeline.
+	//
+	// It is deliberately not compared to a literal, since the CLI's own path is
+	// implementation detail and pinning it here would make a promise this
+	// project has explicitly not made. What pins the entrypoint to the CLI
+	// rather than to one of the generators is checkImageGenerates, which runs
+	// `generate` through it and byte-compares the result: the guarantee is about
+	// behaviour, so the behaviour is what checks it.
+	executables := imageExecutablePaths()
 	entrypoint, err := image.Entrypoint(ctx)
 	switch {
 	case err != nil:
 		errs = append(errs, fmt.Errorf("reading Entrypoint: %w", err))
 	case len(entrypoint) == 0:
 		errs = append(errs, errors.New("the image's Entrypoint is empty: a derived image inherits no program"))
+	case len(entrypoint) > 1:
+		errs = append(errs, fmt.Errorf("the image's Entrypoint is %v, want exactly one element: a caller's arguments are avroc's arguments, and anything else here would come before them", entrypoint))
+	case !slices.Contains(executables, entrypoint[0]):
+		errs = append(errs, fmt.Errorf("the image's Entrypoint is %v, which is not one of the executables the image ships (%v)", entrypoint, executables))
 	}
 
 	args, err := image.DefaultArgs(ctx)
@@ -405,6 +435,17 @@ func imageContents() map[string]imageEntry {
 // generator image is built against.
 func imageExecutables() []string {
 	return []string{"avroc", "avroc-gen-go", "avroc-gen-json", "avroc-gen-pcf"}
+}
+
+// imageExecutablePaths is imageExecutables where they land, which is what an
+// Entrypoint would have to name.
+func imageExecutablePaths() []string {
+	names := imageExecutables()
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		paths = append(paths, pluginDir+"/"+name)
+	}
+	return paths
 }
 
 // imageEntry is one path's expected ownership and mode.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -37,11 +37,11 @@
 // that as-is, and deciding how it should is a live design question that belongs
 // to the base-image story rather than being pre-decided here by an archetype.
 //
-// So this module takes the checks and the base-image work owns how images get
-// built — whether that means extending GoApp upstream in devex, building the
-// image in this module, or using a non-scratch base. Moving to GoApp is a change
-// to which factory New calls, plus dropping .git from the ignore list below; it
-// is not a change to what the pipeline is.
+// So this module takes the checks from the standard and builds the image itself,
+// in image.go, which records why that was chosen over extending GoApp upstream
+// or accepting a non-scratch base (#126). Moving the *checks* to GoApp remains a
+// change to which factory New calls, plus dropping .git from the ignore list
+// below; it is not a change to what the pipeline is.
 //
 // # Why the stage functions exist alongside it
 //
@@ -264,7 +264,9 @@ func (m *Avroc) Regeneration(
 }
 
 // regenerationPlatforms is every platform Regeneration covers, and it is
-// docs/container/SPEC.md's published set rather than a list invented here.
+// docs/container/SPEC.md's published set rather than a list invented here — it
+// is imagePlatforms, read from the one place that set is written down, so a
+// platform added to the image is checked for determinism in the same change.
 //
 // docs/plugin/SPEC.md's "Host platform" targets POSIX hosts and distinguishes
 // nothing between Linux, macOS and the other Unixes. Neither distribution path
@@ -281,7 +283,7 @@ func (m *Avroc) Regeneration(
 // per-generator determinism tests run natively on the host they are actually
 // on, which is the only way that host is ever covered at all.
 func regenerationPlatforms() []dagger.Platform {
-	return []dagger.Platform{"linux/amd64", "linux/arm64"}
+	return imagePlatforms()
 }
 
 // regenerationOn runs both generations for one platform and compares the trees.
@@ -370,7 +372,8 @@ func generateWorkedExample(
 
 // pluginDir is where the binaries go, and it is docs/container/SPEC.md's plugin
 // directory rather than an arbitrary one: avroc discovers generators on PATH, so
-// the run container's layout is the published image's layout.
+// the run container's layout is the published image's layout. image.go reads the
+// same constant, which is what makes that sentence true rather than aspirational.
 const pluginDir = "/usr/local/bin"
 
 // regenerationRun is one generation's arrangement of everything the output must

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,25 @@ jobs:
       - name: Check that regeneration is byte-identical
         run: dagger call regeneration
 
+      # docs/container/SPEC.md's compatibility guarantees table, executed
+      # rather than read (#126). It builds the published base image for each
+      # platform it ships on and checks every promise that document makes about
+      # it: the plugin directory and its place on PATH, the entrypoint, the
+      # empty Cmd, the working directory, the pinned non-root UID, the absence
+      # of a shell — as an exact listing of every path in the image — the
+      # FileDescriptorSet's path, and the image actually generating the worked
+      # example through its own entrypoint, as itself and as an overridden UID.
+      #
+      # It runs on every pull request rather than only at release time because
+      # each of those promises is depended on from a repository this project
+      # cannot see, and breaks without breaking anything here: an image whose
+      # PATH lost /usr/local/bin runs avroc perfectly and fails at the point
+      # where somebody else's generator is not found. Nothing is pushed, so
+      # this job still needs no `packages: write`; release.yaml is what
+      # publishes.
+      - name: Check the base image against its contract
+        run: dagger call image-contract
+
       # The one artifact this repository builds, built on every pull request
       # rather than only at release time. Its contents are asserted by the tests
       # `dagger call ci` just ran — that the set covers proto/, resolves on its

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,3 +69,59 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             "$RUNNER_TEMP/ir.binpb" --clobber
+
+  # The published base image (#126) — the one docs/container/SPEC.md describes
+  # and strangers' Dockerfiles say FROM.
+  #
+  # Only the full version tag is pushed here. docs/container/SPEC.md publishes
+  # four tags and promises that a full version tag never moves while the other
+  # three do; the moving ones, together with signatures, provenance and an SBOM,
+  # are #128's, and they are a change to this job rather than to the module,
+  # because which tags exist is a property of a release and not of an image.
+  image:
+    name: Base image
+    runs-on: ubuntu-latest
+    permissions:
+      # Reading the source, and writing the package. Both grants are here rather
+      # than at the top of the file because this is the only job that pushes
+      # anything, and a grant held in advance is one nothing accounts for.
+      contents: read
+      packages: write
+    steps:
+      # At the release's tag, for the same reason the asset above is built
+      # there: the image is a function of the source, and an image built from a
+      # different commit would be a different program wearing the tag.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install the Dagger CLI
+        run: |
+          curl -fsSL https://dl.dagger.io/dagger/install.sh \
+            | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
+              BIN_DIR="$HOME/.local/bin" sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The same contract check CI runs on every pull request, run once more
+      # against the tag before anything is pushed. A tag is published once and
+      # never repointed, so this is the last moment at which a broken promise
+      # costs nothing.
+      - name: Check the base image against its contract
+        run: dagger call image-contract
+
+      # One multi-platform index covering linux/amd64 and linux/arm64, so that a
+      # `FROM` line naming the tag resolves to the manifest for whatever
+      # platform the builder is on.
+      #
+      # The address is assembled here rather than in the module: the module
+      # pushes the reference it is given, and a function that derived a tag from
+      # the refs at HEAD would be a second place the tag scheme is written down.
+      - name: Build and publish it
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dagger call publish \
+            --address "ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}" \
+            --username "${{ github.actor }}" \
+            --password env://REGISTRY_PASSWORD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,31 @@ it reads `SOURCE_DATE_EPOCH`, returns UTC, and reports a malformed value rather
 than falling back to the clock. Nothing here needs it yet, and a generator that
 grows a timestamp uses it rather than inventing its own.
 
+### The published image
+
+`.dagger/image.go` builds the base image `docs/container/SPEC.md` describes, and
+that document is normative: `/usr/local/bin` on `PATH` holding the CLI and the
+three generators, the CLI as `Entrypoint` with an empty `Cmd`, `/work` as
+`WorkingDir`, UID and GID 65532 owning both directories and running the process,
+the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a `scratch`
+base — no shell, no libc, no package manager, so extension is `COPY`-only. The
+one thing in the filesystem the document does not name is a 1777 `/tmp`, which
+avroc needs because it writes each invocation's descriptor under `os.TempDir`.
+
+It is built here rather than by the devex `GoApp` archetype, whose image half
+produces one scratch image per binary with `/app/<binaryName>` as entrypoint and
+nothing else set; `image.go`'s package comment records why that was the choice
+over extending `GoApp` upstream or accepting a non-scratch base (#126). The
+check stages still route through the Z5Labs standard, so there is still one
+definition of what "checked" means.
+
+`dagger call image-contract` is the compatibility guarantees table executed
+rather than read — the OCI configuration, an *exact* listing of every path in
+the image with its owner and mode, and the image generating `example/` through
+its own entrypoint both as 65532 and as an overridden UID. CI runs it on every
+pull request; `dagger call publish --address <ref>` pushes a multi-platform
+index and is called only from `.github/workflows/release.yaml`.
+
 ### Key Dependencies
 
 - `github.com/z5labs/avro-go` — Avro IDL parser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,41 @@ generates [`example/`](example/) twice, and requires the two trees to be
 byte-identical — and identical to what is committed. See
 [Determinism](#determinism) below for why both comparisons are one function.
 
+### The base image
+
+```sh
+dagger call image-contract                          # every platform
+dagger call image-contract --platform linux/arm64   # one of them
+
+dagger call image export --path ./avroc.tar         # build one, to look at
+```
+
+`image` builds the image [`docs/container/SPEC.md`](docs/container/SPEC.md)
+describes — the one other people's Dockerfiles say `FROM` — and
+`image-contract` is that document's compatibility guarantees table executed
+rather than read: the plugin directory and its place on `PATH`, the entrypoint,
+the empty `Cmd`, the working directory, the pinned non-root UID, the absence of
+a shell, the `FileDescriptorSet`'s path, and the image generating
+[`example/`](example/) through its own entrypoint as itself and as an overridden
+UID.
+
+It is a check because every one of those promises is depended on from a
+repository this project cannot see and breaks without breaking anything here: an
+image whose `PATH` lost `/usr/local/bin` runs avroc perfectly and fails at the
+point where somebody else's generator is not found.
+
+To run the image the way a consumer does, load the tarball and mount a project
+at `/work`:
+
+```sh
+docker load -i ./avroc.tar
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/example:/work" <image> generate
+```
+
+`dagger call publish --address …` pushes a multi-platform index. Nothing but
+[`.github/workflows/release.yaml`](.github/workflows/release.yaml) should call
+it.
+
 ### Getting the tools
 
 The pipeline needs the Dagger CLI and a container runtime (Docker or Podman).

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -274,6 +274,16 @@ hard way by somebody:
   arguments, or against an image built `FROM` this one with a busybox copied in
   for the purpose.
 
+One directory in the image holds no file and is worth naming anyway: there is a
+writable temporary directory, because avroc writes each invocation's descriptor
+into a directory it creates under one. It is **not covered** — its path, its
+mode and its existence are [implementation
+detail](#compatibility-guarantees) like everything else in the filesystem that
+is not named above, and a derived image that wrote into it by path would be
+depending on something that may change in a patch release. It is mentioned here
+only so that "scratch plus the files named above" is not read as a promise that
+the image cannot write anywhere at all.
+
 Keeping the shell out is the same decision as having no plugin registry: the
 image's contents are exactly the executables somebody deliberately put there,
 and there is nothing else in it to run, exploit or depend on by accident.


### PR DESCRIPTION
Closes #126

Builds the image [`docs/container/SPEC.md`](docs/container/SPEC.md) describes — the one strangers'
Dockerfiles say `FROM` — in avroc's own Dagger module, checks every promise that document makes
about it, and publishes a multi-platform index from the release workflow.

## The `GoApp` blocker, and how it was resolved

**Resolution: option 2 — build the image in avroc's own Dagger module.** No upstream devex change
was needed, so there is nothing to link. `.dagger/image.go`'s package comment is the record.

`GoApp`'s `imageForPlatform` produces a `scratch` image holding **one** binary at
`/app/<binaryName>`, with that path as the entrypoint and nothing else set: no `PATH`, no `USER`,
no `WorkingDir`, no second binary, no data file. avroc's image has to promise all six. Four of
them are not settings `GoApp` is missing so much as a different *shape* of image: avroc publishes
one image containing four binaries, three of which are plugins found by a `PATH` search rather
than run as the entrypoint, where `GoApp` publishes one image per binary. Teaching `GoApp` that
shape would be teaching it avroc's plugin model, which is a contract in this repository's `docs/`.
What would have been left upstream after the customization was general enough to keep — a settable
`USER`, `WORKDIR` and `PATH` — is a handful of `Container` calls, which is what `image.go` now is.

Option 3, a non-scratch base, was rejected on the contract rather than on size: "No shell" is
load-bearing, because it is what makes extension `COPY`-only.

The check stages are untouched. `fmt`, `vet`, `lint` and `go test -race` still route through the
Z5Labs standard by way of `Ci`, and the binaries are still built by the shared devex `Go` module's
`Build`, so there is still exactly one definition of what "checked" means.

## Acceptance criteria

- [x] **A stable plugin directory exists inside the image and is on `PATH`.** `/usr/local/bin`,
  and `PATH` is set to it. The constant is shared with the regeneration stage, so the scratch
  container that stage generates in *is* the published layout rather than merely resembling it.
- [x] **The avroc CLI is the image entrypoint.** `Entrypoint` is the CLI and `Cmd` is empty, so a
  caller's arguments are avroc's arguments.
- [x] **A pinned non-root UID owns the plugin directory, and generated output is written as that
  UID.** 65532:65532 owns `/usr/local/bin` and `/work`, and `User` is `65532:65532`. Checked by
  running a generation and requiring every file it produced to be owned by the UID the container
  was running as — once as 65532, once as an overridden 1234, which is also what checks the
  document's promise that `--user $(id -u):$(id -g)` is an ordinary configuration.
- [x] **Shell presence matches what `docs/container/SPEC.md` promises.** The base is `scratch`.
  Checked as an *exhaustive* listing of every path in the image with its owner and mode — a spot
  check for `/bin/sh` passes on an image carrying a busybox under another name.
- [x] **The IR `FileDescriptorSet` ships at the documented path.**
  `/usr/local/share/avroc/ir.binpb`, mode 0644, from the same `IrDescriptorSet` function the
  release asset is built by.
- [x] **The image is built for at least `linux/amd64` and `linux/arm64`.** `imagePlatforms` is now
  the single definition of that set, and `regenerationPlatforms` reads it, so a platform added to
  the image is checked for determinism in the same change.
- [x] **`docker run --rm -v $PWD:/work ghcr.io/z5labs/avroc:<tag> generate` works against the
  example project.** Verified literally — see below — and checked in CI through the image's own
  entrypoint against `example/`, byte-compared to the committed tree.
- [x] **The chosen resolution to the `GoApp` blocker is recorded, and any upstream devex change is
  linked from this issue.** Recorded above and in `.dagger/image.go`. No upstream change was
  required.

## Two findings the check caught

Both are why `ImageContract` runs the image rather than only reading its configuration:

1. **A `scratch` image has no `/tmp`**, and avroc writes each invocation's descriptor into a
   directory it creates under `os.TempDir` — so every generation failed with
   `stat /tmp: no such file or directory`.
2. **`WithDirectory`'s `permissions` argument sets the mode of the files copied *into* a directory,
   not the mode of the directory itself**, which left `/tmp` root-owned at 0755 and every
   generation failing with `permission denied` the moment the process was not root. It is now
   staged with a real `install -d -m 1777`.

`/tmp` is the one thing in the image `docs/container/SPEC.md` does not name. This adds a short
paragraph to "No shell" saying it exists and is explicitly **not** covered — it falls under the
document's existing "everything in the filesystem other than the files named above" — so that
"scratch plus the files named above" is not read as a promise the image cannot write anywhere.

## Judgment calls

- **`Publish` takes the full reference; it does not assemble a tag.** Which tags exist and when
  each one moves is the SPEC's "Tags and what pinning one buys", and a function deriving a tag
  from the refs at HEAD would be a second place the tag scheme is written down. `release.yaml`
  pushes the full version tag only; the moving tags (`v0`, `v0.2`, `latest`), signing, provenance
  and an SBOM are #128's, and they are a change to that job rather than to the module.
- **`packages: write` is on the publishing job alone**, added in the change that needs it.
- **The entrypoint is the CLI at an absolute path in `/usr/local/bin`.** The SPEC makes the CLI's
  own path implementation detail, and this is simply the one directory the image has.
- **Parent directories stay root-owned at 0755.** Only the plugin directory and the working
  directory are promised to the image's user, and a root-owned parent is what stops the running
  user replacing the tree above them.

## Verification

All four `verify` commands, plus the whole Dagger pipeline:

- `go build ./...`, `go test -race -cover ./...`, `golangci-lint run` — clean.
- The `example/` round-trip with `git diff --exit-code` — clean.
- `dagger call ci`, `dagger call regeneration`, `dagger call image-contract` (both platforms) — green.
- `golangci-lint` over `.dagger` against the repository's own config — clean.

The check was confirmed non-vacuous by breaking the image on purpose: clearing `/usr/local/bin`
from `PATH` failed the generation, and adding one stray file failed with
`/usr/local/share/avroc/stowaway: present in the image and not in the contract`.

And the acceptance criterion literally, with the built image loaded into Docker and the example
project bind-mounted:

```console
$ dagger call image --platform linux/amd64 export --path ./avroc.tar
$ docker load -i ./avroc.tar
$ docker image inspect <image> --format '...'
Entrypoint=[/usr/local/bin/avroc] Cmd=[] User=65532:65532 WorkingDir=/work Env=[PATH=/usr/local/bin]
$ docker run --rm -v "$PWD/proj:/work" <image> generate
... generated output generator=avroc-gen-go out=/work/gen output_files=[test_record.go]
... generated output generator=avroc-gen-json out=/work output_files=[test_record.avsc]
... generated output generator=avroc-gen-pcf out=/work/pcf output_files=[test_record.avsc]
$ diff -r example proj   # identical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
