### PR TITLE
story(container): publish generator images built FROM the base

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -202,6 +202,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Avroc":
 		switch fnName {
+		case "BuiltinGenerators":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Avroc).BuiltinGenerators(&parent), nil
 		case "Ci":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -216,6 +223,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Fmt(&parent, ctx)
+		case "GeneratorBundleImage":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return (*Avroc).GeneratorBundleImage(&parent, ctx, platform)
+		case "GeneratorImage":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return (*Avroc).GeneratorImage(&parent, ctx, name, platform)
+		case "GeneratorImageContract":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return nil, (*Avroc).GeneratorImageContract(&parent, ctx, platform)
 		case "Image":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -286,6 +342,41 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Avroc).Publish(&parent, ctx, address, username, password)
+		case "PublishGenerator":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			var username string
+			if inputArgs["username"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			return (*Avroc).PublishGenerator(&parent, ctx, name, address, username, password)
 		case "Regeneration":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -4,8 +4,8 @@
 // https://opensource.org/licenses/MIT
 
 // This file builds and checks the published generator images: avroc's own three
-// generators, each shipped as an image built FROM the base image image.go builds
-// (#127).
+// generators, each shipped as an image built FROM the base image, which image.go
+// builds (#127).
 //
 // # Why the built-ins go through the front door
 //

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// This file builds and checks the published generator images: avroc's own three
+// generators, each shipped as an image built FROM the base image image.go builds
+// (#127).
+//
+// # Why the built-ins go through the front door
+//
+// The base image could hold all four binaries — it did, between #126 and #127 —
+// and every published image would have looked the same from outside. What that
+// arrangement cannot do is test anything. A built-in reachable because the
+// pipeline put it there is not a consumer of the extension mechanism; it is a
+// private arrangement that happens to resemble one, and the first person to find
+// out that the mechanism needs a path the contract does not promise would have
+// been somebody in another repository, at their `docker build`.
+//
+// So the base ships the CLI and nothing else, and avroc-gen-go, avroc-gen-json
+// and avroc-gen-pcf reach their images the way a stranger's generator reaches
+// theirs: FROM the base, COPY into the plugin directory, chowned to the image's
+// user and marked executable, nothing else touched. Every path named below is
+// one docs/container/SPEC.md promises, which is the property this whole
+// arrangement exists to keep honest — and GeneratorImageContract is what fails
+// when it stops being true.
+//
+// # Why this is Dagger rather than a Dockerfile the pipeline builds
+//
+// docs/container/SPEC.md states these images as Dockerfiles, because a Dockerfile
+// is what an adopter writes, and the two instructions below are the two
+// instructions in one. The pipeline nonetheless builds them with the calls here
+// rather than by handing that Dockerfile to a builder, for a reason that is about
+// what is being checked rather than about taste: a `FROM ghcr.io/z5labs/avroc:v0`
+// line names a *published* image, and a pull request has to check the image it
+// just built. There is no way to point a Dockerfile's FROM at a container that
+// exists only inside the pipeline — a registry service is not reachable from a
+// Dockerfile build's image resolution — so building the committed Dockerfile
+// would check the previous release's base and say nothing about this change.
+//
+// The drift that arrangement risks is closed by the check rather than by
+// discipline: checkImageFilesystem compares each generator image against an
+// exhaustive listing, so an image that differs from "the base plus exactly one
+// executable at the promised path" fails, which is the same assertion the
+// Dockerfile makes. Dagger's WithFile *is* COPY — both are buildkit — and the
+// stage built FROM the base runs no exec at all, which is the strongest form of
+// the COPY-only rule available: there is no shell in the image to run one with.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	"dagger/avroc/internal/dagger"
+)
+
+// builtinGenerators is the set of generators avroc itself ships, by the name a
+// manifest asks for them by.
+//
+// It is the single definition of that set in this module: the images published,
+// the images checked, and the bundle they compose into all come from here, so a
+// fourth generator becomes a published image by being added once.
+func builtinGenerators() []string {
+	return []string{"go", "json", "pcf"}
+}
+
+// BuiltinGenerators names every generator avroc ships, one per line.
+//
+// It exists for .github/workflows/release.yaml, which publishes one image per
+// generator: a `for name in go json pcf` written there would be a second copy of
+// the set, in a file that is exercised once per release, and a fourth generator
+// would be forgotten exactly once — at the release where it silently did not get
+// published.
+func (m *Avroc) BuiltinGenerators() []string {
+	return builtinGenerators()
+}
+
+// generatorExecutable is the filename avroc searches PATH for when a manifest
+// asks for name — docs/plugin/SPEC.md's discovery rule, and the only reason the
+// file has to land under this name rather than any other.
+func generatorExecutable(name string) string {
+	return "avroc-gen-" + name
+}
+
+// GeneratorImage builds the published image for one built-in generator: the base
+// image with that generator copied into the plugin directory, and nothing else
+// changed (#127).
+//
+// It is the same two instructions docs/container/SPEC.md's worked example gives
+// a third-party author, and deliberately no more: the entrypoint is inherited
+// rather than set, Cmd stays empty so a caller's arguments are still avroc's, and
+// the only path named is the plugin directory, which is covered by the
+// compatibility guarantees.
+//
+// platform defaults to the engine's own, which is what makes
+// `dagger call generator-image --name go` useful from a checkout.
+func (m *Avroc) GeneratorImage(
+	ctx context.Context,
+	// The generator to build an image for, by the name a manifest asks for it
+	// by — one of `go`, `json` or `pcf`.
+	name string,
+	// Build for this platform, as `GOOS/GOARCH` — one of the published
+	// platforms. Empty builds for the engine's own platform.
+	// +optional
+	platform string,
+) (*dagger.Container, error) {
+	if !slices.Contains(builtinGenerators(), name) {
+		return nil, fmt.Errorf("generator %q is not one avroc ships: %v", name, builtinGenerators())
+	}
+	p, err := imagePlatform(ctx, platform)
+	if err != nil {
+		return nil, err
+	}
+	return m.generatorImage(p, name), nil
+}
+
+// GeneratorBundleImage builds the image that combines every built-in generator:
+// one generator image with the others' executables copied into it (#127).
+//
+// It is here because combining generators is the question an adopter asks
+// immediately after adding one — a project whose manifest names three generators
+// needs one image holding all three — and because the answer had better not be
+// "rebuild them all from source". It is not: each executable is copied out of the
+// published generator image that already carries it, at the path
+// docs/container/SPEC.md promises, which is `COPY --from=<image>` and is
+// available to anybody combining images this project has never heard of.
+//
+// example/ is what it is checked against, since that project's manifest names all
+// three; see checkImageGenerates.
+func (m *Avroc) GeneratorBundleImage(
+	ctx context.Context,
+	// Build for this platform, as `GOOS/GOARCH` — one of the published
+	// platforms. Empty builds for the engine's own platform.
+	// +optional
+	platform string,
+) (*dagger.Container, error) {
+	p, err := imagePlatform(ctx, platform)
+	if err != nil {
+		return nil, err
+	}
+	return m.generatorBundleImage(p), nil
+}
+
+// PublishGenerator pushes one built-in generator's image to address as a
+// multi-platform index, and returns the digest-qualified reference it pushed.
+//
+// One function and one address per generator rather than a loop over a registry
+// prefix: which repository each image is published to and which tags it carries
+// is docs/container/SPEC.md's and the release workflow's, not this module's, for
+// the same reason Publish takes a full reference.
+func (m *Avroc) PublishGenerator(
+	ctx context.Context,
+	// The generator to publish, by the name a manifest asks for it by.
+	name string,
+	// The full image reference to push, including the tag.
+	address string,
+	// The registry username to authenticate as. Both this and password are
+	// needed for a registry that requires authentication.
+	// +optional
+	username string,
+	// The registry password or token to authenticate with.
+	// +optional
+	password *dagger.Secret,
+) (string, error) {
+	if !slices.Contains(builtinGenerators(), name) {
+		return "", fmt.Errorf("generator %q is not one avroc ships: %v", name, builtinGenerators())
+	}
+	return publishIndex(ctx, address, username, password, func(p dagger.Platform) *dagger.Container {
+		return m.generatorImage(p, name)
+	})
+}
+
+// GeneratorImageContract checks every published generator image against the
+// contract its base makes (#127).
+//
+// It is the other half of ImageContract, and it is where the claim "avroc's own
+// generators are the first consumers of the extension mechanism" is either true
+// or a sentence. Four groups:
+//
+//   - The OCI configuration, unchanged from the base. A derived image inherits
+//     Entrypoint, Cmd, User, WorkingDir and PATH, and a generator image that had
+//     edited any of them would be a different program wearing avroc's filesystem.
+//   - The filesystem, as an exact listing: the base's contents plus exactly one
+//     executable, at the path docs/container/SPEC.md promises. That is the
+//     machine-checkable form of "only COPY ran in the stage built FROM the base"
+//     — anything a RUN could have done would show up as a path here — and of
+//     "none of them depends on a path the contract does not promise".
+//   - Each image running its own generator, through the inherited entrypoint,
+//     over a project that names that generator alone. This is what "runs its
+//     plugin with no further configuration" means: no environment, no arguments
+//     beyond `generate`, no path to a plugin anywhere.
+//   - The bundle generating the committed worked example byte-identically, as
+//     the image's own UID and as an overridden one.
+//
+// platform restricts the check to one of the published platforms; empty runs
+// every one of them, and every failure is reported rather than the first.
+//
+// +check
+// +cache="session"
+func (m *Avroc) GeneratorImageContract(
+	ctx context.Context,
+	// Run the check on this platform alone, as `GOOS/GOARCH` — one of the
+	// published platforms. Empty covers all of them.
+	// +optional
+	platform string,
+) error {
+	platforms := imagePlatforms()
+	if platform != "" {
+		if !slices.Contains(platforms, dagger.Platform(platform)) {
+			return fmt.Errorf("platform %q is not one this repository publishes: %v", platform, platforms)
+		}
+		platforms = []dagger.Platform{dagger.Platform(platform)}
+	}
+
+	var errs []error
+	for _, p := range platforms {
+		if err := m.generatorImageContractOn(ctx, p); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// generatorImage is one generator's image for one platform, and the one
+// definition of it: GeneratorImage, PublishGenerator, the bundle and the contract
+// check all come through here.
+//
+// The two calls are FROM and COPY. The owner and the mode are the derived
+// Dockerfile's `--chown=65532:65532 --chmod=0755`, which docs/container/SPEC.md
+// asks for so that the file is the image user's and executable; a world-readable
+// world-executable file would satisfy the contract without them, which is what
+// makes leaving them out a latent bug rather than an immediate one.
+//
+// Nothing else is set. In particular Cmd is left empty even though a derived
+// image MAY set it: a generator image that supplied a default subcommand would be
+// answering a question the caller is entitled to answer, and every invocation in
+// the documentation passes `generate` explicitly anyway.
+func (m *Avroc) generatorImage(platform dagger.Platform, name string) *dagger.Container {
+	exe := generatorExecutable(name)
+
+	return m.image(platform).WithFile(
+		pluginDir+"/"+exe,
+		m.binaries(platform).File(exe),
+		dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: executableMode},
+	)
+}
+
+// generatorBundleImage is the image holding every built-in generator, built by
+// stacking the published generator images rather than by copying binaries out of
+// the build.
+//
+// That is the difference between demonstrating the mechanism and demonstrating
+// that this repository can put four files in a directory: each executable is
+// taken from the image that publishes it, at the promised path, which is exactly
+// what somebody combining two generator images they did not build would write.
+func (m *Avroc) generatorBundleImage(platform dagger.Platform) *dagger.Container {
+	names := builtinGenerators()
+
+	// FROM the first generator's image, so the bundle is a derived image of a
+	// derived image — the case that would break if a generator image had quietly
+	// stopped being a valid base.
+	image := m.generatorImage(platform, names[0])
+	for _, name := range names[1:] {
+		path := pluginDir + "/" + generatorExecutable(name)
+		image = image.WithFile(
+			path,
+			m.generatorImage(platform, name).File(path),
+			dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: executableMode},
+		)
+	}
+	return image
+}
+
+// generatorImageContractOn checks one platform's generator images.
+//
+// Every image is checked and every failure collected rather than stopping at the
+// first: three images built the same way break the same way, and one run should
+// say so once for each.
+func (m *Avroc) generatorImageContractOn(ctx context.Context, platform dagger.Platform) error {
+	var errs []error
+
+	for _, name := range builtinGenerators() {
+		image := m.generatorImage(platform, name)
+		contents := append(baseImageExecutables(), generatorExecutable(name))
+
+		for _, err := range m.checkImageConfig(ctx, image) {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+		for _, err := range m.checkImageFilesystem(ctx, image, contents) {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+		if err := m.checkGeneratorRuns(ctx, image, name); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+
+	bundle := m.generatorBundleImage(platform)
+	bundleContents := baseImageExecutables()
+	for _, name := range builtinGenerators() {
+		bundleContents = append(bundleContents, generatorExecutable(name))
+	}
+
+	for _, err := range m.checkImageConfig(ctx, bundle) {
+		errs = append(errs, fmt.Errorf("bundle: %w", err))
+	}
+	for _, err := range m.checkImageFilesystem(ctx, bundle, bundleContents) {
+		errs = append(errs, fmt.Errorf("bundle: %w", err))
+	}
+	for _, err := range m.checkImageGenerates(ctx, bundle) {
+		errs = append(errs, fmt.Errorf("bundle: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+// checkGeneratorRuns requires the image to generate with its own generator and
+// nothing else — the acceptance criterion "each inherits the entrypoint and runs
+// its plugin with no further configuration", executed.
+//
+// The project it runs against names that generator alone, so a run that
+// succeeded because some other executable was lying around would not: the
+// manifest asks for one generator by name, and avroc fails the run at the
+// capability handshake if PATH does not resolve it.
+//
+// What is checked is that files came out, not which files: the committed worked
+// example is what pins the bytes each generator produces, and it is checked
+// against the bundle below. Duplicating it per generator would be a second copy
+// of example/avroc.json's options in a file nobody would think to update.
+func (m *Avroc) checkGeneratorRuns(ctx context.Context, image *dagger.Container, name string) error {
+	const outDir = "out"
+
+	project, err := generatorProbe(m.Source.File("example/schema.avdl"), name, outDir)
+	if err != nil {
+		return err
+	}
+
+	generated := image.
+		WithDirectory(workDir, project, dagger.ContainerWithDirectoryOpts{Owner: imageUser}).
+		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Directory(workDir + "/" + outDir)
+
+	entries, err := generated.Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("generating with %s through the image's entrypoint: %w", generatorExecutable(name), err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("generating with %s through the image's entrypoint wrote nothing under %s", generatorExecutable(name), outDir)
+	}
+	return nil
+}
+
+// generatorProbe is the smallest project that asks for one generator: the worked
+// example's schema, and a manifest naming that generator and no other.
+//
+// It is a fixture rather than a copy of example/avroc.json, and it is written
+// here rather than committed because what it exercises is discovery — that the
+// executable copied into the image is found on PATH under the name the manifest
+// asks for, and runs. A committed variant per generator would be three more
+// manifests to keep in step with a contract that is already checked elsewhere.
+func generatorProbe(schema *dagger.File, name, outDir string) (*dagger.Directory, error) {
+	manifest, err := json.MarshalIndent(map[string]any{
+		"inputs": []string{"schema.avdl"},
+		"generators": []map[string]any{{
+			"name":    name,
+			"out":     outDir,
+			"options": probeOptions(name),
+		}},
+	}, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("rendering the probe manifest for %s: %w", name, err)
+	}
+
+	return dag.Directory().
+		WithFile("schema.avdl", schema).
+		WithNewFile("avroc.json", string(manifest)), nil
+}
+
+// probeOptions is the least configuration a built-in generator needs to run at
+// all. docs/plugin/SPEC.md lets a generator require an option and avroc-gen-go
+// requires package_name; the other two accept none, and declare so.
+//
+// The value is deliberately not example/avroc.json's. Nothing here compares
+// output, so a value that matched would only invite somebody to read this as the
+// example's configuration and change it when the example changes.
+func probeOptions(name string) map[string]string {
+	if name == "go" {
+		return map[string]string{"package_name": "probe"}
+	}
+	return nil
+}

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -19,9 +19,10 @@
 // PATH, no USER, no working directory, no second binary, no data file. avroc's
 // image has to promise all six, because it is a base that other people build
 // FROM — and four of the six are not settings GoApp is missing so much as a
-// different shape of image. avroc publishes one image containing four binaries,
-// three of which are plugins found by a PATH search rather than run as the
-// entrypoint; GoApp publishes one image per binary. Teaching GoApp that shape
+// different shape of image. avroc publishes an image that is a base: one binary
+// in a directory on PATH, into which other images COPY plugins that are found
+// by a PATH search rather than run as the entrypoint (#127); GoApp publishes one
+// image per binary and has no notion of a derived image. Teaching GoApp that shape
 // would be teaching it avroc's plugin model, which is a contract in this
 // repository's docs/ and belongs nowhere else. What would be left upstream after
 // the customization was general enough to keep — a settable USER, WORKDIR and
@@ -49,6 +50,9 @@
 // fails only in somebody else's repository, at the point where their generator
 // is not found. ImageContract is that document's Compatibility guarantees table
 // executed rather than read.
+//
+// The images built FROM this one — avroc's own three generators, which are the
+// first consumers of the contract — are in generator_image.go (#127).
 package main
 
 import (
@@ -101,6 +105,19 @@ const (
 	// descriptorSetPath is where the IR FileDescriptorSet ships, for a plugin
 	// author whose language has no protobuf code generation in the build.
 	descriptorSetPath = "/usr/local/share/avroc/ir.binpb"
+
+	// cliExecutable is the avroc CLI, and the only executable the base image
+	// ships. Its path is deliberately not part of the contract; that it is the
+	// one and only binary in the base is, because "the base is scratch plus the
+	// files docs/container/SPEC.md names" is what makes a generator image's
+	// contents exactly what somebody copied into it.
+	cliExecutable = "avroc"
+
+	// executableMode is the mode every executable in the plugin directory has:
+	// readable and executable by the image's user and by any UID a caller
+	// overrides it with, which is what makes `--user $(id -u):$(id -g)` an
+	// ordinary configuration rather than a workaround.
+	executableMode = 0o755
 )
 
 // imagePlatforms is the set of platforms the image is published for, and the
@@ -114,11 +131,16 @@ func imagePlatforms() []dagger.Platform {
 // Image builds the published base image for one platform.
 //
 // It is the image docs/container/SPEC.md describes, and every promise that
-// document makes is made here: the CLI and the three generators in
-// /usr/local/bin with that directory on PATH, the CLI as the entrypoint with an
-// empty Cmd, /work as the working directory, UID and GID 65532 owning both
-// directories and running the process, the IR FileDescriptorSet at its
-// documented path, and nothing else in the filesystem at all.
+// document makes is made here: the CLI in /usr/local/bin with that directory on
+// PATH, the CLI as the entrypoint with an empty Cmd, /work as the working
+// directory, UID and GID 65532 owning both directories and running the process,
+// the IR FileDescriptorSet at its documented path, and nothing else in the
+// filesystem at all.
+//
+// No generator is in it. avroc's own three are shipped as images built FROM this
+// one (#127, GeneratorImage), which is the only arrangement in which they are
+// consumers of the extension mechanism rather than a private arrangement that
+// happens to look like one.
 //
 // platform defaults to the engine's own, which is what makes
 // `dagger call image` useful from a checkout; a value must be one of the
@@ -164,10 +186,26 @@ func (m *Avroc) Publish(
 	// +optional
 	password *dagger.Secret,
 ) (string, error) {
+	return publishIndex(ctx, address, username, password, m.image)
+}
+
+// publishIndex pushes one multi-platform index built from build, which is called
+// once per published platform.
+//
+// It is shared by Publish and PublishGenerator rather than written twice: the
+// credential handling and the index shape are properties of publishing an avroc
+// image, not of which image is being published, and a second copy would be a
+// second chance to get the anonymous-push case wrong.
+func publishIndex(
+	ctx context.Context,
+	address, username string,
+	password *dagger.Secret,
+	build func(dagger.Platform) *dagger.Container,
+) (string, error) {
 	platforms := imagePlatforms()
 	variants := make([]*dagger.Container, 0, len(platforms))
 	for _, p := range platforms {
-		variants = append(variants, m.image(p))
+		variants = append(variants, build(p))
 	}
 
 	// Half a credential is refused rather than quietly dropped. Skipping the
@@ -204,13 +242,11 @@ func (m *Avroc) Publish(
 //     mode. Exact rather than a spot check, because "the base is scratch plus
 //     the files this document names" is the promise, and it is the same
 //     assertion as no shell, no libc and no package manager.
-//   - The image actually generating the worked example, run through its own
-//     entrypoint with the example mounted at the working directory and no
-//     arguments beyond `generate` — which is the invocation the document gives.
-//     It runs twice, as the image's own UID and as an overridden one, because
-//     "an overridden UID is an ordinary configuration, not a workaround" is
-//     itself a promise, and because output owned by whichever UID wrote it is
-//     what makes `--user $(id -u):$(id -g)` the recommended invocation.
+//   - The entrypoint being the CLI, by running it: a base holding no generator
+//     cannot be asked to generate anything, so what pins Entrypoint to avroc
+//     rather than to some other executable is `help` through the entrypoint and
+//     the usage avroc prints. Generation is checked where generation is
+//     possible, on the images that carry a generator (GeneratorImageContract).
 //
 // platform restricts the check to one of the published platforms; empty runs
 // every one of them, and every failure is reported rather than the first,
@@ -242,32 +278,28 @@ func (m *Avroc) ImageContract(
 	return errors.Join(errs...)
 }
 
-// image is the base image for one platform, and the one definition of it: Image
-// and Publish both come through here, so there is no arrangement in which the
-// image a check passed is not the image that was pushed.
-//
-// The binaries are cross-compiled by the toolchain container rather than
-// compiled under emulation, and CGO is off because the image is scratch: there
-// is no libc in it, and a dynamically linked executable would find no loader and
-// fail with `no such file or directory` naming a file that is plainly there.
+// image is the base image for one platform, and the one definition of it: Image,
+// Publish and every image built FROM this one all come through here, so there is
+// no arrangement in which the image a check passed is not the image that was
+// pushed, nor one in which a generator image is built on a base nobody checked.
 //
 // The order of the calls below is the order docs/container/SPEC.md states the
 // promises in, which is not an accident worth preserving so much as one worth
 // not breaking: WithEntrypoint clears Cmd, so it comes before the WithoutDefaultArgs
 // that asserts Cmd is empty rather than after it.
 func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
-	binaries := dag.Go().Build(m.Source, dagger.GoBuildOpts{
-		Pkg:        "./cmd/...",
-		Platform:   string(platform),
-		DisableCgo: true,
-	})
+	cli := dag.Directory().WithFile(
+		cliExecutable,
+		m.binaries(platform).File(cliExecutable),
+		dagger.DirectoryWithFileOpts{Permissions: executableMode},
+	)
 
 	return dag.Container(dagger.ContainerOpts{Platform: platform}).
 		// The plugin directory, owned by the image's user so that a generator
 		// copied in by a derived image lands somewhere that user can execute
 		// from. The CLI goes here too; its path is explicitly not part of the
 		// contract, and this is simply the one directory the image has.
-		WithDirectory(pluginDir, binaries, dagger.ContainerWithDirectoryOpts{
+		WithDirectory(pluginDir, cli, dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
 		// The FileDescriptorSet, world-readable because a caller who overrides
@@ -292,8 +324,25 @@ func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
 		WithEnvVariable("PATH", pluginDir).
 		WithWorkdir(workDir).
 		WithUser(imageUser).
-		WithEntrypoint([]string{pluginDir + "/avroc"}).
+		WithEntrypoint([]string{pluginDir + "/" + cliExecutable}).
 		WithoutDefaultArgs()
+}
+
+// binaries builds every executable this repository ships, for one platform.
+//
+// One build for the base image and the three generator images alike, so the CLI
+// a generator image inherits and the generator copied into it are the same
+// binaries the base image was checked with. They are cross-compiled by the
+// toolchain container rather than compiled under emulation, and CGO is off
+// because the image is scratch: there is no libc in it, and a dynamically linked
+// executable would find no loader and fail with `no such file or directory`
+// naming a file that is plainly there.
+func (m *Avroc) binaries(platform dagger.Platform) *dagger.Directory {
+	return dag.Go().Build(m.Source, dagger.GoBuildOpts{
+		Pkg:        "./cmd/...",
+		Platform:   string(platform),
+		DisableCgo: true,
+	})
 }
 
 // tmpDirectory is a directory holding nothing but `tmp`, with mode 1777, for
@@ -324,9 +373,39 @@ func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) e
 	image := m.image(platform)
 
 	errs := m.checkImageConfig(ctx, image)
-	errs = append(errs, m.checkImageFilesystem(ctx, image)...)
-	errs = append(errs, m.checkImageGenerates(ctx, image)...)
+	errs = append(errs, m.checkImageFilesystem(ctx, image, baseImageExecutables())...)
+	if err := m.checkImageIsTheCLI(ctx, image); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
+}
+
+// checkImageIsTheCLI runs the entrypoint and requires avroc's usage back.
+//
+// The behavioural half of the entrypoint guarantee, and the only half a base
+// image can carry on its own: docs/container/SPEC.md promises that a caller's
+// arguments are avroc's arguments, and `help` is the one subcommand that needs
+// no project, no generator and no writable directory to answer. An entrypoint
+// that had been repointed at some other executable would answer differently or
+// not at all.
+//
+// Generation is the stronger check and it is on the generator images, because a
+// base holding no generator has nothing to generate with — which is itself the
+// point of #127, and is why this check exists rather than the base quietly
+// keeping a copy of every built-in so that it could be run here.
+func (m *Avroc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container) error {
+	const want = "Usage: avroc <command>"
+
+	out, err := image.
+		WithExec([]string{"help"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("running `help` through the image's entrypoint: %w", err)
+	}
+	if !strings.Contains(out, want) {
+		return fmt.Errorf("`help` through the image's entrypoint printed %q, which does not contain %q: the entrypoint is not the avroc CLI", out, want)
+	}
+	return nil
 }
 
 // checkImageConfig checks the fields of the OCI image configuration a derived
@@ -343,11 +422,17 @@ func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) [
 	//
 	// It is deliberately not compared to a literal, since the CLI's own path is
 	// implementation detail and pinning it here would make a promise this
-	// project has explicitly not made. What pins the entrypoint to the CLI
-	// rather than to one of the generators is checkImageGenerates, which runs
-	// `generate` through it and byte-compares the result: the guarantee is about
-	// behaviour, so the behaviour is what checks it.
-	executables := imageExecutablePaths()
+	// project has explicitly not made. What pins the entrypoint to the CLI is
+	// behaviour rather than shape: checkImageIsTheCLI on the base, and
+	// checkImageGenerates on the images that carry a generator, which runs
+	// `generate` through it and byte-compares the result.
+	//
+	// The base image's executables rather than the checked image's, because this
+	// runs on derived images too and a derived image inherits its Entrypoint: a
+	// generator image whose Entrypoint had become its own generator would be a
+	// different program wearing avroc's filesystem, which is exactly the edit
+	// docs/container/SPEC.md forbids.
+	executables := baseImageExecutablePaths()
 	entrypoint, err := image.Entrypoint(ctx)
 	switch {
 	case err != nil:
@@ -407,11 +492,16 @@ func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) [
 // plugin directory and the working directory are promised to the image's user,
 // and a root-owned parent with mode 0755 is what stops the running user
 // replacing the tree above them.
-func imageContents() map[string]imageEntry {
+//
+// executables is what is expected in the plugin directory, which is the one
+// thing that differs between the base image and an image built FROM it: the
+// difference between the two listings is exactly the set of files somebody
+// COPYed in, and checking a derived image against this is how "only COPY ran in
+// the stage built FROM the base" becomes an assertion rather than a claim.
+func imageContents(executables []string) map[string]imageEntry {
 	const (
-		dirMode        = 0o755
-		executableMode = 0o755
-		dataMode       = 0o644
+		dirMode  = 0o755
+		dataMode = 0o644
 	)
 
 	contents := map[string]imageEntry{
@@ -424,23 +514,28 @@ func imageContents() map[string]imageEntry {
 		workDir:                  {imageUID, imageGID, dirMode},
 		tmpDir:                   {0, 0, tmpDirMode},
 	}
-	for _, name := range imageExecutables() {
+	for _, name := range executables {
 		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
 	}
 	return contents
 }
 
-// imageExecutables is what ships in the plugin directory: the CLI, and avroc's
-// own generators as the first consumers of the contract every third-party
-// generator image is built against.
-func imageExecutables() []string {
-	return []string{"avroc", "avroc-gen-go", "avroc-gen-json", "avroc-gen-pcf"}
+// baseImageExecutables is what ships in the base image's plugin directory: the
+// CLI, and nothing else.
+//
+// avroc's own generators are not here, and their absence is the substance of
+// #127. A base that carried them would make the three published generator images
+// decorative — the built-ins would be reachable by a path nobody copied them to,
+// which is precisely the private arrangement that would leave the extension
+// mechanism untested by its own author.
+func baseImageExecutables() []string {
+	return []string{cliExecutable}
 }
 
-// imageExecutablePaths is imageExecutables where they land, which is what an
-// Entrypoint would have to name.
-func imageExecutablePaths() []string {
-	names := imageExecutables()
+// baseImageExecutablePaths is baseImageExecutables where they land, which is what
+// an Entrypoint would have to name.
+func baseImageExecutablePaths() []string {
+	names := baseImageExecutables()
 	paths := make([]string, 0, len(names))
 	for _, name := range names {
 		paths = append(paths, pluginDir+"/"+name)
@@ -466,7 +561,11 @@ func (e imageEntry) String() string {
 // anything *in* the image, which is the point of the image having no shell, and
 // a Dagger Entries walk would report the paths without their owners — and
 // ownership is half of what is being checked.
-func (m *Avroc) checkImageFilesystem(ctx context.Context, image *dagger.Container) []error {
+//
+// executables is what the plugin directory is expected to hold: the CLI alone
+// for the base image, and the CLI plus whatever was copied in for an image built
+// FROM it.
+func (m *Avroc) checkImageFilesystem(ctx context.Context, image *dagger.Container, executables []string) []error {
 	const mountedAt = "/image"
 
 	// Numeric %U and %G rather than %u and %g: the listing container has no
@@ -483,7 +582,7 @@ func (m *Avroc) checkImageFilesystem(ctx context.Context, image *dagger.Containe
 		return []error{fmt.Errorf("listing the image filesystem: %w", err)}
 	}
 
-	want := imageContents()
+	want := imageContents(executables)
 	got := make(map[string]imageEntry, len(want))
 
 	var errs []error
@@ -510,7 +609,7 @@ func (m *Avroc) checkImageFilesystem(ctx context.Context, image *dagger.Containe
 	}
 	for path := range got {
 		if _, ok := want[path]; !ok {
-			errs = append(errs, fmt.Errorf("%s: present in the image and not in the contract; the base is scratch plus the files docs/container/SPEC.md names, and nothing else", path))
+			errs = append(errs, fmt.Errorf("%s: present in the image and not in the contract; the base is scratch plus the files docs/container/SPEC.md names, plus whatever a derived image COPYed in, and nothing else", path))
 		}
 	}
 
@@ -544,6 +643,12 @@ func parseFindLine(line, prefix string) (imageEntry, string, error) {
 // checkImageGenerates runs the image the way docs/container/SPEC.md says to run
 // it, and checks both what it produced and who owns it.
 //
+// It needs every generator example/avroc.json names, so it runs against the
+// image that combines all three (#127) rather than against the base, which ships
+// none. That is not a weakening of the check: the tree it compares is the same
+// committed worked example, produced through the same entrypoint, by generators
+// that reached the image the way a stranger's generator reaches theirs.
+//
 // Twice, as two different users. The first run is the documented default. The
 // second overrides the UID the way a caller writing output into a bind mount is
 // told to, and is what turns "an overridden UID is an ordinary configuration"
@@ -570,10 +675,10 @@ func (m *Avroc) checkImageGenerates(ctx context.Context, image *dagger.Container
 // tree it left behind.
 //
 // UseEntrypoint is what makes this the same invocation as
-// `docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc:v0 generate`: the
-// arguments are avroc's arguments, and nothing here names the CLI by path. No
-// environment is set either — the image's own PATH is what has to resolve the
-// three generators, which is the one job it has.
+// `docker run --rm -v "$PWD:/work" <image> generate`: the arguments are avroc's
+// arguments, and nothing here names the CLI by path. No environment is set
+// either — the image's own PATH is what has to resolve the generators copied
+// into it, which is the one job it has.
 func generateInImage(image *dagger.Container, example *dagger.Directory, user string) *dagger.Directory {
 	return image.
 		WithUser(user).

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,6 +112,23 @@ jobs:
       - name: Check the base image against its contract
         run: dagger call image-contract
 
+      # The other half of that contract: the images avroc's own three generators
+      # ship in, each built FROM the base with nothing but a COPY (#127). It
+      # checks that a generator image inherits the base's entrypoint, Cmd, user,
+      # working directory and PATH unchanged, that its filesystem is the base's
+      # plus exactly one executable at the promised path — which is what makes
+      # "only COPY ran" an assertion rather than a claim — that each image
+      # generates with its own generator through the inherited entrypoint and no
+      # further configuration, and that an image combining all three reproduces
+      # the committed worked example byte for byte.
+      #
+      # It is a separate step from the one above because it is a separate claim:
+      # the base can keep every promise it makes while the extension mechanism
+      # built on it has stopped working, and this is the step that says which of
+      # the two broke.
+      - name: Check the generator images against the contract
+        run: dagger call generator-image-contract
+
       # The one artifact this repository builds, built on every pull request
       # rather than only at release time. Its contents are asserted by the tests
       # `dagger call ci` just ran — that the set covers proto/, resolves on its

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,14 @@ jobs:
             "$RUNNER_TEMP/ir.binpb" --clobber
 
   # The published base image (#126) — the one docs/container/SPEC.md describes
-  # and strangers' Dockerfiles say FROM.
+  # and strangers' Dockerfiles say FROM — and the three generator images built
+  # FROM it (#127).
+  #
+  # One job rather than two, because the four images are one release: a base
+  # published without its generator images would leave every `FROM` line in this
+  # repository's own documentation naming a tag whose generators are a release
+  # behind, and the generator images are built from the same base this job
+  # checked, so splitting them would mean building it twice.
   #
   # Only the full version tag is pushed here. docs/container/SPEC.md publishes
   # four tags and promises that a full version tag never moves while the other
@@ -79,7 +86,7 @@ jobs:
   # are #128's, and they are a change to this job rather than to the module,
   # because which tags exist is a property of a release and not of an image.
   image:
-    name: Base image
+    name: Images
     runs-on: ubuntu-latest
     permissions:
       # Reading the source, and writing the package. Both grants are here rather
@@ -110,6 +117,12 @@ jobs:
       - name: Check the base image against its contract
         run: dagger call image-contract
 
+      # And the images built FROM it, for the same reason: a tag is published
+      # once and never repointed, so this is the last moment at which a generator
+      # image that had stopped inheriting the entrypoint costs nothing.
+      - name: Check the generator images against the contract
+        run: dagger call generator-image-contract
+
       # One multi-platform index covering linux/amd64 and linux/arm64, so that a
       # `FROM` line naming the tag resolves to the manifest for whatever
       # platform the builder is on.
@@ -117,7 +130,7 @@ jobs:
       # The address is assembled here rather than in the module: the module
       # pushes the reference it is given, and a function that derived a tag from
       # the refs at HEAD would be a second place the tag scheme is written down.
-      - name: Build and publish it
+      - name: Build and publish the base image
         env:
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -125,3 +138,25 @@ jobs:
             --address "ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}" \
             --username "${{ github.actor }}" \
             --password env://REGISTRY_PASSWORD
+
+      # One image per built-in generator, at ghcr.io/<owner>/avroc-gen-<name>:
+      # the base with that generator copied into the plugin directory, which is
+      # the same two instructions docs/container/SPEC.md gives a third-party
+      # author (#127).
+      #
+      # The set of generators is read from the module rather than written out
+      # here, because the module is where that set is defined; a `for name in go
+      # json pcf` in this file would be forgotten exactly once, at the release
+      # where a fourth generator silently did not get published. The tags are
+      # still assembled here, for the reason the base image's step gives.
+      - name: Build and publish the generator images
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for name in $(dagger call builtin-generators); do
+            dagger call publish-generator \
+              --name "$name" \
+              --address "ghcr.io/${{ github.repository }}-gen-$name:${{ github.event.release.tag_name }}" \
+              --username "${{ github.actor }}" \
+              --password env://REGISTRY_PASSWORD
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,16 +183,27 @@ it reads `SOURCE_DATE_EPOCH`, returns UTC, and reports a malformed value rather
 than falling back to the clock. Nothing here needs it yet, and a generator that
 grows a timestamp uses it rather than inventing its own.
 
-### The published image
+### The published images
 
 `.dagger/image.go` builds the base image `docs/container/SPEC.md` describes, and
-that document is normative: `/usr/local/bin` on `PATH` holding the CLI and the
-three generators, the CLI as `Entrypoint` with an empty `Cmd`, `/work` as
+that document is normative: `/usr/local/bin` on `PATH` holding the CLI **and no
+generator**, the CLI as `Entrypoint` with an empty `Cmd`, `/work` as
 `WorkingDir`, UID and GID 65532 owning both directories and running the process,
 the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a `scratch`
 base — no shell, no libc, no package manager, so extension is `COPY`-only. The
 one thing in the filesystem the document does not name is a 1777 `/tmp`, which
 avroc needs because it writes each invocation's descriptor under `os.TempDir`.
+
+`.dagger/generator_image.go` builds the three images that carry avroc's own
+generators, each of them the base plus one executable in the plugin directory
+(#127). The generators are deliberately not in the base: a built-in on `PATH`
+because the pipeline put it there is not a consumer of the extension mechanism,
+and the first person to discover that the mechanism needs a path the contract
+does not promise would otherwise have been a stranger at their own
+`docker build`. `dagger call generator-image --name go`, `... publish-generator`
+and `... generator-bundle-image` — the last being all three combined by copying
+each executable out of the image that publishes it, which is what an adopter
+writes as `COPY --from`.
 
 It is built here rather than by the devex `GoApp` archetype, whose image half
 produces one scratch image per binary with `/app/<binaryName>` as entrypoint and
@@ -203,10 +214,18 @@ definition of what "checked" means.
 
 `dagger call image-contract` is the compatibility guarantees table executed
 rather than read — the OCI configuration, an *exact* listing of every path in
-the image with its owner and mode, and the image generating `example/` through
-its own entrypoint both as 65532 and as an overridden UID. CI runs it on every
-pull request; `dagger call publish --address <ref>` pushes a multi-platform
-index and is called only from `.github/workflows/release.yaml`.
+the image with its owner and mode, and `help` through the entrypoint, which is
+all a base holding no generator can be asked to do.
+`dagger call generator-image-contract` is the other half: each generator image's
+configuration inherited unchanged, its filesystem exhaustively equal to the
+base's plus one executable (which is how "only `COPY` ran" becomes an assertion),
+each image generating with its own generator through the inherited entrypoint,
+and the combined image reproducing the committed `example/` byte for byte as 65532
+and as an overridden UID. CI runs both on every pull request;
+`dagger call publish --address <ref>` and `dagger call publish-generator --name
+<name> --address <ref>` push multi-platform indexes and are called only from
+`.github/workflows/release.yaml`, which reads the set of generators from
+`dagger call builtin-generators` rather than repeating it in YAML.
 
 ### Key Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,15 @@ generates [`example/`](example/) twice, and requires the two trees to be
 byte-identical — and identical to what is committed. See
 [Determinism](#determinism) below for why both comparisons are one function.
 
-### The base image
+### The images
 
 ```sh
 dagger call image-contract                          # every platform
 dagger call image-contract --platform linux/arm64   # one of them
+dagger call generator-image-contract                # the images built FROM it
 
 dagger call image export --path ./avroc.tar         # build one, to look at
+dagger call generator-bundle-image export --path ./avroc-all.tar
 ```
 
 `image` builds the image [`docs/container/SPEC.md`](docs/container/SPEC.md)
@@ -62,26 +64,34 @@ describes — the one other people's Dockerfiles say `FROM` — and
 `image-contract` is that document's compatibility guarantees table executed
 rather than read: the plugin directory and its place on `PATH`, the entrypoint,
 the empty `Cmd`, the working directory, the pinned non-root UID, the absence of
-a shell, the `FileDescriptorSet`'s path, and the image generating
-[`example/`](example/) through its own entrypoint as itself and as an overridden
-UID.
+a shell, and the `FileDescriptorSet`'s path.
+
+The base ships the CLI and **no generator**. avroc's own three are images built
+`FROM` it, one `COPY` each, exactly as a stranger's generator image is
+(`generator-image --name go|json|pcf`), and `generator-image-contract` checks
+them: the configuration inherited unchanged, a filesystem that is the base's plus
+exactly one executable, each image generating with its own generator through the
+inherited entrypoint, and the combined image reproducing the committed
+[`example/`](example/) as itself and as an overridden UID.
 
 It is a check because every one of those promises is depended on from a
 repository this project cannot see and breaks without breaking anything here: an
 image whose `PATH` lost `/usr/local/bin` runs avroc perfectly and fails at the
 point where somebody else's generator is not found.
 
-To run the image the way a consumer does, load the tarball and mount a project
-at `/work`:
+To run an image the way a consumer does, load the tarball and mount a project
+at `/work`. Use the bundle rather than the base — `example/`'s manifest names
+three generators, and the base carries none:
 
 ```sh
-docker load -i ./avroc.tar
+docker load -i ./avroc-all.tar
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/example:/work" <image> generate
 ```
 
-`dagger call publish --address …` pushes a multi-platform index. Nothing but
+`dagger call publish --address …` and `dagger call publish-generator --name …
+--address …` push multi-platform indexes. Nothing but
 [`.github/workflows/release.yaml`](.github/workflows/release.yaml) should call
-it.
+either.
 
 ### Getting the tools
 

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -32,8 +32,9 @@ entrypoint, the working directory a project is mounted at, the user and UID the
 process runs as together with the guidance for overriding it with
 `--user $(id -u):$(id -g)`, whether a shell is present and what follows from the
 answer, the path the IR `FileDescriptorSet` ships at, the tags a derived image
-may pin, and which of these are covered by a compatibility guarantee and which
-are implementation detail that may change without notice.
+may pin, what avroc's own generator images are and how they are combined, and
+which of these are covered by a compatibility guarantee and which are
+implementation detail that may change without notice.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -88,7 +89,11 @@ requirement here rather than two facts in different sections.
 
 The image **MUST** set `Env` such that `PATH` contains `/usr/local/bin`, and the
 directory **MUST** exist in the base image even when it is empty, so that a
-`COPY` into it never depends on the builder creating it. A derived image
+`COPY` into it never depends on the builder creating it. The base image holds one
+executable in it — the avroc CLI — and **no generator**: avroc's own three are
+images built `FROM` the base, exactly as a stranger's is, and
+[avroc's own generators](#avrocs-own-generators) is where they are described
+(#127). A derived image
 **MUST NOT** remove the directory from `PATH` or shadow it with an earlier entry
 containing an executable of the same name; the plugin contract's rule that
 [the earliest `PATH` match
@@ -137,8 +142,12 @@ The image's `Entrypoint` is the avroc CLI, and its `Cmd` is empty (#126). The
 arguments a caller passes to `docker run` are therefore avroc's arguments:
 
 ```console
-$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc:v0 generate
+$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
+
+The image named there is a [generator image](#avrocs-own-generators), because
+generating needs a generator and the base ships none; everything this section
+says about the entrypoint is the base's, inherited unchanged.
 
 A derived image **MUST NOT** replace or clear `Entrypoint`. That is the one
 edit which turns a derived image into a different program wearing avroc's
@@ -160,7 +169,7 @@ against the working directory, so a mount at `/work` and no further arguments is
 the shortest complete invocation:
 
 ```console
-$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc:v0 generate
+$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 
 `/work` **MUST** exist in the base image and **MUST** be owned by the [image's
@@ -220,7 +229,7 @@ A caller **SHOULD** therefore run as themselves:
 
 ```console
 $ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
-    ghcr.io/z5labs/avroc:v0 generate
+    ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 
 This is supported and is the recommended invocation whenever output is written
@@ -359,10 +368,102 @@ reproducibility](../plugin/SPEC.md#plugin-distribution-and-reproducibility).
 Pinning a digest fixes every generator in the image along with avroc itself,
 which is the whole reason this project has no lockfile.
 
+The same four tags are published for each of [avroc's own generator
+images](#avrocs-own-generators), and a given version tag means the same release
+across all of them: `avroc-gen-go:v0.2.0` is built `FROM` `avroc:v0.2.0`.
+
 Images are signed and carry provenance and an SBOM (#128), and a consumer can
 verify a signature before trusting a tag. That verification is a thing a
 consumer can perform, so it is in scope here; how the signature comes to exist
 is not, and is under [Out of Scope](#how-the-image-is-built-and-published).
+
+## avroc's own generators
+
+avroc ships three generators, and each one is published as an image built `FROM`
+the base — `avroc-gen-go`, `avroc-gen-json` and `avroc-gen-pcf` (#127). They are
+not in the base image, and that is the whole point of this section.
+
+Each of the three **MUST** be the base image plus exactly one executable, at the
+[plugin directory](#the-plugin-directory) path the generator's name gives it, and
+**MUST NOT** change anything else the base image sets. The Dockerfile below is a
+complete statement of what one of them is:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -o /out/avroc-gen-go ./cmd/avroc-gen-go
+
+FROM ghcr.io/z5labs/avroc:v0
+COPY --from=build --chown=65532:65532 --chmod=0755 \
+     /out/avroc-gen-go /usr/local/bin/avroc-gen-go
+```
+
+There is nothing in it that is not in the [worked
+example](#worked-example-adding-a-generator) a stranger is given: the same base,
+the same destination, the same ownership and mode, no `RUN` in the stage built
+`FROM` the base, and no `ENTRYPOINT` line, because the entrypoint is inherited
+and a generator image is still avroc. Running one is running avroc with one more
+generator on its `PATH`:
+
+```console
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+    ghcr.io/z5labs/avroc-gen-json:v0 generate
+```
+
+### Why the built-ins are not in the base
+
+A base image carrying its own generators would publish the same bytes to a
+consumer and would quietly stop testing anything. A built-in that is on `PATH`
+because the build put it there is not a consumer of this contract; it is a
+private arrangement that resembles one. If the built-ins needed a path this
+document does not promise, or an entrypoint edit, or a shell in the final stage,
+nobody here would find out — the first person to find out would be a stranger, at
+their `docker build`, against a contract that had never been used.
+
+So the mechanism has three users before it has any: `avroc-gen-go`,
+`avroc-gen-json` and `avroc-gen-pcf` go through the front door, and the pipeline
+checks each published image against exactly the promises above — the inherited
+entrypoint, `Cmd`, user, working directory and `PATH`, a filesystem that is the
+base's plus one executable and nothing else, and the image generating with its
+own generator through the inherited entrypoint and no further configuration.
+
+The cost is one extra image reference in a consumer's Dockerfile, and it buys the
+guarantee that the extension mechanism described here is the one avroc itself
+uses.
+
+### Combining more than one generator
+
+A project whose manifest names several generators needs one image holding all of
+them, and no rebuild from source is required to get one: a generator image is
+itself a valid base, and each executable sits at a path this document promises,
+so `COPY --from` reaches it.
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/z5labs/avroc-gen-go:v0
+COPY --from=ghcr.io/z5labs/avroc-gen-json:v0 \
+     /usr/local/bin/avroc-gen-json /usr/local/bin/avroc-gen-json
+COPY --from=ghcr.io/z5labs/avroc-gen-pcf:v0 \
+     /usr/local/bin/avroc-gen-pcf /usr/local/bin/avroc-gen-pcf
+```
+
+That image runs the [example project](../../example), whose manifest names all
+three generators, with no arguments beyond `generate`. Nothing about it is
+special to avroc's own images: the same two `COPY --from` lines combine a
+generator this project has never heard of with one it publishes, because the only
+thing either line depends on is the plugin directory being where this document
+says it is.
+
+The images being combined **MUST** agree about the base they were built `FROM`,
+in the sense that matters to the result: the final image's avroc is the one in
+the `FROM` line, and a generator copied out of an image built on a much older
+base is subject to the [plugin contract](../plugin/SPEC.md#capability-negotiation)'s
+version handshake like any other. That handshake failing is the good outcome, and
+is why nothing here needs to police the combination.
 
 ## Worked example: adding a generator
 
@@ -497,6 +598,7 @@ to any of them is a breaking change:
 | [No shell](#no-shell) | Absent; extension is `COPY`-only |
 | [The `FileDescriptorSet`](#the-ir-filedescriptorset) | `/usr/local/share/avroc/ir.binpb` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
+| [avroc's own generators](#avrocs-own-generators) | One image each, `FROM` the base, adding one executable and changing nothing else |
 
 Not covered, and explicitly implementation detail. Depending on any of it is
 depending on something that may change in a patch release, with no notice:
@@ -599,9 +701,9 @@ found there and what happens to it.
 | [No shell](#no-shell) | [#126](https://github.com/z5labs/avroc/issues/126) |
 | [The IR `FileDescriptorSet`](#the-ir-filedescriptorset) | [#113](https://github.com/z5labs/avroc/issues/113), [#126](https://github.com/z5labs/avroc/issues/126) |
 | [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | [#128](https://github.com/z5labs/avroc/issues/128) |
+| [avroc's own generators](#avrocs-own-generators) | [#127](https://github.com/z5labs/avroc/issues/127) |
 | [Worked example: adding a generator](#worked-example-adding-a-generator) | [#129](https://github.com/z5labs/avroc/issues/129) |
 | [Compatibility guarantees](#compatibility-guarantees) | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128) |
-| avroc's own generators as the first consumers of this contract | [#127](https://github.com/z5labs/avroc/issues/127) |
 | Multi-platform build and publishing — out of scope, see above | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128) |
 | A convenience over this contract, with no spec of its own | [#130](https://github.com/z5labs/avroc/issues/130) |
 | The plugin contract this one is the deployment half of | [#106](https://github.com/z5labs/avroc/issues/106) |


### PR DESCRIPTION
Closes #127

Ships avroc's three built-in generators as images built `FROM` the base image, and
takes the generators **out** of the base to make that mean something.

## The judgment call that shaped everything else

The base image, as #126 left it, carried all four binaries. Building
`avroc-gen-go` as "the base plus `avroc-gen-go`" would then have been a no-op, and
the story's premise — *making avroc's own generators the first consumers of avroc's
extension mechanism is the only honest test of it* — would have had nothing to
test. A built-in that is on `PATH` because the pipeline put it there is not a
consumer of the contract; it is a private arrangement that resembles one.

So the base now ships the avroc CLI and **no generator**, and `avroc-gen-go`,
`avroc-gen-json` and `avroc-gen-pcf` reach their images through the front door:
`FROM` the base, `COPY --chown=65532:65532 --chmod=0755` into `/usr/local/bin`,
nothing else touched. `docs/container/SPEC.md` states this as a compatibility
guarantee, and its `docker run` examples now name a generator image, because the
base has nothing to generate with.

## The second judgment call: Dagger rather than a Dockerfile the pipeline builds

`docs/container/SPEC.md` states each image as a multi-stage Dockerfile, because a
Dockerfile is what an adopter writes and the two instructions are the two
instructions. The pipeline builds them with Dagger's `FROM`/`COPY` equivalents
rather than by handing that Dockerfile to a builder, for a reason recorded in
`.dagger/generator_image.go`: `FROM ghcr.io/z5labs/avroc:v0` names a *published*
image, and a pull request has to check the image it just built. There is no way to
point a Dockerfile's `FROM` at a container that exists only inside the pipeline, so
building the committed Dockerfile would check the last release's base and say
nothing about the change under review.

The drift that risks is closed by the check rather than by discipline:
`generator-image-contract` compares each image against an **exhaustive** filesystem
listing, so an image that is not "the base plus exactly one executable at the
promised path" fails — the same assertion the Dockerfile makes.

## Acceptance criteria

- [x] **`avroc-gen-go`, `avroc-gen-json` and `avroc-gen-pcf` each ship as an image
  built `FROM` the base with a multi-stage Dockerfile.** `GeneratorImage` builds
  one per generator, `PublishGenerator` pushes a multi-platform index for each, and
  `.github/workflows/release.yaml` publishes all three to
  `ghcr.io/z5labs/avroc-gen-<name>` at the release tag — reading the set of
  generators from `dagger call builtin-generators` rather than repeating it in YAML.
  The Dockerfile form is in `docs/container/SPEC.md`; why the pipeline does not
  build it is above.
- [x] **Those Dockerfiles use only `COPY` in the stage built `FROM` the base.** The
  stage runs no exec at all — there is no shell in the image to run one with — and
  the exhaustive filesystem check is the machine-checkable form of it: anything a
  `RUN` could have done shows up as a path that is not in the contract.
- [x] **Each inherits the entrypoint and runs its plugin with no further
  configuration.** `checkImageConfig` runs on every derived image and requires
  `Entrypoint`, `Cmd`, `User`, `WorkingDir` and `PATH` inherited unchanged;
  `checkGeneratorRuns` then runs `generate` through the inherited entrypoint over a
  project naming that generator alone — no environment, no arguments, no path to a
  plugin anywhere.
- [x] **An image combining more than one generator is demonstrated.**
  `GeneratorBundleImage` stacks them: `FROM` the `go` image, then each other
  executable copied out of the image that publishes it at the promised path, which
  is `COPY --from=<image>` and is what an adopter writes. It is checked by
  generating the committed `example/` — whose manifest names all three — byte for
  byte, as 65532 and as an overridden UID. `docs/container/SPEC.md` gives the
  Dockerfile.
- [x] **None of them depends on a path the base-image contract does not promise.**
  The only paths named are `/usr/local/bin/avroc-gen-<name>`, and the exhaustive
  listing is what makes that a check rather than a claim.

## Verification

- `go build ./...`, `go test -race -cover ./...`, `golangci-lint run`, and the
  `example/` round-trip (`avroc generate` + `git diff --exit-code`) — all clean.
- `dagger call image-contract` and `dagger call generator-image-contract`, both
  platforms, locally: pass. The new check was confirmed to *fail* when the probe
  manifest was deliberately broken, so a green result is not a check that never ran.
- `dagger call builtin-generators` prints the three names one per line, which is
  what the release workflow's loop consumes.

## Note for #128

Signing, provenance and SBOMs now cover four image repositories rather than one.
