### PR TITLE
encoding=single_object fails rather than silently generating nothing for a non-record root

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Generates idiomatic Go types with binary Avro serialization support.
 | Option | Required | Description |
 |---|---|---|
 | `package_name` | Yes | The Go package name for all generated files. |
-| `encoding` | No | Set to `single_object` to generate a `Fingerprint()` method on the primary record type for [Avro Single Object Encoding](https://avro.apache.org/docs/current/specification/#single-object-encoding). |
+| `encoding` | No | Set to `single_object` to generate a `Fingerprint()` method on the primary record type for [Avro Single Object Encoding](https://avro.apache.org/docs/current/specification/#single-object-encoding). Every schema in the run must be rooted at a record; one rooted at an array, a map, a union or a primitive fails the run with a diagnostic naming that root, rather than generating without the fingerprint. |
 
 **Generated types:**
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Generates idiomatic Go types with binary Avro serialization support.
 | Option | Required | Description |
 |---|---|---|
 | `package_name` | Yes | The Go package name for all generated files. |
-| `encoding` | No | Set to `single_object` to generate a `Fingerprint()` method on the primary record type for [Avro Single Object Encoding](https://avro.apache.org/docs/current/specification/#single-object-encoding). Every schema in the run must be rooted at a record; one rooted at an array, a map, a union or a primitive fails the run with a diagnostic naming that root, rather than generating without the fingerprint. |
+| `encoding` | No | Set to `single_object` to generate a `Fingerprint()` method on the primary record type for [Avro Single Object Encoding](https://avro.apache.org/docs/current/specification/#single-object-encoding). Every schema in the run must be rooted at a record. Any other root — an array, a map, a union, an enum, a fixed or a primitive — fails the run with a diagnostic naming that root, rather than generating without the fingerprint. |
 
 **Generated types:**
 

--- a/internal/avroc-gen-go/generate.go
+++ b/internal/avroc-gen-go/generate.go
@@ -54,6 +54,16 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 		return fmt.Errorf("unsupported encoding option: %q (supported: single_object)", encoding)
 	}
 
+	// What single-object encoding asks for is checked against every schema
+	// before the loop below writes any of them, so a descriptor this generator
+	// cannot give that encoding to fails the invocation with nothing written
+	// rather than with a package the option had no effect on.
+	if singleObject {
+		if err := checkSingleObjectRoots(req.GetSchemas()); err != nil {
+			return err
+		}
+	}
+
 	for _, schema := range req.Schemas {
 		filename, content, err := buildSchemaFile(packageName, schema, singleObject)
 		if err != nil {

--- a/internal/avroc-gen-go/singleobject.go
+++ b/internal/avroc-gen-go/singleobject.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"fmt"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+)
+
+// checkSingleObjectRoots refuses every schema this generator cannot give
+// single-object encoding to, and refuses it before a file has been written.
+//
+// Avro's single-object encoding frames one value behind the fingerprint of the
+// schema that value was written against, and this generator publishes that
+// fingerprint as a Fingerprint method on the Go type it generated for the
+// schema's root record. A root that is not a record has no such type, so there
+// was nowhere to put the method and none was emitted — the run exited zero, and
+// a user who asked for single-object encoding was handed ordinary binary
+// encoding with nothing on stderr saying so (#173). Silence was the bug:
+// docs/plugin/SPEC.md makes a non-zero exit how a generator says it cannot do
+// what an option asked, and avroc discards the invocation's scratch directory
+// on one, so the user is told rather than shipped the wrong thing.
+//
+// It walks every schema in the descriptor before the generation loop rather
+// than checking inside it, because that loop writes as it goes: refusing the
+// third schema from within it would leave the first two behind in the output
+// directory. avroc would discard them, so nothing wrong reaches the user's
+// tree either way — but a generator that has written half a package before
+// noticing it was never going to finish has read the descriptor in the wrong
+// order.
+//
+// Refusing is a complete fix on its own, and not the only possible one:
+// single-object encoding frames *one* value, and for schema array<Event>; that
+// value is the array, so the fingerprint is the array schema's and belongs once
+// at the head of the stream rather than once per item. Supporting that is a
+// later story, and it turns this refusal into generation.
+func checkSingleObjectRoots(schemas []*avrocpb.Schema) error {
+	for _, schema := range schemas {
+		if _, ok := schema.GetType().GetType().(*avrocpb.Type_Record); ok {
+			continue
+		}
+
+		// The diagnostic below names a type constructor, so it has to be one
+		// that exists. Validate owns that closed set, and a root outside it is
+		// a schema this generator cannot represent at all rather than one an
+		// option was wrong about — so it is reported as the former, in the
+		// words the rest of the repository uses for it.
+		if err := ir.Validate(schema); err != nil {
+			return err
+		}
+
+		return fmt.Errorf(
+			"encoding=single_object requires a record at the schema root: schema %q has a root of type %s",
+			ir.SchemaBaseName(schema),
+			typeConstructor(schema.GetType()),
+		)
+	}
+	return nil
+}
+
+// typeConstructor names a type the way Avro's specification does, for a
+// diagnostic a person reads.
+//
+// A reference is named by what it refers to — the primitive's name, or the
+// named type's — because "reference" is a fact about how the IR encodes a type
+// and not about the schema anybody wrote. The default arm is unreachable for a
+// type Validate has accepted and is there because a switch on a closed set
+// still needs one.
+func typeConstructor(t *avrocpb.Type) string {
+	switch v := t.GetType().(type) {
+	case *avrocpb.Type_Record:
+		return "record"
+	case *avrocpb.Type_EnumType:
+		return "enum"
+	case *avrocpb.Type_Fixed:
+		return "fixed"
+	case *avrocpb.Type_Array:
+		return "array"
+	case *avrocpb.Type_MapType:
+		return "map"
+	case *avrocpb.Type_Union:
+		return "union"
+	case *avrocpb.Type_Reference:
+		return v.Reference.GetName()
+	default:
+		return "unknown"
+	}
+}

--- a/internal/avroc-gen-go/singleobject_test.go
+++ b/internal/avroc-gen-go/singleobject_test.go
@@ -133,6 +133,27 @@ func TestSingleObjectEncodingRefusesBeforeWritingAnyFile(t *testing.T) {
 	assertNothingWritten(t, dir, w)
 }
 
+// TestSingleObjectEncodingReportsARootOutsideTheClosedSet pins the one place
+// the root check defers: the diagnostic names a type constructor, so a root
+// that is not one at all is reported by Validate, which owns that closed set,
+// rather than as a refused option. A schema carrying no root type is the case
+// that reaches it, and it must arrive as that error and not as a panic — the
+// protobuf getters are nil-safe all the way down, so the type assertion above
+// simply does not match.
+func TestSingleObjectEncodingReportsARootOutsideTheClosedSet(t *testing.T) {
+	dir := t.TempDir()
+	w := plugin.NewOutputDir(dir)
+
+	err := Generate(singleObjectRequest(&avrocpb.Schema{Namespace: proto.String("com.example")}), w)
+	if err == nil {
+		t.Fatal("Generate accepted a schema carrying no root type")
+	}
+	if !strings.Contains(err.Error(), "nil type") {
+		t.Errorf("diagnostic %q is not the one Validate gives a schema with no root type", err.Error())
+	}
+	assertNothingWritten(t, dir, w)
+}
+
 // TestSingleObjectEncodingAcceptsARecordRoot is the guard on the two tests
 // above: a check that refused every schema would pass both.
 func TestSingleObjectEncodingAcceptsARecordRoot(t *testing.T) {
@@ -270,6 +291,6 @@ func assertNothingWritten(t *testing.T, dir string, w *plugin.OutputDir) {
 		t.Fatalf("failed to read the output directory: %v", err)
 	}
 	if len(entries) != 0 {
-		t.Errorf("output directory holds %d entrie(s) from an invocation the generator refused", len(entries))
+		t.Errorf("output directory holds %d entries from an invocation the generator refused", len(entries))
 	}
 }

--- a/internal/avroc-gen-go/singleobject_test.go
+++ b/internal/avroc-gen-go/singleobject_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+	"github.com/z5labs/avroc/internal/plugin"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// eventRecord is a record this generator handles without complaint, so a
+// failure below is the root type and nothing else.
+func eventRecord() *avrocpb.Type {
+	return &avrocpb.Type{
+		Type: &avrocpb.Type_Record{
+			Record: &avrocpb.Record{
+				Name:      proto.String("Event"),
+				Namespace: proto.String("com.example"),
+				FullName:  proto.String("com.example.Event"),
+				Fields: []*avrocpb.Field{
+					{
+						Name: proto.String("id"),
+						Type: &avrocpb.Type{Type: &avrocpb.Type_Reference{Reference: primRef("string")}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// singleObjectRequest builds a request asking for single-object encoding over
+// the schemas it is given.
+func singleObjectRequest(schemas ...*avrocpb.Schema) *avrocpb.GenerateRequest {
+	return &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{
+			{Name: proto.String("package_name"), Value: proto.String("gen")},
+			{Name: proto.String("encoding"), Value: proto.String("single_object")},
+		},
+		Schemas: schemas,
+	}
+}
+
+// TestSingleObjectEncodingRefusesANonRecordRoot is #173: the fingerprint
+// single-object encoding needs is published as a method on the Go type
+// generated for the schema's root record, so a root that is not a record used
+// to produce no Fingerprint at all — and the run exited zero, handing back
+// ordinary binary encoding with nothing on stderr saying so. Silence is the
+// bug; a diagnostic naming the root's type constructor is the fix.
+func TestSingleObjectEncodingRefusesANonRecordRoot(t *testing.T) {
+	testCases := []struct {
+		name        string
+		root        *avrocpb.Type
+		constructor string
+	}{
+		{
+			name:        "array root",
+			root:        &avrocpb.Type{Type: &avrocpb.Type_Array{Array: &avrocpb.Array{Items: eventRecord()}}},
+			constructor: "array",
+		},
+		{
+			name:        "map root",
+			root:        &avrocpb.Type{Type: &avrocpb.Type_MapType{MapType: &avrocpb.Map{Values: eventRecord()}}},
+			constructor: "map",
+		},
+		{
+			name: "union root",
+			root: &avrocpb.Type{Type: &avrocpb.Type_Union{Union: &avrocpb.Union{
+				Types: []*avrocpb.Type{
+					{Type: &avrocpb.Type_Reference{Reference: primRef("null")}},
+					eventRecord(),
+				},
+			}}},
+			constructor: "union",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			w := plugin.NewOutputDir(dir)
+
+			err := Generate(singleObjectRequest(&avrocpb.Schema{
+				Namespace: proto.String("com.example"),
+				Type:      tc.root,
+			}), w)
+
+			if err == nil {
+				t.Fatal("Generate exited zero for a schema it cannot give single-object encoding to")
+			}
+			if !strings.Contains(err.Error(), tc.constructor) {
+				t.Errorf("diagnostic %q does not name the root's type constructor %q", err.Error(), tc.constructor)
+			}
+			if !strings.Contains(err.Error(), "single_object") {
+				t.Errorf("diagnostic %q does not name the option that was refused", err.Error())
+			}
+			assertNothingWritten(t, dir, w)
+		})
+	}
+}
+
+// TestSingleObjectEncodingRefusesBeforeWritingAnyFile is the reason the check
+// runs over the whole descriptor before the generation loop rather than inside
+// it: the loop writes as it goes, so a refusal from within it would leave the
+// schemas before the offending one behind as half a package.
+func TestSingleObjectEncodingRefusesBeforeWritingAnyFile(t *testing.T) {
+	dir := t.TempDir()
+	w := plugin.NewOutputDir(dir)
+
+	err := Generate(singleObjectRequest(
+		&avrocpb.Schema{Namespace: proto.String("com.example"), Type: eventRecord()},
+		&avrocpb.Schema{
+			Namespace: proto.String("com.example"),
+			Type: &avrocpb.Type{Type: &avrocpb.Type_Array{
+				Array: &avrocpb.Array{Items: eventRecord()},
+			}},
+		},
+	), w)
+
+	if err == nil {
+		t.Fatal("Generate accepted a descriptor carrying a schema it cannot give single-object encoding to")
+	}
+	assertNothingWritten(t, dir, w)
+}
+
+// TestSingleObjectEncodingAcceptsARecordRoot is the guard on the two tests
+// above: a check that refused every schema would pass both.
+func TestSingleObjectEncodingAcceptsARecordRoot(t *testing.T) {
+	dir := t.TempDir()
+	w := plugin.NewOutputDir(dir)
+
+	if err := Generate(singleObjectRequest(&avrocpb.Schema{
+		Namespace: proto.String("com.example"),
+		Type:      eventRecord(),
+	}), w); err != nil {
+		t.Fatalf("Generate refused a record root: %v", err)
+	}
+
+	if len(w.Written()) != 1 {
+		t.Fatalf("generator wrote %d file(s), want 1", len(w.Written()))
+	}
+
+	code := readWritten(t, dir, w.Written()[0])
+	validateGoSyntax(t, code)
+	if !strings.Contains(code, "func (x *Event) Fingerprint() [8]byte {") {
+		t.Errorf("generated code carries no Fingerprint method for the root record, got:\n%s", code)
+	}
+}
+
+// TestANonRecordRootGeneratesWithoutSingleObjectEncoding scopes the refusal to
+// the option that asked for the fingerprint. A schema rooted at an array is
+// perfectly generatable as ordinary binary encoding, and nothing about #173
+// makes it otherwise.
+func TestANonRecordRootGeneratesWithoutSingleObjectEncoding(t *testing.T) {
+	dir := t.TempDir()
+	w := plugin.NewOutputDir(dir)
+
+	err := Generate(&avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
+		Schemas: []*avrocpb.Schema{{
+			Namespace: proto.String("com.example"),
+			Type: &avrocpb.Type{Type: &avrocpb.Type_Array{
+				Array: &avrocpb.Array{Items: eventRecord()},
+			}},
+		}},
+	}, w)
+	if err != nil {
+		t.Fatalf("Generate refused an array root that asked for no encoding: %v", err)
+	}
+
+	if len(w.Written()) != 1 {
+		t.Fatalf("generator wrote %d file(s), want 1", len(w.Written()))
+	}
+
+	code := readWritten(t, dir, w.Written()[0])
+	validateGoSyntax(t, code)
+	if !strings.Contains(code, "type Event struct") {
+		t.Errorf("generated code carries no type for the array's items, got:\n%s", code)
+	}
+	if strings.Contains(code, "Fingerprint()") {
+		t.Errorf("generated code carries a Fingerprint method nobody asked for, got:\n%s", code)
+	}
+}
+
+// TestTypeConstructorNamesEveryConstructor pins the vocabulary the diagnostic
+// is written in: Avro's names for the six constructors, and for a reference the
+// name of what it refers to, because "reference" is a fact about how the IR
+// encodes a type rather than about the schema anybody wrote.
+func TestTypeConstructorNamesEveryConstructor(t *testing.T) {
+	testCases := []struct {
+		typ  *avrocpb.Type
+		want string
+	}{
+		{typ: eventRecord(), want: "record"},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_EnumType{EnumType: &avrocpb.Enum{Name: proto.String("Colour")}}},
+			want: "enum",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_Fixed{Fixed: &avrocpb.Fixed{Name: proto.String("MD5")}}},
+			want: "fixed",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_Array{Array: &avrocpb.Array{Items: eventRecord()}}},
+			want: "array",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_MapType{MapType: &avrocpb.Map{Values: eventRecord()}}},
+			want: "map",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_Union{Union: &avrocpb.Union{}}},
+			want: "union",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_Reference{Reference: primRef("string")}},
+			want: "string",
+		},
+		{
+			typ:  &avrocpb.Type{Type: &avrocpb.Type_Reference{Reference: namedRef("com.example.Event")}},
+			want: "com.example.Event",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := typeConstructor(tc.typ); got != tc.want {
+				t.Errorf("typeConstructor() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// readWritten reads one of the files an invocation wrote, named the way
+// OutputDir records it: a slash-separated path relative to the output
+// directory.
+func readWritten(t *testing.T, dir string, written string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(written)))
+	if err != nil {
+		t.Fatalf("failed to read the generated file: %v", err)
+	}
+	return string(content)
+}
+
+// assertNothingWritten requires a refused invocation to have left the output
+// directory as it found it — empty. Both halves are checked because they can
+// disagree: the writer's record is what avroc's merge is planned from, and the
+// directory is what it actually merges.
+func assertNothingWritten(t *testing.T, dir string, w *plugin.OutputDir) {
+	t.Helper()
+
+	if n := len(w.Written()); n != 0 {
+		t.Errorf("generator recorded %d file(s) from an invocation it refused", n)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read the output directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("output directory holds %d entrie(s) from an invocation the generator refused", len(entries))
+	}
+}


### PR DESCRIPTION
Closes #173

`encoding=single_object` silently generated nothing when a schema's root was not
a record. `generateFileCode` emits the `Fingerprint` method only for the type
whose name `schemaRecordName` returns, and that is the empty string for any root
that is not a `Type_Record` — so for `schema array<Event>;` no generated type
matched, no method was emitted, and the run exited zero. The user asked for
single-object encoding and got ordinary binary encoding, with nothing on stderr
saying so.

`internal/avroc-gen-go/singleobject.go` now refuses that combination.
`docs/plugin/SPEC.md` makes a non-zero exit how a generator says it cannot do
what an option asked, and avroc discards the invocation's scratch directory on
one, so the user is told rather than shipped the wrong thing.

## Acceptance Criteria

- [x] `encoding=single_object` against a schema whose root is not a record fails
      the invocation with a diagnostic naming the root's type constructor,
      instead of exiting zero having emitted no `Fingerprint`.
      The message is
      `encoding=single_object requires a record at the schema root: schema "Event" has a root of type array`.
- [x] The failure is reached before any file is written, so no partial package is
      left behind. `checkSingleObjectRoots` walks every schema in the descriptor
      *before* the generation loop, which writes as it goes — refusing the third
      schema from inside it would leave the first two in the output directory.
      `TestSingleObjectEncodingRefusesBeforeWritingAnyFile` is a two-schema
      descriptor whose good schema comes first, and it asserts on both
      `OutputDir.Written()` and the directory itself.
- [x] A test covers an array root, a map root and a union root under
      `encoding=single_object` —
      `TestSingleObjectEncodingRefusesANonRecordRoot`, table-driven over the
      three, each asserting the diagnostic names its constructor and that nothing
      was written.
- [x] The existing record-root behaviour is unchanged and still covered.
      `TestGenerate_SingleObjectEncoding` and
      `TestGenerate_SingleObjectEncoding_FingerprintComputation` are untouched
      and still pass; `TestSingleObjectEncodingAcceptsARecordRoot` is the guard
      on the new tests, since a check that refused everything would pass them.

## Judgment calls

- **The refusal, not the support.** The issue leaves the choice open. This
  refuses, and says so in the code: single-object encoding frames *one* value,
  and for `schema array<Event>;` that value is the array, so the fingerprint is
  the array schema's and belongs once at the head of the stream rather than once
  per item. That is a later story, and it turns this refusal into generation.
- **The check is scoped to the option.** An array-rooted schema with no
  `encoding` option still generates exactly as it did —
  `TestANonRecordRootGeneratesWithoutSingleObjectEncoding` pins that. Nothing
  about #173 makes ordinary binary encoding over a non-record root wrong.
- **The vocabulary.** `typeConstructor` names a type the way Avro's
  specification does — `record`, `enum`, `fixed`, `array`, `map`, `union` — and
  names a reference by what it refers to, the primitive's name or the named
  type's, because "reference" is a fact about how the IR encodes a type and not
  about the schema anybody wrote. It is unexported and lives beside its one
  caller rather than in `internal/ir`: no second generator needs it yet.
- **A root outside the closed set defers to `ir.Validate`.** The diagnostic names
  a type constructor, so it has to be one that exists. On the refusal path
  `Validate` runs first, and a root it does not recognise is reported as the
  unrepresentable schema it is, in the words the rest of the repository uses,
  rather than as a refused option.
- **`README.md`** now says the rule alongside the option, since that table is
  where a user meets `encoding` at all.

## Verification

All four `verify` commands, from the worktree:

- `go build ./...`
- `go test -race -cover ./...` — all packages pass
- `golangci-lint run` — 0 issues
- the four binaries built, `example/` regenerated, `git diff --exit-code -- example` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)