### PR TITLE
chore(backlog): migrate the plugin config to the 0.10.0 reviewer roster

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -1,7 +1,7 @@
 {
   "select": {
     "label": "story",
-    "milestone": "v0.2.0",
+    "milestone": null,
     "limit": 200
   },
   "dependencies": {
@@ -9,6 +9,8 @@
   },
   "verify": [
     "go build ./...",
+    "out=$(gofmt -l .); test -z \"$out\" || { echo \"$out\"; exit 1; }",
+    "go vet ./...",
     "go test -race -cover ./...",
     "golangci-lint run",
     "go build -o ./bin/avroc ./cmd/avroc && go build -o ./bin/avroc-gen-go ./cmd/avroc-gen-go && go build -o ./bin/avroc-gen-json ./cmd/avroc-gen-json && go build -o ./bin/avroc-gen-pcf ./cmd/avroc-gen-pcf && (export PATH=\"$PWD/bin:$PATH\"; cd example && avroc generate) && git diff --exit-code -- example"
@@ -18,7 +20,11 @@
     "workflow": "auto-merge.yaml"
   },
   "review": {
-    "required": true
+    "reviewers": ["copilot", "local"],
+    "app": {
+      "idEnv": "Z5LABS_REVIEW_APP_ID",
+      "keyEnv": "Z5LABS_REVIEW_APP_KEY"
+    }
   },
   "worktreeDir": ".claude/worktrees"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "backlog@z5labs-devex": true
+  },
   "extraKnownMarketplaces": {
     "z5labs-devex": {
       "source": {
@@ -6,8 +9,5 @@
         "repo": "z5labs/devex"
       }
     }
-  },
-  "enabledPlugins": {
-    "backlog@z5labs-devex": true
   }
 }


### PR DESCRIPTION
`.claude/backlog.json` was written against an older backlog plugin and the 0.10.0
selector refuses it outright — exit 4 at step 1, before an issue is ever listed:

```
select-issue: .claude/backlog.json: review.required is no longer read; replace it
with review.reviewers, an ordered roster tried in order
```

So the loop could not run at all. Three things were wrong, and only the first was
loud.

## `review.required` → `review.reviewers`

The boolean could say "review" and "do not review" and nothing between them, so a
repository whose Copilot allowance ran out could only choose between no loop and no
review — permanently, in a tracked file. It becomes an ordered roster tried on
**availability**:

```json
"reviewers": ["copilot", "local"]
```

Copilot is the rung that demonstrably works here: **109 Copilot review comments**
across this repository's pull requests, which is proof rather than inference.
`local` is a fallback that costs nothing until the first rung is unreachable.

`none` is deliberately **not** in the roster. Without a final rung, a pull request
no reviewer could handle reports `BLOCKED` instead of merging unreviewed.

The `local` rung reads its credentials from the two variables named under
`review.app` rather than the defaults, because a GitHub App is installed per
*account* and this operator owns repositories under two. These are **names, not
values** — the App ID and the private key stay in the environment.

## `select.milestone: "v0.2.0"` → `null`

**That milestone no longer exists.** The only milestone on this repository is
v0.3.0, and all ten open stories are in it.

This is the exact failure the key is documented for: a value that decays silently
as releases ship, leaving `gh issue list --milestone` to answer `[]` with exit 0 —
which reads as a drained backlog and stops the loop *looking like success*. `null`
cannot decay, and a run that wants one milestone passes `--milestone` instead of
editing a tracked file.

## `verify` gains gofmt and vet

CI runs `dagger call ci`, which is the Z5Labs `GoLib` pipeline — fmt, vet, lint,
test. The list carried lint and test only, so a formatting miss surfaced as a red
pull request that the cycle then spent one of its three fix attempts on.

gofmt is **not** spelled `gofmt -l .`. That exits 0 while listing the files it
would rewrite, which makes it a verify command that can never fail. It is written
to name the offending files and exit 1, and was exercised in both directions —
exit 0 on the clean tree, exit 1 naming the file on a deliberately malformed one.

## What was checked and deliberately left alone

- **`dependencies.style: "native"` kept.** Verified rather than assumed: all ten
  open stories carry typed `blocked_by` edges (1–3 each), so the edge set is
  genuinely populated and not silently empty.
- **`.github/workflows/auto-merge.yaml` untouched.** It differs from the plugin
  asset only by pinning `actions/create-github-app-token` to a SHA where the asset
  floats at `@v3`. Ours is the better version.
- **The `.claude/settings.json` hunk** is a key reorder written by
  `/plugin install`. Semantically nothing.

## Verified after the change

```
select-issue: reviewer roster: copilot -> local
select-issue: reviewer App credentials: $Z5LABS_REVIEW_APP_ID and $Z5LABS_REVIEW_APP_KEY
select-issue: #190 eligible (dependencies all CLOSED)
```

## Not fixed here — needs repository admin

`main` carries `deletion`, `non_fast_forward`, `required_linear_history`,
`required_signatures` and `pull_request`, but **no `required_status_checks` rule**,
and `required_approving_review_count` is 0. With nothing to wait on, the
`auto-merge` label merges the pull request essentially immediately — `Build`,
`CodeQL` and `Analyze (go)` report into the void, and the cycle's local `verify` is
the only thing that ever looked at the code. Requiring `Build` at minimum is worth
doing before the loop runs unattended.

Two environment faults also stop the `local` rung, both found by actually minting a
token and neither fixable in this repository:

1. `Z5LABS_REVIEW_APP_KEY` holds the literal string `~/.config/backlog/…`; the
   tilde is never expanded, so the key reads as unreadable. `"$HOME/…"` fixes it.
2. With the path expanded, `--login` succeeds as `z5labs-local-reviewer[bot]` but
   the App is **not installed on `z5labs/avroc`**.

Both surface as exit 3 — UNAVAILABLE — which a roster reads as a rung merely
*down*. With no `none` rung the worst case is a `BLOCKED` report rather than an
unreviewed merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
