### PR TITLE
story(avroc): spans for the phases of a run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,45 @@ Four things are decisions rather than mechanics.
   `TestTheTracingStackCarriesNoGRPCTransport` reads `go.mod` and is what notices
   the day somebody imports the convenient thing instead.
 
+**`avroc generate` is the trace** (#192, `internal/avroc/trace.go`). One root span,
+`avroc.generate`, with a child for each phase that already existed as a function:
+`avroc.manifest.load`, `avroc.idl.parse` and `avroc.ir.resolve` (one of each per
+declared input, named as `avroc.json` wrote it, and skipped for an input the
+schema cache already parsed), `avroc.handshake` with an
+`avroc.generator.handshake` inside it per generator, an `avroc.generator.run` per
+invocation, then `avroc.merge`, `avroc.prune` and `avroc.record`. Nothing else is
+a phase — the trace is the decomposition the code already had, not a second one.
+`init` and `inspect` are untraced by construction rather than by omission: `Main`
+hands the tracer to `runGenerate` and to nothing else.
+
+Four things there are decisions.
+
+- **The provider travels in the context, not in a parameter and not in a global.**
+  `startSpan` takes the tracer from `trace.SpanFromContext(ctx).TracerProvider()`,
+  so every phase inherits the provider the run was configured with, a phase
+  called on its own in a test gets the no-op one rather than whatever
+  `otel.GetTracerProvider` is holding, and nothing below `Main` grew a
+  `trace.Tracer` argument to thread through untouched. It is the same reasoning
+  that has `internal/telemetry` read its environment through `cli.Context`.
+- **`endSpan` is the only place a status is set**, so a phase records failure
+  once. `reportFailure` contributes the classification it had already made for
+  the log — `exit_code`, or `signal` and `signal_number`, or neither for a
+  generator that never ran — as *attributes*, spelled exactly as the log spells
+  them; the status is set where the span ends, which is what lets a generator
+  killed by the kill `exec.CommandContext` sends be marked `cancelled` rather
+  than described twice.
+- **A collision is an event on the merge span**, not on either generator's, and
+  `findCollisions`/`collisionError` are one value rendered twice so the trace and
+  the refusal cannot disagree about which paths collided or in what order.
+- **Instrumentation must not become the reason iteration follows completion
+  order.** The merge, the record and the report are the manifest's (#184), and
+  `TestInstrumentationDidNotChangeTheIteration` runs generators that finish in the
+  reverse of the manifest's order with the spans recording.
+
 Tracing is an observation of a run and never an input to it:
 `TestGeneratedBytesAreTheSameTracedOrNot` requires a traced run and an untraced
-one to leave the same tree behind, byte for byte.
+one to leave the same tree behind, byte for byte — with a decoding collector on
+the traced side, so a run that exported nothing cannot pass it.
 
 ### Determinism
 

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -23,6 +23,8 @@ import (
 	"github.com/z5labs/avroc/internal/telemetry"
 
 	"github.com/z5labs/avro-go/idl"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Main dispatches to an avroc subcommand. Generators are declared in an
@@ -35,6 +37,12 @@ import (
 // processor holding the run's spans would drop every one of them. Down here it
 // is on every path out of the command, the failing ones included, because every
 // path out is a return.
+//
+// The tracer the provider hands out goes to generate and to nothing else (#192).
+// A run is the thing worth a trace: it forks processes, walks a project tree and
+// takes seconds. init writes one file it was asked for and inspect renders one it
+// was handed, and neither is a question anybody asks a span about — so they are
+// not merely untraced by omission, they are never given the means.
 func Main(ctx context.Context, cli cli.Context) int {
 	// A configuration this build cannot honour is a warning and an untraced run,
 	// never a failed one: see internal/telemetry. The provider is usable either
@@ -64,7 +72,7 @@ func Main(ctx context.Context, cli cli.Context) int {
 		if code, ok := rejectExtraArgs(cmd, cli.Args[1:]); !ok {
 			return code
 		}
-		return runGenerate(ctx, cli)
+		return runGenerate(ctx, cli, tracing.Tracer(tracerScope))
 	case "inspect":
 		// inspect names the descriptor it renders, so it owns its own argument
 		// handling rather than being routed through rejectExtraArgs.
@@ -209,6 +217,16 @@ type generator struct {
 // project tree (#118). On any failure the directory is removed here, with
 // whatever the generator left in it, and no plan is returned.
 func (g generator) run(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (out *generatorOutput, err error) {
+	// One span per invocation, and the anchor #193 hangs the generator's own
+	// spans off: the context it is started from is the one exec.CommandContext
+	// carries into the child. Registered before every other defer here so that it
+	// unwinds after all of them, and therefore records the error the whole
+	// invocation returned rather than the one the process exited with.
+	ctx, span := startSpan(ctx, spanGeneratorRun, generatorAttr(g.name))
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
 	desc := newDescriptor(options, schemas)
 
 	// One descriptor file per generator invocation, in a directory created for
@@ -348,7 +366,18 @@ func (g generator) run(ctx context.Context, output string, options []*avrocpb.Op
 // No meaning is attached to a particular non-zero value beyond failure. The
 // small integers are already spoken for by parties this contract does not
 // control, so the code is reported and nothing is concluded from it.
+//
+// The three cases are also the three shapes the invocation's span takes, because
+// the classification has already been made here and a second reading of the same
+// error somewhere else would be a fourth description of the same distinction: a
+// signal carries signal and signal_number, a non-zero exit carries exit_code,
+// and a generator that never ran carries neither, there having been no process
+// to produce either. What this does not do is set the span's status — run's
+// deferred endSpan sets it once, from the error this returns, so a generator
+// killed because the run was cancelled is still marked cancelled.
 func (g generator) reportFailure(ctx context.Context, runErr error) error {
+	span := trace.SpanFromContext(ctx)
+
 	var exitErr *exec.ExitError
 	if !errors.As(runErr, &exitErr) {
 		g.log.ErrorContext(ctx, "failed to run generator",
@@ -360,6 +389,10 @@ func (g generator) reportFailure(ctx context.Context, runErr error) error {
 
 	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
 		signal := status.Signal()
+		span.SetAttributes(
+			attribute.String(attrSignal, signal.String()),
+			attribute.Int(attrSignalNumber, int(signal)),
+		)
 		g.log.ErrorContext(ctx, "generator terminated by signal",
 			slog.String("generator", g.name),
 			slog.String("signal", signal.String()),
@@ -368,6 +401,7 @@ func (g generator) reportFailure(ctx context.Context, runErr error) error {
 		return fmt.Errorf("generator %q was terminated by signal %s (%d): %w", g.name, signal, int(signal), runErr)
 	}
 
+	span.SetAttributes(attribute.Int(attrExitCode, exitErr.ExitCode()))
 	g.log.ErrorContext(ctx, "generator exited non-zero",
 		slog.String("generator", g.name),
 		slog.Int("exit_code", exitErr.ExitCode()),

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -217,11 +217,16 @@ type generator struct {
 // project tree (#118). On any failure the directory is removed here, with
 // whatever the generator left in it, and no plan is returned.
 func (g generator) run(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (out *generatorOutput, err error) {
-	// One span per invocation, and the anchor #193 hangs the generator's own
-	// spans off: the context it is started from is the one exec.CommandContext
-	// carries into the child. Registered before every other defer here so that it
-	// unwinds after all of them, and therefore records the error the whole
-	// invocation returned rather than the one the process exited with.
+	// One span per invocation, and the anchor #193 will hang the generator's own
+	// spans off. Nothing crosses the process boundary yet: exec.CommandContext
+	// takes this context for cancellation and for nothing else, and a child
+	// learns of a parent span only when something puts it on the vector or in the
+	// environment, which is #193's to add. What this does is make the span it
+	// would carry exist, and be the invocation rather than the run.
+	//
+	// Registered before every other defer here so that it unwinds after all of
+	// them, and therefore records the error the whole invocation returned rather
+	// than the one the process exited with.
 	ctx, span := startSpan(ctx, spanGeneratorRun, generatorAttr(g.name))
 	defer func() {
 		endSpan(ctx, span, err)

--- a/internal/avroc/descriptor_test.go
+++ b/internal/avroc/descriptor_test.go
@@ -218,7 +218,7 @@ func TestPlanGenerators_DescriptorsAreReproducible(t *testing.T) {
 
 	encode := func() [][]byte {
 		t.Helper()
-		tasks, err := planGenerators(m, generators, dir)
+		tasks, err := planGenerators(t.Context(), m, generators, dir)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/avroc/generate.go
+++ b/internal/avroc/generate.go
@@ -18,6 +18,9 @@ import (
 	"github.com/z5labs/avroc/internal/cli"
 
 	"github.com/sourcegraph/conc/pool"
+	"github.com/z5labs/avro-go/idl"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // genTask is a single resolved unit of work: one generator to run with its
@@ -34,29 +37,59 @@ type genTask struct {
 // generator against the PATH-discovered executables, parses the declared input
 // IDL files, and runs the generators concurrently, writing their streamed
 // output under each generator's output directory.
-func runGenerate(ctx context.Context, cli cli.Context) int {
+//
+// It is also where the run's root span starts and ends, which is the one place
+// the tracer is handed in rather than taken from the context: every phase below
+// inherits its provider from this span (see startSpan). The exit status and the
+// span's status say the same thing about the same run — a run that returns 1
+// leaves a span marked with the error that produced it, and a run somebody
+// interrupted leaves one marked cancelled.
+func runGenerate(ctx context.Context, cli cli.Context, tracer trace.Tracer) int {
+	ctx, span := tracer.Start(ctx, spanRun)
+
+	var err error
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
+	if err = generate(ctx, cli); err != nil {
+		return 1
+	}
+	return 0
+}
+
+// generate is the run itself, phase by phase, each of them reported as it fails
+// and returned to runGenerate to become the exit status and the root span's.
+func generate(ctx context.Context, cli cli.Context) error {
 	path, ok := cli.Env.LookupEnv("PATH")
 	if !ok {
-		cli.Log.ErrorContext(ctx, "unable to lookup generators", slog.Any("error", "PATH environment variable not set"))
-		return 1
+		err := errors.New("PATH environment variable not set")
+		cli.Log.ErrorContext(ctx, "unable to lookup generators", slog.Any("error", err))
+		return err
 	}
 
 	generators, err := lookupGenerators(ctx, cli.Log, cli.OpenDir, filepath.SplitList(path)...)
 	if err != nil {
 		cli.Log.ErrorContext(ctx, "failed to lookup generators", slog.Any("error", err))
-		return 1
+		return err
 	}
 
+	// The span is started and ended around the call rather than inside
+	// loadManifest, which takes no context and does one filesystem read: a phase
+	// that cannot be cancelled has no business growing a context parameter for a
+	// span's sake.
+	_, manifestSpan := startSpan(ctx, spanManifestLoad)
 	manifest, err := loadManifest(cli, cli.WorkingDir)
+	endSpan(ctx, manifestSpan, err)
 	if err != nil {
 		cli.Log.ErrorContext(ctx, "failed to load manifest", slog.Any("error", err))
-		return 1
+		return err
 	}
 
-	tasks, err := planGenerators(manifest, generators, cli.WorkingDir)
+	tasks, err := planGenerators(ctx, manifest, generators, cli.WorkingDir)
 	if err != nil {
 		cli.Log.ErrorContext(ctx, "failed to plan generation", slog.Any("error", err))
-		return 1
+		return err
 	}
 
 	// docs/plugin/SPEC.md's capability handshake, and it runs before the pool
@@ -65,15 +98,15 @@ func runGenerate(ctx context.Context, cli cli.Context) int {
 	// produced output the user now has to work out whether to keep.
 	if err := checkGenerators(ctx, cli.Log, tasks); err != nil {
 		cli.Log.ErrorContext(ctx, "generator capability handshake failed", slog.Any("error", err))
-		return 1
+		return err
 	}
 
 	if err := generateAll(ctx, cli.Log, cli.WorkingDir, tasks); err != nil {
 		cli.Log.ErrorContext(ctx, "failed to run generators", slog.Any("error", err))
-		return 1
+		return err
 	}
 
-	return 0
+	return nil
 }
 
 // generateAll runs every planned generator and merges what they produced into
@@ -159,7 +192,7 @@ func generateAll(ctx context.Context, log *slog.Logger, projectRoot string, task
 		return waitErr
 	}
 
-	if err := mergeOutputs(projectRoot, outs); err != nil {
+	if err := mergeOutputs(ctx, projectRoot, outs); err != nil {
 		log.ErrorContext(ctx, "failed to merge generated output", slog.Any("error", err))
 		return err
 	}
@@ -228,8 +261,9 @@ func maxConcurrentGenerators() int {
 // working directory — no generator subprocesses are spawned — so it can be
 // unit-tested in isolation. It does read and parse the declared input IDL files
 // from disk; each input is parsed at most once even when shared across
-// generators.
-func planGenerators(m *Manifest, generators map[string]string, workingDir string) ([]genTask, error) {
+// generators — and so is traced at most once, because the cache is what decides
+// whether there was any work to observe.
+func planGenerators(ctx context.Context, m *Manifest, generators map[string]string, workingDir string) ([]genTask, error) {
 	schemaCache := make(map[string]*avrocpb.Schema)
 
 	tasks := make([]genTask, 0, len(m.Generators))
@@ -250,7 +284,7 @@ func planGenerators(m *Manifest, generators map[string]string, workingDir string
 			resolved := filepath.Join(workingDir, in)
 			schema, ok := schemaCache[resolved]
 			if !ok {
-				loaded, err := loadSchema(resolved)
+				loaded, err := loadSchema(ctx, in, resolved)
 				if err != nil {
 					return nil, fmt.Errorf("generator %q input %q: %w", g.Name, in, err)
 				}
@@ -289,16 +323,52 @@ func dedupInputs(shared, own []string) []string {
 
 // loadSchema parses, validates, and resolves a single IDL file into the
 // protobuf schema sent to a generator.
-func loadSchema(path string) (*avrocpb.Schema, error) {
+//
+// The two halves carry a span each, because they are the two phases the story
+// names: reading an IDL file and resolving the IR it describes are different
+// work over the same input, and a project that is slow in one is not slow in the
+// other. Both name the input as the manifest wrote it rather than as it resolved
+// on this machine, so a trace reads like avroc.json.
+func loadSchema(ctx context.Context, input, path string) (*avrocpb.Schema, error) {
+	schema, err := parseInput(ctx, input, path)
+	if err != nil {
+		return nil, err
+	}
+	return resolveInput(ctx, input, schema)
+}
+
+// parseInput is loadSchema's first phase: the IDL file read off disk and parsed.
+func parseInput(ctx context.Context, input, path string) (_ *idl.Schema, err error) {
+	_, span := startSpan(ctx, spanIDLParse, trace.WithAttributes(attribute.String(attrInput, input)))
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
 	f, err := parseIDL(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse IDL file: %w", err)
 	}
 	if f.Schema == nil {
-		return nil, fmt.Errorf("IDL file does not contain a schema")
+		return nil, errors.New("IDL file does not contain a schema")
 	}
-	if err := validateSchema(f.Schema); err != nil {
+	return f.Schema, nil
+}
+
+// resolveInput is loadSchema's second phase: the parsed schema validated and
+// resolved into the IR a generator is handed.
+//
+// Validation is inside this span rather than beside it. It is the first half of
+// resolving — the questions resolve.go would otherwise have to ask again — and a
+// third span for it would be a boundary in the trace that is not a boundary in
+// the code.
+func resolveInput(ctx context.Context, input string, schema *idl.Schema) (_ *avrocpb.Schema, err error) {
+	_, span := startSpan(ctx, spanIRResolve, trace.WithAttributes(attribute.String(attrInput, input)))
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
+	if err := validateSchema(schema); err != nil {
 		return nil, fmt.Errorf("schema validation failed: %w", err)
 	}
-	return resolveSchema(f.Schema)
+	return resolveSchema(schema)
 }

--- a/internal/avroc/generate_test.go
+++ b/internal/avroc/generate_test.go
@@ -56,7 +56,7 @@ func TestPlanGenerators(t *testing.T) {
 		}
 		generators := map[string]string{"avroc-gen-go": "/fake/avroc-gen-go"}
 
-		tasks, err := planGenerators(m, generators, dir)
+		tasks, err := planGenerators(t.Context(), m, generators, dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -99,7 +99,7 @@ func TestPlanGenerators(t *testing.T) {
 			"avroc-gen-json": "/fake/avroc-gen-json",
 		}
 
-		tasks, err := planGenerators(m, generators, dir)
+		tasks, err := planGenerators(t.Context(), m, generators, dir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,7 +119,7 @@ func TestPlanGenerators(t *testing.T) {
 			},
 		}
 
-		_, err := planGenerators(m, map[string]string{}, t.TempDir())
+		_, err := planGenerators(t.Context(), m, map[string]string{}, t.TempDir())
 		if err == nil {
 			t.Fatal("expected an error, got nil")
 		}
@@ -134,7 +134,7 @@ func TestPlanGenerators(t *testing.T) {
 		}
 		generators := map[string]string{"avroc-gen-go": "/fake/avroc-gen-go"}
 
-		if _, err := planGenerators(m, generators, t.TempDir()); err == nil {
+		if _, err := planGenerators(t.Context(), m, generators, t.TempDir()); err == nil {
 			t.Fatal("expected an error for missing inputs, got nil")
 		}
 	})
@@ -183,7 +183,7 @@ func TestRunGenerate_MissingManifest(t *testing.T) {
 		WorkingDir: t.TempDir(), // empty dir: no avroc.json
 	}
 
-	if code := runGenerate(context.Background(), ctx); code != 1 {
+	if code := runGenerate(context.Background(), ctx, noopTracer()); code != 1 {
 		t.Errorf("exit code = %d, want 1", code)
 	}
 }
@@ -195,7 +195,7 @@ func TestRunGenerate_PathNotSet(t *testing.T) {
 		OpenDir: staticOpenDir(fstest.MapFS{}),
 	}
 
-	if code := runGenerate(context.Background(), ctx); code != 1 {
+	if code := runGenerate(context.Background(), ctx, noopTracer()); code != 1 {
 		t.Errorf("exit code = %d, want 1", code)
 	}
 }

--- a/internal/avroc/merge.go
+++ b/internal/avroc/merge.go
@@ -6,6 +6,7 @@
 package avroc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,9 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // newScratchDir creates the private, empty directory one generator invocation
@@ -96,9 +100,26 @@ type generatorOutput struct {
 // run produced and this one did not is pruneStale's, and it runs after this
 // returns: nothing is removed from the tree until everything this run produced
 // is in it (#119).
-func mergeOutputs(projectRoot string, outs []*generatorOutput) error {
-	if err := checkCollisions(outs); err != nil {
-		return err
+func mergeOutputs(ctx context.Context, projectRoot string, outs []*generatorOutput) (err error) {
+	ctx, span := startSpan(ctx, spanMerge)
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
+	// Recorded on this span rather than on any generator's, because a collision
+	// is a fact about the whole set of plans: the generators that claimed a path
+	// each did nothing wrong on their own, and neither of their spans is where a
+	// person would look for what the two of them did together. The events are
+	// added in the order the refusal reports them, so the trace and the message a
+	// user sees name the same paths in the same order.
+	if collisions := findCollisions(outs); len(collisions) > 0 {
+		for _, c := range collisions {
+			span.AddEvent(eventCollision, trace.WithAttributes(
+				attribute.String(attrPath, c.path),
+				attribute.StringSlice(attrGenerators, c.generators),
+			))
+		}
+		return collisionError(collisions)
 	}
 	if err := checkReservedPaths(projectRoot, outs); err != nil {
 		return err
@@ -122,7 +143,19 @@ func mergeOutputs(projectRoot string, outs []*generatorOutput) error {
 	return nil
 }
 
-// checkCollisions refuses a run in which two generators produce the same file.
+// collision is one destination path more than one generator produced: the path,
+// and every generator that claimed it, sorted by name.
+//
+// It is a value rather than a formatted string because the same fact is said
+// twice — once to the person whose run was refused and once on the merge span —
+// and two renderings computed from one value cannot disagree about which
+// generators collided or in what order.
+type collision struct {
+	path       string
+	generators []string
+}
+
+// findCollisions reports every destination path two or more generators produced.
 //
 // avroc owns the project's output tree, so this is avroc's to detect: the
 // generators cannot see each other's directories, they are told not to try
@@ -138,12 +171,13 @@ func mergeOutputs(projectRoot string, outs []*generatorOutput) error {
 // destination says so. That is also why the report names the absolute path — it
 // is the one name both generators' output is described by.
 //
-// The report is a function of the plans and of nothing else. Every claim is
-// collected before anything is reported, the colliding paths are sorted, and the
+// The result is a function of the plans and of nothing else. Every claim is
+// collected before anything is decided, the colliding paths are sorted, and the
 // generators claiming each one are sorted by name, so two runs over unchanged
-// inputs produce the identical message however the generators were ordered in
-// the manifest and whichever of them finished first.
-func checkCollisions(outs []*generatorOutput) error {
+// inputs produce the identical report — and the identical events on the merge
+// span — however the generators were ordered in the manifest and whichever of
+// them finished first.
+func findCollisions(outs []*generatorOutput) []collision {
 	claimants := make(map[string][]string)
 	var collided []string
 	for _, out := range outs {
@@ -161,11 +195,27 @@ func checkCollisions(outs []*generatorOutput) error {
 	}
 
 	slices.Sort(collided)
-	reports := make([]string, 0, len(collided))
+	collisions := make([]collision, 0, len(collided))
 	for _, dst := range collided {
 		names := slices.Clone(claimants[dst])
 		slices.Sort(names)
-		reports = append(reports, fmt.Sprintf("%q is produced by generators %s", dst, quotedList(names)))
+		collisions = append(collisions, collision{path: dst, generators: names})
+	}
+	return collisions
+}
+
+// collisionError is what a run refused for a collision fails with: every
+// colliding path, in the order findCollisions fixed, naming every generator that
+// claimed it.
+//
+// The path it names is the absolute destination rather than either generator's
+// relative one, because two generators need not share an output directory: one
+// writing "pkg/user.avsc" under the project root and one writing "user.avsc"
+// under "pkg/" collide, and only the resolved destination says so.
+func collisionError(collisions []collision) error {
+	reports := make([]string, 0, len(collisions))
+	for _, c := range collisions {
+		reports = append(reports, fmt.Sprintf("%q is produced by generators %s", c.path, quotedList(c.generators)))
 	}
 	return fmt.Errorf("refusing to merge: %s", strings.Join(reports, "; "))
 }

--- a/internal/avroc/merge_test.go
+++ b/internal/avroc/merge_test.go
@@ -6,6 +6,7 @@
 package avroc
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -111,7 +112,7 @@ func TestMergeOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	merged, err := mergeOne(scratch, output)
+	merged, err := mergeOne(t.Context(), scratch, output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +163,7 @@ func TestMergeOutputReplacesAnExistingFile(t *testing.T) {
 	}
 	writeScratch(t, scratch, "user.go", "package avro // new\n")
 
-	if _, err := mergeOne(scratch, output); err != nil {
+	if _, err := mergeOne(t.Context(), scratch, output); err != nil {
 		t.Fatal(err)
 	}
 
@@ -238,7 +239,7 @@ func TestMergeOutputRefusesToEscape(t *testing.T) {
 func assertRefused(t *testing.T, output, scratch, name string) {
 	t.Helper()
 
-	merged, err := mergeOne(scratch, output)
+	merged, err := mergeOne(t.Context(), scratch, output)
 	if err == nil {
 		t.Fatalf("the merge accepted %q and merged %q", name, merged)
 	}
@@ -275,7 +276,7 @@ func TestMergeOutputCreatesNothingWhenItRefuses(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := mergeOne(scratch, output); err == nil {
+	if _, err := mergeOne(t.Context(), scratch, output); err == nil {
 		t.Fatal("the merge accepted a scratch directory holding a symbolic link")
 	}
 
@@ -289,10 +290,21 @@ func TestMergeOutputCreatesNothingWhenItRefuses(t *testing.T) {
 // TestCheckCollisions is the report #118 asks for: two generators producing one
 // file is an error naming both of them and the path, and it is the same error
 // whichever of them avroc heard from first.
-func TestCheckCollisions(t *testing.T) {
+func TestFindCollisions(t *testing.T) {
 	root := t.TempDir()
 	pkg := filepath.Join(root, "pkg")
-	collision := filepath.Join(pkg, "user.avsc")
+	collided := filepath.Join(pkg, "user.avsc")
+
+	// The two halves the merge uses together: what collided, and what the run is
+	// refused with. Asserting on the second is asserting on both, because the
+	// message is computed from nothing but the first.
+	checkCollisions := func(outs []*generatorOutput) error {
+		collisions := findCollisions(outs)
+		if len(collisions) == 0 {
+			return nil
+		}
+		return collisionError(collisions)
+	}
 
 	t.Run("two generators producing one file", func(t *testing.T) {
 		// A different relative path under a different output directory, resolving
@@ -300,17 +312,17 @@ func TestCheckCollisions(t *testing.T) {
 		// destination, and it is the one the example manifest is a single edit
 		// away from — json at "." and pcf at "pcf/", both emitting .avsc.
 		json := &generatorOutput{generator: "avroc-gen-json", output: root, files: []mergedFile{
-			{rel: "pkg/user.avsc", dst: collision},
+			{rel: "pkg/user.avsc", dst: collided},
 		}}
 		pcf := &generatorOutput{generator: "avroc-gen-pcf", output: pkg, files: []mergedFile{
-			{rel: "user.avsc", dst: collision},
+			{rel: "user.avsc", dst: collided},
 		}}
 
 		err := checkCollisions([]*generatorOutput{json, pcf})
 		if err == nil {
 			t.Fatal("checkCollisions accepted two generators producing the same file")
 		}
-		for _, want := range []string{"avroc-gen-json", "avroc-gen-pcf", collision} {
+		for _, want := range []string{"avroc-gen-json", "avroc-gen-pcf", collided} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("error %q does not name %q", err, want)
 			}
@@ -399,7 +411,7 @@ func TestMergeOutputsRefusesACollision(t *testing.T) {
 		"user.avsc": `{"produced_by":"pcf"}`,
 	})
 
-	err := mergeOutputs(output, []*generatorOutput{first, second})
+	err := mergeOutputs(t.Context(), output, []*generatorOutput{first, second})
 	if err == nil {
 		t.Fatal("the merge accepted two generators producing the same file")
 	}
@@ -510,7 +522,7 @@ func TestCopyIntoPlace(t *testing.T) {
 // resolved into a plan, and that plan merged. It is the pair of calls generateAll
 // makes with a single generator in the manifest, and it reports the files the
 // merge moved.
-func mergeOne(scratch, output string) ([]string, error) {
+func mergeOne(ctx context.Context, scratch, output string) ([]string, error) {
 	files, err := planMerge(scratch, output)
 	if err != nil {
 		return nil, err
@@ -521,7 +533,7 @@ func mergeOne(scratch, output string) ([]string, error) {
 		scratch:   scratch,
 		files:     files,
 	}
-	if err := mergeOutputs(output, []*generatorOutput{out}); err != nil {
+	if err := mergeOutputs(ctx, output, []*generatorOutput{out}); err != nil {
 		return nil, err
 	}
 	return relPaths(files), nil

--- a/internal/avroc/plugininfo.go
+++ b/internal/avroc/plugininfo.go
@@ -103,22 +103,44 @@ type pluginInfoJSON struct {
 //
 // Sequential, in task order, so that a manifest with two broken generators
 // reports the same one every time rather than whichever process lost the race.
-func checkGenerators(ctx context.Context, log *slog.Logger, tasks []genTask) error {
-	for _, task := range tasks {
-		info, err := queryPluginInfo(ctx, task.name, task.executablePath)
-		if err != nil {
-			return err
-		}
-		if err := checkPluginInfo(task.name, task.options, info); err != nil {
-			return err
-		}
+// The phase carries a span and so does each generator's handshake within it: the
+// phase is where the sequence is visible, and the child is where the generator
+// that was slow, or the generator that refused, is named.
+func checkGenerators(ctx context.Context, log *slog.Logger, tasks []genTask) (err error) {
+	ctx, span := startSpan(ctx, spanHandshake)
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
 
-		log.DebugContext(ctx, "generator declared its capabilities",
-			slog.String("generator", task.name),
-			slog.String("version", *info.Version),
-			slog.Int("ir_version", int(*info.IRVersion)),
-		)
+	for _, task := range tasks {
+		if err := checkGenerator(ctx, log, task); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+// checkGenerator is one generator's half of the handshake: it answers, and what
+// it answered is one avroc accepts.
+func checkGenerator(ctx context.Context, log *slog.Logger, task genTask) (err error) {
+	ctx, span := startSpan(ctx, spanGeneratorHandshake, generatorAttr(task.name))
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
+	info, err := queryPluginInfo(ctx, task.name, task.executablePath)
+	if err != nil {
+		return err
+	}
+	if err := checkPluginInfo(task.name, task.options, info); err != nil {
+		return err
+	}
+
+	log.DebugContext(ctx, "generator declared its capabilities",
+		slog.String("generator", task.name),
+		slog.String("version", *info.Version),
+		slog.Int("ir_version", int(*info.IRVersion)),
+	)
 	return nil
 }
 

--- a/internal/avroc/plugininfo_test.go
+++ b/internal/avroc/plugininfo_test.go
@@ -559,7 +559,7 @@ func TestRunGenerateStopsAtTheHandshake(t *testing.T) {
 		WorkingDir: workingDir,
 	}
 
-	if code := runGenerate(t.Context(), c); code != 1 {
+	if code := runGenerate(t.Context(), c, noopTracer()); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
 	if !strings.Contains(logs.String(), "IR version") {

--- a/internal/avroc/prune.go
+++ b/internal/avroc/prune.go
@@ -179,7 +179,12 @@ func marshalOutputRecord(files []string) ([]byte, error) {
 // regeneration that produced the same files leaves the committed record and its
 // mtime exactly as it found them, so nothing downstream rebuilds because avroc
 // ran.
-func writeOutputRecord(ctx context.Context, log *slog.Logger, projectRoot string, files []string) error {
+func writeOutputRecord(ctx context.Context, log *slog.Logger, projectRoot string, files []string) (err error) {
+	ctx, span := startSpan(ctx, spanRecord)
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
 	data, err := marshalOutputRecord(files)
 	if err != nil {
 		return fmt.Errorf("failed to render %s: %w", outputRecordFilename, err)
@@ -252,7 +257,12 @@ func producedFiles(projectRoot string, outs []*generatorOutput) ([]string, error
 // A path that is no longer a regular file is left alone and reported. A person
 // who replaced a generated file with a directory or a link has taken it over,
 // and avroc removing it would be avroc deleting something it did not write.
-func pruneStale(ctx context.Context, log *slog.Logger, projectRoot string, previous, produced []string) error {
+func pruneStale(ctx context.Context, log *slog.Logger, projectRoot string, previous, produced []string) (err error) {
+	ctx, span := startSpan(ctx, spanPrune)
+	defer func() {
+		endSpan(ctx, span, err)
+	}()
+
 	root, err := filepath.Abs(projectRoot)
 	if err != nil {
 		return err

--- a/internal/avroc/prune_test.go
+++ b/internal/avroc/prune_test.go
@@ -555,7 +555,7 @@ func TestRunGenerateRenamingARecordRemovesTheStaleFile(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(projectRoot, "schema.avdl"), []byte(recordIDL(record)), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if code := runGenerate(ctx, c); code != 0 {
+		if code := runGenerate(ctx, c, noopTracer()); code != 0 {
 			t.Fatalf("avroc generate over record %q exited %d", record, code)
 		}
 	}

--- a/internal/avroc/telemetry_test.go
+++ b/internal/avroc/telemetry_test.go
@@ -161,8 +161,13 @@ func TestAMisconfiguredExporterDoesNotFailTheRun(t *testing.T) {
 // traced run leaves behind is the tree an untraced one leaves behind, byte for
 // byte. Nothing in the generated output may reach for a trace id, a timestamp or
 // an endpoint.
+//
+// The collector is a decoding one rather than somewhere to discard an export,
+// because the comparison is only worth anything if the traced run was traced:
+// with the spans of #192 on it, a run that exported nothing would pass this test
+// while proving that tracing changes nothing about a run it never observed.
 func TestGeneratedBytesAreTheSameTracedOrNot(t *testing.T) {
-	endpoint := otlpEndpoint(t)
+	collector := newSpanCollector(t)
 
 	generate := func(t *testing.T, traced bool) map[string]string {
 		t.Helper()
@@ -183,7 +188,7 @@ func TestGeneratedBytesAreTheSameTracedOrNot(t *testing.T) {
 
 		env := map[string]string{"PATH": filepath.Dir(generatorPath)}
 		if traced {
-			env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+			env["OTEL_EXPORTER_OTLP_ENDPOINT"] = collector.endpoint()
 			env["OTEL_SERVICE_NAME"] = "avroc-under-test"
 		}
 
@@ -210,6 +215,9 @@ func TestGeneratedBytesAreTheSameTracedOrNot(t *testing.T) {
 
 	if len(untraced) == 0 {
 		t.Fatal("the untraced run generated nothing, so the comparison is vacuous")
+	}
+	if names := collector.spanNames(t); len(names) == 0 {
+		t.Fatal("the traced run exported no spans, so the comparison is vacuous")
 	}
 	if len(untraced) != len(traced) {
 		t.Fatalf("the traced run produced %d files and the untraced one %d", len(traced), len(untraced))

--- a/internal/avroc/trace.go
+++ b/internal/avroc/trace.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracerScope names the instrumentation a run's spans come from. It is this
+// package's import path, which is what the OpenTelemetry specification asks a
+// tracer name to be.
+const tracerScope = "github.com/z5labs/avroc/internal/avroc"
+
+// The phases of a run, one span name each.
+//
+// They are the boundaries that already existed as functions — loading the
+// manifest, parsing the IDL, resolving the IR, the handshake, each generator's
+// invocation, the merge, the prune and the record — and not a second
+// decomposition invented for the trace. A phase that is not one of these is a
+// phase avroc does not have.
+//
+// The per-generator spans are named for the work and carry the generator as an
+// attribute rather than in the name, so that a backend can aggregate "how long
+// does the handshake take" across every generator without parsing a string.
+const (
+	spanRun                = "avroc.generate"
+	spanManifestLoad       = "avroc.manifest.load"
+	spanIDLParse           = "avroc.idl.parse"
+	spanIRResolve          = "avroc.ir.resolve"
+	spanHandshake          = "avroc.handshake"
+	spanGeneratorHandshake = "avroc.generator.handshake"
+	spanGeneratorRun       = "avroc.generator.run"
+	spanMerge              = "avroc.merge"
+	spanPrune              = "avroc.prune"
+	spanRecord             = "avroc.record"
+)
+
+// The attributes those spans carry.
+//
+// Every one of them is spelled exactly as the log attribute that reports the
+// same fact, because they are two renderings of one run: a person reading a
+// trace beside avroc's own log should not have to learn that exit_code is called
+// something else in one of them. docs/plugin/SPEC.md's reading of a non-zero
+// status holds here too — the code is carried and nothing is concluded from its
+// value.
+const (
+	attrGenerator    = "generator"
+	attrGenerators   = "generators"
+	attrInput        = "input"
+	attrPath         = "path"
+	attrExitCode     = "exit_code"
+	attrSignal       = "signal"
+	attrSignalNumber = "signal_number"
+)
+
+// eventCollision is the event a merge records when two generators produced the
+// same destination (#118). It is an event on the merge span rather than an
+// attribute of any generator's, because a collision is a function of the whole
+// set of plans and of no single generator's output.
+const eventCollision = "collision"
+
+// statusCancelled is the description on the span of a phase that did not finish
+// because the run was cancelled. It is told apart from a phase that failed on
+// its own account, because a run somebody interrupted is not a run that went
+// wrong.
+const statusCancelled = "cancelled"
+
+// startSpan starts a child of the span ctx already carries.
+//
+// The tracer comes from that span's own provider rather than from
+// otel.GetTracerProvider: internal/telemetry hands Main a provider, Main starts
+// the run's root span from it, and every phase beneath inherits the provider the
+// run was actually configured with. A phase reached without a root span above it
+// — a unit test calling one directly — gets the no-op tracer instead of whatever
+// the process global happens to be holding, which is the same reason
+// internal/telemetry reads its environment through cli.Context and never
+// through os: a configuration half injected and half ambient is one no test can
+// describe.
+//
+// It is also why nothing below Main grew a [trace.Tracer] parameter. The provider
+// is already in the context, threaded by the spans themselves.
+func startSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return trace.SpanFromContext(ctx).TracerProvider().Tracer(tracerScope).Start(ctx, name, opts...)
+}
+
+// endSpan ends span, recording err on it if there was one.
+//
+// It is the one place a status is set, and every phase ends its span through it.
+// A phase that classified its own failure — [generator.reportFailure] is the one
+// that does — contributes attributes and leaves the status here, so that a
+// generator killed because the run was cancelled is marked cancelled rather than
+// described twice in two vocabularies.
+func endSpan(ctx context.Context, span trace.Span, err error) {
+	defer span.End()
+
+	if err == nil {
+		return
+	}
+
+	span.RecordError(err)
+	if cancelled(ctx, err) {
+		span.SetStatus(codes.Error, statusCancelled)
+		return
+	}
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// cancelled reports whether err is the run having been interrupted rather than
+// anything about the work.
+//
+// The context is consulted as well as the error because the two are not the same
+// sentence: a generator killed by the signal exec.CommandContext sends on
+// cancellation reports itself as terminated by SIGKILL, and only the context says
+// who sent it.
+func cancelled(ctx context.Context, err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+}
+
+// generatorAttr names the generator a span is about, as docs/plugin/SPEC.md
+// names it: the executable, avroc-gen-<name>.
+func generatorAttr(name string) trace.SpanStartEventOption {
+	return trace.WithAttributes(attribute.String(attrGenerator, name))
+}

--- a/internal/avroc/trace_test.go
+++ b/internal/avroc/trace_test.go
@@ -1,0 +1,743 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+// noopTracer is what a test that is not about tracing hands runGenerate: the
+// same thing an untraced run gets, which is the point — every test in this
+// package other than these ones exercises the code path a laptop with no
+// collector near it takes.
+func noopTracer() oteltrace.Tracer {
+	return noop.NewTracerProvider().Tracer(tracerScope)
+}
+
+// recordingTracer is a real SDK tracer whose spans a test reads back once they
+// have ended.
+//
+// The SDK rather than a fake, because the thing being asserted on is what a
+// collector would receive: the parentage, the attributes, the events and the
+// status are all things the SDK computes, and a fake tracer would assert that
+// the code called itself.
+func recordingTracer() (oteltrace.Tracer, *tracetest.SpanRecorder) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	return provider.Tracer(tracerScope), recorder
+}
+
+// rootedContext is a context carrying a run's root span, which is what a phase
+// called on its own would otherwise be without.
+//
+// startSpan takes its provider from the span already in the context, so a phase
+// reached with no root span above it traces into a no-op — deliberately, and
+// that is what every other test in this package relies on. A test about the
+// spans has to supply the root the command would have started.
+func rootedContext(t *testing.T) (context.Context, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	tracer, recorder := recordingTracer()
+	ctx, span := tracer.Start(t.Context(), spanRun)
+	t.Cleanup(func() { span.End() })
+	return ctx, recorder
+}
+
+// spansNamed is every recorded span of that name.
+func spansNamed(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var found []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			found = append(found, s)
+		}
+	}
+	return found
+}
+
+// onlySpanNamed is the one recorded span of that name, and fails when a run
+// produced none or several.
+func onlySpanNamed(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	found := spansNamed(spans, name)
+	if len(found) != 1 {
+		t.Fatalf("the run produced %d %q spans, want 1: %v", len(found), name, recordedNames(spans))
+	}
+	return found[0]
+}
+
+// recordedNames is every span a run ended, for a failure message that shows
+// what was there instead.
+func recordedNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, s := range spans {
+		names = append(names, s.Name())
+	}
+	return names
+}
+
+// parentName names the span that started this one, so a failure reads like the
+// tree it is about rather than like two span ids.
+func parentName(spans []sdktrace.ReadOnlySpan, span sdktrace.ReadOnlySpan) string {
+	for _, s := range spans {
+		if s.SpanContext().SpanID() == span.Parent().SpanID() {
+			return s.Name()
+		}
+	}
+	return "(nothing recorded)"
+}
+
+// attrOf reads one attribute off a span.
+func attrOf(span sdktrace.ReadOnlySpan, key string) (attribute.Value, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// stringAttr is attrOf for the usual case, reported rather than returned.
+func stringAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) string {
+	t.Helper()
+
+	value, ok := attrOf(span, key)
+	if !ok {
+		t.Fatalf("span %q carries no %q attribute: %v", span.Name(), key, span.Attributes())
+	}
+	return value.AsString()
+}
+
+// tracedProject is a project a generator produces one file from: the manifest,
+// the schema, and a conforming plugin on PATH.
+func tracedProject(t *testing.T, env map[string]string, args ...string) (cli.Context, string) {
+	t.Helper()
+
+	projectRoot := t.TempDir()
+	generatorPath := nameFromDescriptorGenerator(t)
+
+	if err := os.WriteFile(filepath.Join(projectRoot, manifestFilename), []byte(`{
+  "inputs": ["schema.avdl"],
+  "generators": [{"name": "test", "out": "gen"}]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "schema.avdl"), []byte(recordIDL("User")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if env == nil {
+		env = make(map[string]string)
+	}
+	env["PATH"] = filepath.Dir(generatorPath)
+
+	return cli.Context{
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			value, ok := env[key]
+			return value, ok
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: projectRoot,
+		Args:       args,
+	}, projectRoot
+}
+
+// TestEveryPhaseOfARunIsASpan is the story's first requirement: a run is a
+// trace, and the phases it is made of are the ones that already exist as
+// functions — nothing invented for the trace, and nothing left out of it.
+//
+// The parentage is asserted as well as the names, because a flat list of spans
+// with the right names is not a trace: it is what you get when a phase starts
+// its span from the wrong context, and a backend renders it as eight unrelated
+// operations.
+func TestEveryPhaseOfARunIsASpan(t *testing.T) {
+	tracer, recorder := recordingTracer()
+	c, _ := tracedProject(t, nil, "generate")
+
+	if code := runGenerate(t.Context(), c, tracer); code != 0 {
+		t.Fatalf("avroc generate exited %d", code)
+	}
+
+	spans := recorder.Ended()
+	root := onlySpanNamed(t, spans, spanRun)
+
+	// Every phase the story names, once, directly under the run.
+	for _, name := range []string{
+		spanManifestLoad,
+		spanIDLParse,
+		spanIRResolve,
+		spanHandshake,
+		spanGeneratorRun,
+		spanMerge,
+		spanPrune,
+		spanRecord,
+	} {
+		if got := parentName(spans, onlySpanNamed(t, spans, name)); got != spanRun {
+			t.Errorf("span %q hangs off %q, want %q", name, got, spanRun)
+		}
+	}
+
+	// The one that is a phase within a phase: the handshake is sequential over
+	// the generators, and each generator's is inside it.
+	if got := parentName(spans, onlySpanNamed(t, spans, spanGeneratorHandshake)); got != spanHandshake {
+		t.Errorf("span %q hangs off %q, want %q", spanGeneratorHandshake, got, spanHandshake)
+	}
+
+	// One run is one trace, and a run that worked says so.
+	for _, s := range spans {
+		if s.SpanContext().TraceID() != root.SpanContext().TraceID() {
+			t.Errorf("span %q is in a different trace from the run", s.Name())
+		}
+		if s.Status().Code == codes.Error {
+			t.Errorf("span %q is marked failed on a run that succeeded: %q", s.Name(), s.Status().Description)
+		}
+	}
+}
+
+// TestTheHandshakeAndTheInvocationNameTheirGenerator: the two things avroc does
+// per generator are separately visible, and each says which generator it was.
+//
+// The generator is an attribute rather than part of the span name so that "how
+// long does the handshake take" is a question a backend can answer across every
+// generator without parsing a string.
+func TestTheHandshakeAndTheInvocationNameTheirGenerator(t *testing.T) {
+	tracer, recorder := recordingTracer()
+	c, _ := tracedProject(t, nil, "generate")
+
+	if code := runGenerate(t.Context(), c, tracer); code != 0 {
+		t.Fatalf("avroc generate exited %d", code)
+	}
+
+	spans := recorder.Ended()
+	for _, name := range []string{spanGeneratorHandshake, spanGeneratorRun} {
+		span := onlySpanNamed(t, spans, name)
+		if got, want := stringAttr(t, span, attrGenerator), "avroc-gen-test"; got != want {
+			t.Errorf("span %q names generator %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestAFailedGeneratorIsClassifiedOnItsSpan is docs/plugin/SPEC.md's three
+// failures on the invocation's span, and it is the same classification
+// reportFailure already made for the log rather than a fourth description of the
+// distinction.
+//
+// Nothing is concluded from the value of a non-zero code: it is carried, and
+// that is all.
+func TestAFailedGeneratorIsClassifiedOnItsSpan(t *testing.T) {
+	t.Run("a generator that exited non-zero carries its exit code", func(t *testing.T) {
+		ctx, recorder := rootedContext(t)
+		g := testGenerator(t, writeShellGenerator(t, "exit 3\n"))
+
+		projectRoot, output := newProject(t)
+		if err := generateOne(ctx, g, projectRoot, output, nil, testSchema("User")); err == nil {
+			t.Fatal("generate accepted a generator that exited non-zero")
+		}
+
+		span := onlySpanNamed(t, recorder.Ended(), spanGeneratorRun)
+		if span.Status().Code != codes.Error {
+			t.Errorf("span status = %v, want %v", span.Status().Code, codes.Error)
+		}
+		code, ok := attrOf(span, attrExitCode)
+		if !ok {
+			t.Fatalf("the span carries no %q: %v", attrExitCode, span.Attributes())
+		}
+		if code.AsInt64() != 3 {
+			t.Errorf("%s = %d, want 3", attrExitCode, code.AsInt64())
+		}
+		if _, ok := attrOf(span, attrSignal); ok {
+			t.Error("a generator that exited was described as one that was signalled")
+		}
+	})
+
+	t.Run("a generator terminated by a signal carries the signal", func(t *testing.T) {
+		ctx, recorder := rootedContext(t)
+		g := testGenerator(t, writeShellGenerator(t, "kill -TERM $$\n"))
+
+		projectRoot, output := newProject(t)
+		if err := generateOne(ctx, g, projectRoot, output, nil, testSchema("User")); err == nil {
+			t.Fatal("generate accepted a generator killed by a signal")
+		}
+
+		span := onlySpanNamed(t, recorder.Ended(), spanGeneratorRun)
+		if span.Status().Code != codes.Error {
+			t.Errorf("span status = %v, want %v", span.Status().Code, codes.Error)
+		}
+		if got, want := stringAttr(t, span, attrSignal), syscall.SIGTERM.String(); got != want {
+			t.Errorf("%s = %q, want %q", attrSignal, got, want)
+		}
+		number, ok := attrOf(span, attrSignalNumber)
+		if !ok {
+			t.Fatalf("the span carries no %q: %v", attrSignalNumber, span.Attributes())
+		}
+		if number.AsInt64() != int64(syscall.SIGTERM) {
+			t.Errorf("%s = %d, want %d", attrSignalNumber, number.AsInt64(), int64(syscall.SIGTERM))
+		}
+		if _, ok := attrOf(span, attrExitCode); ok {
+			t.Error("a generator killed by a signal was described with an exit code")
+		}
+	})
+
+	t.Run("a generator that never ran carries neither", func(t *testing.T) {
+		ctx, recorder := rootedContext(t)
+		executablePath := writeShellGenerator(t, "exit 0\n")
+		if err := os.Chmod(executablePath, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		g := testGenerator(t, executablePath)
+
+		projectRoot, output := newProject(t)
+		if err := generateOne(ctx, g, projectRoot, output, nil, testSchema("User")); err == nil {
+			t.Fatal("generate accepted a generator that never ran")
+		}
+
+		span := onlySpanNamed(t, recorder.Ended(), spanGeneratorRun)
+		if span.Status().Code != codes.Error {
+			t.Errorf("span status = %v, want %v", span.Status().Code, codes.Error)
+		}
+		for _, key := range []string{attrExitCode, attrSignal, attrSignalNumber} {
+			if _, ok := attrOf(span, key); ok {
+				t.Errorf("a generator that never ran was described with %q: there was no process to produce one", key)
+			}
+		}
+	})
+}
+
+// TestACollisionIsAnEventOnTheMergeSpan: two generators producing one path is a
+// fact about the whole set of plans, so it is recorded where the whole set is
+// decided rather than on either generator's span.
+//
+// The events and the refusal are two renderings of one value, and this is what
+// requires them not to disagree: the same paths, in the same order, each naming
+// the same generators.
+func TestACollisionIsAnEventOnTheMergeSpan(t *testing.T) {
+	ctx, recorder := rootedContext(t)
+	output := t.TempDir()
+
+	json := scratchPlan(t, output, "avroc-gen-json", map[string]string{
+		"order.avsc": `{"produced_by":"json"}`,
+		"user.avsc":  `{"produced_by":"json"}`,
+	})
+	pcf := scratchPlan(t, output, "avroc-gen-pcf", map[string]string{
+		"order.avsc": `{"produced_by":"pcf"}`,
+		"user.avsc":  `{"produced_by":"pcf"}`,
+	})
+
+	err := mergeOutputs(ctx, output, []*generatorOutput{json, pcf})
+	if err == nil {
+		t.Fatal("the merge accepted two generators producing the same files")
+	}
+
+	span := onlySpanNamed(t, recorder.Ended(), spanMerge)
+	if span.Status().Code != codes.Error {
+		t.Errorf("the merge span is not marked failed: %v", span.Status())
+	}
+
+	var paths []string
+	for _, event := range span.Events() {
+		if event.Name != eventCollision {
+			continue
+		}
+
+		var path string
+		var claimants []string
+		for _, kv := range event.Attributes {
+			switch string(kv.Key) {
+			case attrPath:
+				path = kv.Value.AsString()
+			case attrGenerators:
+				claimants = kv.Value.AsStringSlice()
+			}
+		}
+		paths = append(paths, path)
+
+		if want := []string{"avroc-gen-json", "avroc-gen-pcf"}; !slices.Equal(claimants, want) {
+			t.Errorf("the event for %q names %q, want %q", path, claimants, want)
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("the event names %q, which the refusal does not: %v", path, err)
+		}
+	}
+
+	// Sorted by path, and the same order the refusal reports: one value renders
+	// both, so a trace read beside the message a user was given agrees with it.
+	want := []string{filepath.Join(output, "order.avsc"), filepath.Join(output, "user.avsc")}
+	if !slices.Equal(paths, want) {
+		t.Errorf("the merge span records %q, want %q", paths, want)
+	}
+	if strings.Index(err.Error(), want[0]) > strings.Index(err.Error(), want[1]) {
+		t.Errorf("the refusal reports the collisions in a different order from the span: %v", err)
+	}
+}
+
+// TestACancelledRunKeepsTheSpansItGotThrough is the trace of the run somebody
+// pressed Ctrl-C on, which is the run whose trace is most worth having and the
+// one whose context is already cancelled by the time anything is written.
+//
+// Three things are required of it. The phases that finished are in it, so the
+// question "where had it got to" has an answer at all; the phase that did not
+// finish is marked cancelled rather than broken, because a generator killed by
+// the kill exec.CommandContext sends is not a generator that went wrong; and the
+// phases the run never reached are not in it, invented from work that did not
+// happen.
+func TestACancelledRunKeepsTheSpansItGotThrough(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	projectRoot := t.TempDir()
+	started := filepath.Join(t.TempDir(), "started")
+
+	// It answers the handshake at once and then blocks, so every phase before the
+	// invocation completes and the invocation is the one the cancellation lands
+	// on. exec, so that the process the cancellation kills is the one that sleeps:
+	// a shell that forked it would leave it orphaned holding the inherited
+	// streams.
+	generatorPath := writeNamedShellGenerator(t, "slow", fmt.Sprintf(`if [ "$1" = "--plugin-info" ]; then
+  printf '{"name":"slow","version":"9.9.9","ir_version":%d,"options":[]}\n'
+  exit 0
+fi
+: > '%s'
+exec sleep 300
+`, ir.Version, started))
+
+	if err := os.WriteFile(filepath.Join(projectRoot, manifestFilename), []byte(`{
+  "inputs": ["schema.avdl"],
+  "generators": [{"name": "slow", "out": "gen"}]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "schema.avdl"), []byte(recordIDL("User")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := cli.Context{
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			if key == "PATH" {
+				return filepath.Dir(generatorPath), true
+			}
+			return "", false
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: projectRoot,
+		Args:       []string{"generate"},
+	}
+
+	tracer, recorder := recordingTracer()
+	done := make(chan int, 1)
+	go func() {
+		done <- runGenerate(ctx, c, tracer)
+	}()
+
+	// Cancelled only once the child is definitely running, so this is about a
+	// cancellation reaching a live process rather than a context that was already
+	// done before the fork.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the generator never started")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	select {
+	case code := <-done:
+		if code == 0 {
+			t.Fatal("a cancelled run reported success")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the run did not return after its context was cancelled")
+	}
+
+	spans := recorder.Ended()
+
+	// Everything it got through is in the trace, and none of it is described as
+	// having failed: they did not.
+	for _, name := range []string{spanManifestLoad, spanIDLParse, spanIRResolve, spanHandshake, spanGeneratorHandshake} {
+		span := onlySpanNamed(t, spans, name)
+		if span.Status().Code == codes.Error {
+			t.Errorf("phase %q completed before the cancellation but is marked failed: %v", name, span.Status())
+		}
+	}
+
+	// The one it was in the middle of, and the run itself.
+	for _, name := range []string{spanGeneratorRun, spanRun} {
+		span := onlySpanNamed(t, spans, name)
+		if span.Status().Code != codes.Error {
+			t.Errorf("span %q is not marked failed on a cancelled run: %v", name, span.Status())
+		}
+		if got := span.Status().Description; got != statusCancelled {
+			t.Errorf("span %q is described as %q, want %q", name, got, statusCancelled)
+		}
+	}
+
+	// And the phases it never reached are not in it.
+	for _, name := range []string{spanMerge, spanPrune, spanRecord} {
+		if len(spansNamed(spans, name)) != 0 {
+			t.Errorf("the cancelled run recorded a %q span for a phase it never reached", name)
+		}
+	}
+}
+
+// TestInstrumentationDidNotChangeTheIteration is the story's other half: the
+// merge, the record and the collision report are the manifest's order, and a
+// span per generator must not become the reason any of them follows the order
+// the generators finished in.
+//
+// The generators finish in the reverse of the manifest's order, so an
+// implementation that iterated over completions rather than over tasks would
+// produce the reverse of every assertion here — and unlike the same check on an
+// untraced run, this one is running the instrumentation while it does it.
+func TestInstrumentationDidNotChangeTheIteration(t *testing.T) {
+	ctx, recorder := rootedContext(t)
+
+	names := []string{"a", "b", "c", "d"}
+	pauses := []string{"0.4", "0.3", "0.2", "0.1"}
+
+	log, records := recordingLogger()
+	projectRoot, output := newProject(t)
+	events := filepath.Join(t.TempDir(), "trace")
+
+	tasks := make([]genTask, 0, len(names))
+	for i, name := range names {
+		tasks = append(tasks, tracedTask(t, name, output, events, pauses[i]))
+	}
+	if err := generateAll(ctx, log, projectRoot, tasks); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: they really did finish in some order other than the manifest's,
+	// so nothing below is vacuously true of a run in which the two coincided.
+	want := []string{"avroc-gen-a", "avroc-gen-b", "avroc-gen-c", "avroc-gen-d"}
+	var finished []string
+	for _, e := range readTrace(t, events) {
+		if e.event == "end" {
+			finished = append(finished, e.generator)
+		}
+	}
+	if slices.Equal(finished, want) {
+		t.Skipf("the generators finished in the manifest's order %q, so this run proves nothing", finished)
+	}
+
+	if got := generatorsReported(records()); !slices.Equal(got, want) {
+		t.Errorf("the run reported %q, want the manifest's %q", got, want)
+	}
+
+	// The record is the manifest's too, and every generator is in it.
+	record := readRecord(t, projectRoot)
+	for _, name := range names {
+		if !strings.Contains(record, name+".txt") {
+			t.Errorf("the record does not name %q:\n%s", name+".txt", record)
+		}
+	}
+
+	// And every generator got a span, whichever order they finished in.
+	invocations := spansNamed(recorder.Ended(), spanGeneratorRun)
+	if len(invocations) != len(names) {
+		t.Fatalf("the run recorded %d invocation spans, want %d", len(invocations), len(names))
+	}
+	var traced []string
+	for _, span := range invocations {
+		traced = append(traced, stringAttr(t, span, attrGenerator))
+	}
+	slices.Sort(traced)
+	if !slices.Equal(traced, want) {
+		t.Errorf("the invocation spans name %q, want %q", traced, want)
+	}
+}
+
+// TestOnlyGenerateIsTraced is the last of the story's requirements, and it is
+// asserted through Main over a real exporter rather than through a tracer a test
+// injected: the question is what a collector receives from each of avroc's
+// commands, and only the command deciding whether to trace at all can answer it.
+//
+// A run is worth a trace — it forks processes, walks a project tree and takes
+// seconds. init writes the one file it was asked for and inspect renders the one
+// it was handed, and a span apiece would be an export, a connection and a flush
+// bought for nothing.
+func TestOnlyGenerateIsTraced(t *testing.T) {
+	t.Run("generate exports the run", func(t *testing.T) {
+		collector := newSpanCollector(t)
+		c, _ := tracedProject(t, map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": collector.endpoint()}, "generate")
+
+		if code := Main(t.Context(), c); code != 0 {
+			t.Fatalf("avroc generate exited %d", code)
+		}
+
+		names := collector.spanNames(t)
+		if !slices.Contains(names, spanRun) {
+			t.Errorf("the collector received %q, which does not include the run itself", names)
+		}
+	})
+
+	t.Run("init exports nothing", func(t *testing.T) {
+		collector := newSpanCollector(t)
+		c := commandContext(t, collector, t.TempDir(), "init")
+
+		if code := Main(t.Context(), c); code != 0 {
+			t.Fatalf("avroc init exited %d", code)
+		}
+
+		if names := collector.spanNames(t); len(names) != 0 {
+			t.Errorf("avroc init exported %q", names)
+		}
+	})
+
+	t.Run("inspect exports nothing", func(t *testing.T) {
+		descriptor, _ := writeInspectFixture(t)
+
+		collector := newSpanCollector(t)
+		c := commandContext(t, collector, t.TempDir(), "inspect", descriptor)
+
+		if code := Main(t.Context(), c); code != 0 {
+			t.Fatalf("avroc inspect exited %d", code)
+		}
+
+		if names := collector.spanNames(t); len(names) != 0 {
+			t.Errorf("avroc inspect exported %q", names)
+		}
+	})
+}
+
+// commandContext is one avroc command with tracing configured and nothing else
+// in its environment.
+func commandContext(t *testing.T, collector *spanCollector, workingDir string, args ...string) cli.Context {
+	t.Helper()
+
+	env := map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": collector.endpoint()}
+
+	return cli.Context{
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			value, ok := env[key]
+			return value, ok
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: workingDir,
+		Args:       args,
+	}
+}
+
+// resourceSpansField is ExportTraceServiceRequest's one field, which is as much
+// of that message as anything here needs to know.
+//
+// The envelope is peeled by hand rather than by importing the collector's
+// generated Go package, for the reason internal/telemetry writes the exporter
+// itself: that package carries the OTLP gRPC service with it, and a test that
+// pulled grpc-go into the module graph would be a test that broke
+// TestTheTracingStackCarriesNoGRPCTransport.
+const resourceSpansField = 1
+
+// spanCollector is an OTLP/HTTP receiver a whole command can be pointed at.
+type spanCollector struct {
+	server *httptest.Server
+
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func newSpanCollector(t *testing.T) *spanCollector {
+	t.Helper()
+
+	c := &spanCollector{}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		c.mu.Lock()
+		c.bodies = append(c.bodies, body)
+		c.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.server.Close)
+
+	return c
+}
+
+// endpoint is what OTEL_EXPORTER_OTLP_ENDPOINT is set to: the base URL, with no
+// signal path on it.
+func (c *spanCollector) endpoint() string {
+	return c.server.URL
+}
+
+// spanNames is every span the collector was sent, in the order it received them.
+func (c *spanCollector) spanNames(t *testing.T) []string {
+	t.Helper()
+
+	c.mu.Lock()
+	bodies := append([][]byte(nil), c.bodies...)
+	c.mu.Unlock()
+
+	var names []string
+	for _, body := range bodies {
+		for len(body) > 0 {
+			number, typ, read := protowire.ConsumeTag(body)
+			if read < 0 {
+				t.Fatalf("export body is not protobuf: %v", protowire.ParseError(read))
+			}
+			body = body[read:]
+			if number != resourceSpansField || typ != protowire.BytesType {
+				t.Fatalf("export body carries field %d of type %d, want field %d of type %d",
+					number, typ, resourceSpansField, protowire.BytesType)
+			}
+
+			encoded, read := protowire.ConsumeBytes(body)
+			if read < 0 {
+				t.Fatalf("export body is not protobuf: %v", protowire.ParseError(read))
+			}
+			body = body[read:]
+
+			var rs tracepb.ResourceSpans
+			if err := proto.Unmarshal(encoded, &rs); err != nil {
+				t.Fatalf("export body does not hold a ResourceSpans: %v", err)
+			}
+			for _, ss := range rs.GetScopeSpans() {
+				for _, span := range ss.GetSpans() {
+					names = append(names, span.GetName())
+				}
+			}
+		}
+	}
+	return names
+}


### PR DESCRIPTION
Closes #192

`avroc generate` is now a trace. With #191's provider in place, the phases that already existed as functions each get a span, so "why does regeneration take eleven seconds" has an answer that is not an exit status and one log line per generator.

```
avroc.generate
├── avroc.manifest.load
├── avroc.idl.parse            (per declared input, named as avroc.json wrote it)
├── avroc.ir.resolve           (per declared input; validation is inside it)
├── avroc.handshake
│   └── avroc.generator.handshake   generator=avroc-gen-…
├── avroc.generator.run             generator=avroc-gen-…
├── avroc.merge
├── avroc.prune
└── avroc.record
```

## Judgment calls

- **The provider travels in the context, not in a parameter and not in a global.** `startSpan` takes the tracer from `trace.SpanFromContext(ctx).TracerProvider()`. `Main` hands the injected tracer to `runGenerate`, which starts the root span, and every phase below inherits the provider the run was actually configured with. A phase reached with no root span above it — a unit test calling one directly — gets the no-op tracer rather than whatever `otel.GetTracerProvider` happens to hold, which is the same reasoning that has `internal/telemetry` read its environment through `cli.Context` and never through `os`. It is also why nothing below `Main` grew a `trace.Tracer` argument to thread through untouched.
- **`endSpan` is the only place a status is set.** `reportFailure` contributes the classification it had already made for the log as *attributes*, spelled exactly as the log spells them (`exit_code`; `signal` and `signal_number`; neither, for a generator that never ran), and leaves the status to the one place a span ends. That is what lets a generator killed by the kill `exec.CommandContext` sends be marked `cancelled` rather than described twice in two vocabularies.
- **A collision is an event on the merge span**, not on either generator's: it is a fact about the whole set of plans. `checkCollisions` became `findCollisions` (a `[]collision` value) plus `collisionError`, so the events and the refusal are one value rendered twice and cannot disagree about which paths collided or in what order.
- **The per-generator spans carry the generator as an attribute rather than in the name**, so "how long does the handshake take" is a question a backend can answer across generators without parsing a string.
- **`init` and `inspect` are untraced by construction**, not by omission: they are never handed a tracer.
- **PATH discovery is deliberately not a phase.** The story enumerates the boundaries worth measuring and it is not among them; the decomposition here is the one the code already had.

## Acceptance criteria

- [x] One root span per run with a child per phase — `TestEveryPhaseOfARunIsASpan` asserts the names *and* the parentage, because a flat list of correctly-named spans is what you get when a phase starts from the wrong context.
- [x] The handshake and the invocation are separately visible per generator, each naming it — `TestTheHandshakeAndTheInvocationNameTheirGenerator`.
- [x] `reportFailure`'s three cases set an error status and carry `exit_code`, or `signal` and `signal_number`, or neither — `TestAFailedGeneratorIsClassifiedOnItsSpan`, one subtest each, including that neither case is described in the other's vocabulary.
- [x] A collision is an event on the merge span naming every path and every claimant, in the order the failure reports — `TestACollisionIsAnEventOnTheMergeSpan` compares the events against the refusal's own text.
- [x] A cancelled run keeps the phases that completed and marks the cancelled one — `TestACancelledRunKeepsTheSpansItGotThrough` runs the whole command against a generator that answers the handshake and then blocks: the five phases before it completed and are unmarked, the invocation and the root are `cancelled`, and merge/prune/record are absent.
- [x] Merge order, the recorded file set and the collision report remain the manifest's — `TestInstrumentationDidNotChangeTheIteration` runs four generators finishing in the reverse of the manifest's order **with the spans recording**, and skips itself if that premise did not hold.
- [x] `init` and `inspect` unaffected — `TestOnlyGenerateIsTraced` goes through `Main` over a real OTLP endpoint and reads what a collector received, because only the command deciding whether to trace can answer that. The envelope is peeled with `protowire` rather than by importing the collector's generated package, which would pull grpc-go into the module graph and break `TestTheTracingStackCarriesNoGRPCTransport`.
- [x] `example/` regenerates byte-identically traced or not — `TestGeneratedBytesAreTheSameTracedOrNot` now uses a *decoding* collector and fails if the traced run exported nothing, so it cannot pass by proving that tracing changes nothing about a run it never observed. Checked by hand too: `avroc generate` over `example/` with `OTEL_EXPORTER_OTLP_ENDPOINT` set leaves the committed tree byte for byte.

## Verification

`go build ./...`, `gofmt -l .`, `go vet ./...`, `go test -race -cover ./...`, `golangci-lint run`, and the `example/` round trip — all clean. `internal/avroc` coverage 88.2% → 88.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)