### PR TITLE
story(issue-202): every dagger call in CI publishes its trace to Dagger Cloud

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,43 @@ jobs:
       # below — but this job only builds it and throws it away; the grant that
       # publishes it lives on the job that publishes it, in release.yaml.
       contents: read
+    # Every `dagger call` below publishes its trace to Dagger Cloud, and this is
+    # the whole of the mechanism: the CLI uploads whenever a Cloud token is in
+    # its environment. There is nothing to install and no flag to pass.
+    #
+    # It answers the questions this log cannot. Most of these calls fan out over
+    # linux/amd64 and linux/arm64 and build containers inside containers, so a
+    # red step here is a wall of interleaved output, and *which platform*,
+    # *which stage inside the module* and *why it took eleven minutes* are
+    # things you would otherwise read by eye. The trace already records all
+    # three; before this it was recorded and thrown away.
+    #
+    # Deliberately not `dagger/dagger-for-github`. Its `version` input takes a
+    # literal semver or `latest`, and both workflows here install the CLI at the
+    # `engineVersion` read out of dagger.json specifically so that no Dagger
+    # version is ever typed into a workflow file — the same argument as
+    # .golangci.yml and the --platform matrix living in the module. The action
+    # buys one environment variable and costs that.
+    #
+    # The scope is this job rather than the workflow, and the value is never
+    # given to the module: it reaches the CLI and stops there. Nothing the
+    # module builds sees it, because Dagger puts host environment inside a
+    # container only where the module asks for it, and none of these functions
+    # ask.
+    #
+    # This is Dagger's own telemetry. `OTEL_EXPORTER_OTLP_*` is a different
+    # lever pointing at a different backend; setting one has nothing to do with
+    # the other.
+    #
+    # One-time setup: sign in to Dagger Cloud, open the organisation's Settings
+    # -> Tokens (https://dagger.cloud/<org>/settings?tab=Tokens), and add the
+    # value as a repository secret named DAGGER_CLOUD_TOKEN. It is an ingest
+    # credential for that organisation's traces and grants nothing in this
+    # repository. DAGGER_CLOUD_TOKEN is the name the pinned engineVersion reads
+    # — _EXPERIMENTAL_DAGGER_CLOUD_TOKEN is the name it replaced, and v0.21.8
+    # does not look at it.
+    env:
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     steps:
       # A shallow checkout on purpose. The module excludes .git from the source
       # directory it checks, because none of fmt, vet, lint or test reads git
@@ -69,6 +106,27 @@ jobs:
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Degrade loudly, not silently, and only where somebody can act on it. A
+      # run without the token still passes and simply publishes nothing — which
+      # is the permanent state of a pull request from a fork, because GitHub
+      # denies forks secrets by design and nothing on that side could fix it.
+      # Warning there would put a defect on every outside contributor's first
+      # pull request that is not one.
+      #
+      # Every other run — a branch in this repository, main, the merge queue —
+      # is missing the token only because nobody has added the secret yet, and
+      # what is lost is the trace of the run being read. So that case says so,
+      # the way auto-merge.yaml warns when BACKLOG_APP_ID is unset.
+      - name: Warn when no trace will be published
+        if: >-
+          env.DAGGER_CLOUD_TOKEN == '' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          echo "::warning title=No Dagger Cloud trace::DAGGER_CLOUD_TOKEN is unset, so \
+          this run publishes no trace and every failure below has to be read out of this \
+          log by eye. See the comment on this job for where an operator gets one."
 
       # No arguments, because the module's source defaults to the repository
       # root and its lint configuration defaults to the .golangci.yml committed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,25 @@ jobs:
       # else on this workflow needs either, which is why the grant is on the job
       # rather than at the top of the file.
       contents: write
+    # The `dagger call` below publishes its trace to Dagger Cloud, because the
+    # CLI uploads whenever a Cloud token is in its environment — the same one
+    # line as build.yaml's, on the run where finding out afterwards is worst. A
+    # release happens once and the tag is never repointed, so the run that
+    # produced it is the one whose trace is worth having.
+    #
+    # Per job rather than at the top of the file, so the token's scope is what
+    # uses it: it reaches the CLI and stops there, and nothing the module builds
+    # is given it.
+    #
+    # One-time setup: sign in to Dagger Cloud, open the organisation's Settings
+    # -> Tokens (https://dagger.cloud/<org>/settings?tab=Tokens), and add the
+    # value as a repository secret named DAGGER_CLOUD_TOKEN. It is an ingest
+    # credential for that organisation's traces and grants nothing in this
+    # repository. DAGGER_CLOUD_TOKEN is the name the pinned engineVersion reads
+    # — _EXPERIMENTAL_DAGGER_CLOUD_TOKEN is the name it replaced, and v0.21.8
+    # does not look at it.
+    env:
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     steps:
       # At the release's tag, not at whatever main has moved to since. The
       # artifact is a function of the source, so an asset built from a different
@@ -52,6 +71,17 @@ jobs:
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Degrade loudly, not silently: without the secret the release still runs
+      # and simply publishes no trace. There is no fork case to exclude here as
+      # there is in build.yaml — a release event only ever fires in this
+      # repository, so a missing token is always something an operator can fix.
+      - name: Warn when no trace will be published
+        if: env.DAGGER_CLOUD_TOKEN == ''
+        run: |
+          echo "::warning title=No Dagger Cloud trace::DAGGER_CLOUD_TOKEN is unset, so \
+          this release publishes no trace. See the comment on this job for where an \
+          operator gets one."
 
       # The same function CI builds on every pull request and a contributor runs
       # locally, so the released asset is produced by the recipe that has already
@@ -104,6 +134,18 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    # The three `dagger call`s below publish their traces, for the reason the
+    # job above gives and with the same one-time setup — the account of what
+    # this secret is and where an operator gets one is on that job, a screen up
+    # in this file. It is repeated per job rather than hoisted to the workflow
+    # because the scope of the token should be what reads it.
+    #
+    # It is not passed to `dagger call release` and must not be. That call
+    # already carries the registry password and the identity token; the Cloud
+    # token is the CLI's own and has no business inside anything the module
+    # builds.
+    env:
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     steps:
       # At the release's tag, for the same reason the asset above is built
       # there: the image is a function of the source, and an image built from a
@@ -126,6 +168,15 @@ jobs:
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # As on the job above, and for the same reason: the publish is the run
+      # where reading a failure out of the log by eye costs the most.
+      - name: Warn when no trace will be published
+        if: env.DAGGER_CLOUD_TOKEN == ''
+        run: |
+          echo "::warning title=No Dagger Cloud trace::DAGGER_CLOUD_TOKEN is unset, so \
+          this release publishes no trace. See the comment on this job for where an \
+          operator gets one."
 
       # The same contract check CI runs on every pull request, run once more
       # against the tag before anything is pushed. A tag is published once and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,26 @@ The version comes out of `dagger.json` rather than being typed in, because the
 provisions a different engine is a difference between your machine and CI, which
 is the one thing this module exists to prevent.
 
+### Reading a run's trace
+
+Every `dagger call` CI makes publishes its trace to [Dagger
+Cloud](https://dagger.cloud), and the link to it is printed in the log of the
+step that made the call. Start there when a check goes red: most of those calls
+fan out over `linux/amd64` and `linux/arm64` and build containers inside
+containers, so the Actions log is interleaved output from all of it, while the
+trace says which platform, which stage inside the module and where the time
+went.
+
+**Your own `dagger call` publishes nothing unless you have set your own token.**
+The CLI uploads only when `DAGGER_CLOUD_TOKEN` is in its environment; with no
+token it runs entirely on your machine and sends nothing anywhere. If you want
+traces for your local runs, get a token from your own Dagger Cloud
+organisation's Settings → Tokens and export it — it is yours, unrelated to this
+repository's secret, and nothing here asks you to have one.
+
+A pull request from a fork publishes no trace either: GitHub does not give a
+fork's run access to secrets. That is expected and the run still passes.
+
 ### After changing a module
 
 `.dagger/dagger.gen.go` and `.dagger/internal/` are generated **and committed**,


### PR DESCRIPTION
CI ran the whole pipeline through Dagger and threw the trace away — eight `dagger call`s on every
pull request, four more on a release, every one of them producing a trace the engine already
recorded and none of it leaving the runner. Most of those calls fan out over `linux/amd64` and
`linux/arm64` and build containers inside containers, so a red step is a wall of interleaved output
and *which platform*, *which stage inside the module* and *why it took eleven minutes* are read by
eye. The trace answers all three by construction.

**The mechanism is the environment, not a new tool.** The Dagger CLI uploads whenever a Cloud token
is in its environment; there is nothing to install and no flag to pass. So the change is a
job-scoped `DAGGER_CLOUD_TOKEN` on the three jobs that call the module, plus a step that says so
when it is absent.

**The name was confirmed against the pinned CLI rather than assumed.** `dagger v0.21.8` reads
`DAGGER_CLOUD_TOKEN`; `_EXPERIMENTAL_DAGGER_CLOUD_TOKEN` does not appear in that binary at all.

**`dagger/dagger-for-github` is not adopted**, on the story's own test. Its `version` input takes a
literal semver or `latest` — there is no way to say "read `dagger.json`" — and both workflows
install the CLI at the `engineVersion` read out of `dagger.json` specifically so that no Dagger
version is ever typed into a workflow file. The action buys one environment variable and costs
that.

### What changed

- `.github/workflows/build.yaml` — job-scoped `DAGGER_CLOUD_TOKEN` on `build`, covering all eight
  calls for `pull_request`, `push` to main and `merge_group` alike, and a warning step.
- `.github/workflows/release.yaml` — the same on both `ir-descriptor-set` and `image`, covering all
  four calls. It is deliberately not passed to `dagger call release`: that call already carries the
  registry password and the identity token, and the Cloud token is the CLI's own.
- `CONTRIBUTING.md` — a "Reading a run's trace" section: where a failed check's trace is read, and
  that a contributor's own `dagger call` publishes only with their own token, so nobody has to
  wonder whether running the pipeline locally sends anything anywhere.

### The absent-token case

A run without the token still passes and publishes nothing. That is the permanent state of a pull
request from a fork, which GitHub denies secrets by design — so the warning excludes forks, because
nothing on that side could act on it, and fires on everything else, the way `auto-merge.yaml` warns
when `BACKLOG_APP_ID` is unset. A release run has no fork case, so its condition is just the empty
check.

### Scope

Job-level rather than workflow-level, and never handed to the module: it reaches the CLI and stops
there. Nothing the module builds sees it, because Dagger puts host environment inside a container
only where the module asks, and none of these functions ask.

### Verification

`DAGGER_CLOUD_TOKEN` is already provisioned as a `z5labs` organisation secret visible to this
repository, so **this pull request's own run is the verification**: its `Build` job should carry no
"No Dagger Cloud trace" warning, and each of the eight steps should print its trace link. Checked
locally: `actionlint` is clean on both workflows, `go build ./...` and `go test ./...` pass, and
`internal/docs`'s link check passes over the new CONTRIBUTING.md section.

Out of scope, as the issue names them: fork pull requests, exporting anywhere other than Dagger
Cloud (`OTEL_EXPORTER_OTLP_*` is a separate lever, #199's), and asserting anything about the trace
(#199 is what makes propagation an executable check).

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)