### PR TITLE
story(avroc): avroc sets TRACEPARENT on every generator process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,10 +246,42 @@ Four things there are decisions.
   `TestInstrumentationDidNotChangeTheIteration` runs generators that finish in the
   reverse of the manifest's order with the spans recording.
 
+**The trace crosses the fork** (#193, `internal/avroc/propagate.go`). A generator
+is a separate process, so a span it opens has no parent unless avroc hands it
+one; `generatorEnv` is the whole of that, and `cmd.Env` on both the generation
+invocation and the `--plugin-info` handshake is where it is used. The carrier is
+`TRACEPARENT` and `TRACESTATE` — a convention rather than a ratified part of any
+specification, and nonetheless the one `otel-cli`, Dagger, Buildkite and the
+Jenkins plugin converged on, which is why avroc under `dagger call` already has a
+parent. `docs/plugin/SPEC.md`'s "Trace context" is normative.
+
+Four things there are decisions. It **overwrites**: a `TRACEPARENT` avroc
+inherited from CI is avroc's *own* parent, and the child gets the per-invocation
+span context instead of accompanying it. The **handshake is propagated to on the
+same terms**, because it runs a whole process and is the first thing in a run
+that can hang. **Off means actively unset**: with no span context to write,
+passing an inherited value through would parent a generator's spans to a trace
+avroc is not part of, so both variables are removed — which falls out of one code
+path, since the propagator injects nothing for an invalid span context and the
+strip already happened. And **`OTEL_SERVICE_NAME` is not overridden**, so a
+generator's identity is the user's choice or the SDK's default and never
+avroc's; every other SDK *configuration* variable reaches the child for the
+reason it always did, that avroc passes its environment through.
+
+Setting `cmd.Env` at all is the hazard the tests are aimed at — a nil `Env` means
+`os.Environ()`, so building one is how the rest of the environment gets silently
+dropped. `TestAGeneratorStillGetsEverythingElseFromAvrocsEnvironment` asserts an
+unrelated variable and `SOURCE_DATE_EPOCH` through a real child process, and
+`TestATracedRunPropagatesToEveryGeneratorProcess` reads what the child was
+actually handed — a shell generator writing its own environment down — rather
+than what avroc put in `cmd.Env`, which would pass with no process ever run.
+
 Tracing is an observation of a run and never an input to it:
 `TestGeneratedBytesAreTheSameTracedOrNot` requires a traced run and an untraced
 one to leave the same tree behind, byte for byte — with a decoding collector on
-the traced side, so a run that exported nothing cannot pass it.
+the traced side, so a run that exported nothing cannot pass it — and
+`TestGeneratedBytesAreTheSameWithATraceparentOrWithout` is the same requirement
+against the variables themselves.
 
 ### Determinism
 

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -255,13 +255,46 @@ convenient place to put it, and it costs a plugin one branch.
 ### The environment
 
 avroc passes its own environment through to a generator unchanged, except as
-[Determinism](#determinism) requires of `SOURCE_DATE_EPOCH`.
+[Determinism](#determinism) requires of `SOURCE_DATE_EPOCH` and as
+[Trace context](#trace-context) requires of `TRACEPARENT` and `TRACESTATE`.
 
 A plugin **MUST NOT** require an environment variable to be set in order to do
 its normal work; everything that configures its output arrives as `--opt`. The
 manifest is the reviewable record of how a project's code was generated, and a
 setting that lives in the environment is absent from it — the two developers
 comparing generated output cannot see the difference between their machines.
+
+#### Trace context
+
+avroc sets `TRACEPARENT`, and `TRACESTATE` where there is one, on every process
+it runs — a generation invocation and a `--plugin-info` handshake alike. Their
+values are the [W3C Trace Context] header values of the span avroc opened for
+*that* invocation, so a plugin that starts its own spans with them as the parent
+produces a trace nested under the run that asked for the work. The names are the
+header names upper-cased, which is a convention rather than a ratified part of
+any specification, and is nonetheless what `otel-cli`, Dagger, Buildkite and the
+Jenkins OpenTelemetry plugin already agree on.
+
+Three consequences a plugin author should expect:
+
+- A plugin **MAY** ignore both variables entirely, and one that does behaves
+  exactly as it did before they existed. Reading them is how a plugin joins the
+  run's trace, not how it is configured.
+- The value is **per-invocation**, so it is neither the value avroc was started
+  with nor the same for two invocations of one run. A `TRACEPARENT` avroc
+  inherited is avroc's own parent and is replaced rather than passed on.
+- When avroc is not tracing, **neither variable is present** — including when
+  avroc's own environment carried one. A plugin therefore never sees trace
+  context belonging to a trace avroc is not part of.
+
+Everything else an OpenTelemetry SDK reads from the environment — the endpoint,
+the protocol, the headers, the sampler, the resource attributes — reaches a
+plugin unchanged, because avroc passes its environment through and configures
+none of them for the child. `OTEL_SERVICE_NAME` is included in that: avroc
+neither sets nor overrides it, so a user who sets it gets the whole build under
+one service name and a user who does not gets each executable's own default.
+
+[W3C Trace Context]: https://www.w3.org/TR/trace-context/
 
 ### Standard streams
 
@@ -484,7 +517,7 @@ working directory, the locale, the environment beyond `SOURCE_DATE_EPOCH`, the
 absolute paths passed in `--descriptor` and `--out`, the order in which the
 filesystem returns entries, and any concurrency inside the plugin. In
 particular, a plugin **MUST NOT** embed a timestamp, a hostname, a username, an
-absolute path or a random value in its output, and **MUST** emit anything
+absolute path, a trace id or a random value in its output, and **MUST** emit anything
 derived from an unordered collection in a fixed order — the descriptor's own
 order where there is one, or a byte-wise sort of a stable key where there is
 not. Map iteration order is the usual way this requirement is broken, and it

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -217,12 +217,10 @@ type generator struct {
 // project tree (#118). On any failure the directory is removed here, with
 // whatever the generator left in it, and no plan is returned.
 func (g generator) run(ctx context.Context, output string, options []*avrocpb.Option, schemas ...*avrocpb.Schema) (out *generatorOutput, err error) {
-	// One span per invocation, and the anchor #193 will hang the generator's own
-	// spans off. Nothing crosses the process boundary yet: exec.CommandContext
-	// takes this context for cancellation and for nothing else, and a child
-	// learns of a parent span only when something puts it on the vector or in the
-	// environment, which is #193's to add. What this does is make the span it
-	// would carry exist, and be the invocation rather than the run.
+	// One span per invocation, and the anchor the generator's own spans hang off:
+	// generatorEnv below puts this span's context in the child's environment
+	// (#193), so a span the generator opens is a child of this invocation rather
+	// than of the run as a whole.
 	//
 	// Registered before every other defer here so that it unwinds after all of
 	// them, and therefore records the error the whole invocation returned rather
@@ -308,6 +306,11 @@ func (g generator) run(ctx context.Context, output string, options []*avrocpb.Op
 	// success, on failure and on cancellation, and no generator outlives the
 	// avroc that started it.
 	cmd := exec.CommandContext(ctx, g.executablePath, args...)
+	// avroc's own environment, carrying this invocation's span context instead of
+	// whatever trace context it inherited (#193). Setting Env at all is the thing
+	// to be careful about — a nil Env means the child gets os.Environ(), so
+	// generatorEnv starts from exactly that and removes exactly two variables.
+	cmd.Env = generatorEnv(ctx, os.Environ())
 	// Standard input is unused: avroc always passes the descriptor as a path,
 	// never through the "-" form the contract also allows.
 	cmd.Stdin = nil

--- a/internal/avroc/plugininfo.go
+++ b/internal/avroc/plugininfo.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"os/exec"
 	"slices"
 	"strconv"
@@ -153,6 +154,11 @@ func checkGenerator(ctx context.Context, log *slog.Logger, task genTask) (err er
 // stack trace attributed to nobody.
 func queryPluginInfo(ctx context.Context, name, executablePath string) (*pluginInfo, error) {
 	cmd := exec.CommandContext(ctx, executablePath, pluginInfoFlag)
+	// The handshake is propagated to on the same terms as a generation
+	// invocation (#193). It runs a whole process, and it is the first thing in a
+	// run that can be slow or hang; excluding it would leave the one invocation
+	// that happens before anything else the only untraced child avroc forks.
+	cmd.Env = generatorEnv(ctx, os.Environ())
 	// No descriptor is read during a handshake, so there is nothing standard
 	// input could carry; a plugin blocking on it would otherwise hang the run
 	// before any generation had been attempted.

--- a/internal/avroc/propagate.go
+++ b/internal/avroc/propagate.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// The environment variables a generator learns its parent span from (#193).
+//
+// This is a convention rather than a ratified part of any specification: W3C
+// Trace Context defines HTTP headers, and OpenTelemetry's environment variable
+// specification covers SDK configuration and not context propagation. It is
+// nonetheless what the ecosystem converged on — otel-cli, the Jenkins
+// OpenTelemetry plugin, Buildkite's tracing, and Dagger, which sets TRACEPARENT
+// on every container exec and is therefore why avroc running under `dagger call`
+// already has one to be a child of.
+//
+// The names are the header names upper-cased, which is the whole of the
+// convention: the values are the header values, unchanged, so a generator using
+// any OpenTelemetry SDK parses them with the propagator it already has.
+const (
+	envTraceparent = "TRACEPARENT"
+	envTracestate  = "TRACESTATE"
+)
+
+// generatorEnv is the environment one generator process runs with: avroc's,
+// with this invocation's span context written over whatever trace context it
+// already carried.
+//
+// docs/plugin/SPEC.md's "The environment" is normative, and everything below
+// follows from its one sentence — avroc passes its own environment through
+// unchanged, except for the trace context, which is per-invocation and therefore
+// cannot be inherited. Every SDK *configuration* variable an operator set —
+// endpoint, protocol, headers, sampler, resource attributes — reaches the child
+// because it is in environ and nothing here removes it, OTEL_SERVICE_NAME
+// included: a user who sets it gets avroc and its generators under one name, and
+// a user who does not gets each executable's own SDK default, which is not a
+// choice avroc is entitled to make on their behalf.
+//
+// Three things it does are decisions rather than mechanics.
+//
+// It **overwrites**. avroc may itself have been started with a TRACEPARENT — by
+// CI, or by the Dagger exec running it — and that one is avroc's own parent. The
+// child gets the span context of the invocation that is starting, which replaces
+// the inherited value rather than accompanying it; two TRACEPARENT entries in
+// one environment is a child parented by whichever the reader happened to take.
+//
+// It **removes when there is nothing to write**. A run avroc is not tracing has
+// no span context to hand over, and passing an inherited TRACEPARENT through
+// would parent the generator's spans to a trace avroc is not part of — a child
+// of a span nobody ever exported. Off is therefore actively unset rather than
+// merely unmodified, and it falls out of the same code path: the propagator
+// injects nothing for an invalid span context, and the two variables were
+// already stripped.
+//
+// It **strips case-insensitively**. The convention is the upper-case spelling
+// and that is the only one written, but a lower-case traceparent left in place
+// beside it is trace context avroc did not set and cannot vouch for, reachable by
+// anything that looks the name up the way a header would be.
+func generatorEnv(ctx context.Context, environ []string) []string {
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+
+	env := make([]string, 0, len(environ)+len(carrier))
+	for _, entry := range environ {
+		if isTraceContextVar(entry) {
+			continue
+		}
+		env = append(env, entry)
+	}
+
+	// The carrier is keyed by the header names, which are lower case; the
+	// variables are their upper-case spellings, and there are exactly two of
+	// them. Appended in a fixed order after an environment whose order is
+	// preserved, so that the vector a child is handed is a function of avroc's
+	// environment and not of a map iteration.
+	if traceparent := carrier.Get("traceparent"); traceparent != "" {
+		env = append(env, envTraceparent+"="+traceparent)
+	}
+	if tracestate := carrier.Get("tracestate"); tracestate != "" {
+		env = append(env, envTracestate+"="+tracestate)
+	}
+	return env
+}
+
+// isTraceContextVar reports whether an environment entry — a NAME=VALUE string,
+// as os.Environ writes them — carries trace context.
+//
+// An entry with no "=" in it is not a variable this recognises and is passed
+// through, like everything else avroc has no opinion about.
+func isTraceContextVar(entry string) bool {
+	name, _, found := strings.Cut(entry, "=")
+	if !found {
+		return false
+	}
+	return strings.EqualFold(name, envTraceparent) || strings.EqualFold(name, envTracestate)
+}

--- a/internal/avroc/propagate_test.go
+++ b/internal/avroc/propagate_test.go
@@ -1,0 +1,477 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/z5labs/avroc/internal/cli"
+	"github.com/z5labs/avroc/internal/ir"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// TestGeneratorEnv is the unit half of #193: what one child's environment is,
+// given avroc's and the span the invocation is running under.
+func TestGeneratorEnv(t *testing.T) {
+	t.Run("carries the invocation's span context", func(t *testing.T) {
+		ctx, span := recordedSpan(t)
+		defer span.End()
+
+		env := generatorEnv(ctx, nil)
+
+		sc := span.SpanContext()
+		want := fmt.Sprintf("00-%s-%s-%s", sc.TraceID(), sc.SpanID(), sc.TraceFlags())
+		if got := onlyValue(t, env, envTraceparent); got != want {
+			t.Errorf("%s = %q, want %q", envTraceparent, got, want)
+		}
+	})
+
+	t.Run("replaces a traceparent inherited from avroc's own environment", func(t *testing.T) {
+		ctx, span := recordedSpan(t)
+		defer span.End()
+
+		inherited := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+		env := generatorEnv(ctx, []string{envTraceparent + "=" + inherited})
+
+		got := onlyValue(t, env, envTraceparent)
+		if got == inherited {
+			t.Errorf("the child inherited avroc's own %s: a generator's spans would be children of avroc's parent", envTraceparent)
+		}
+		if want := span.SpanContext().SpanID().String(); !strings.Contains(got, want) {
+			t.Errorf("%s = %q, which does not name the invocation's span %s", envTraceparent, got, want)
+		}
+	})
+
+	t.Run("propagates a tracestate when the span context carries one", func(t *testing.T) {
+		state, err := oteltrace.ParseTraceState("vendor=value")
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+			TraceID:    oteltrace.TraceID{0x01},
+			SpanID:     oteltrace.SpanID{0x02},
+			TraceFlags: oteltrace.FlagsSampled,
+			TraceState: state,
+		})
+		ctx := oteltrace.ContextWithSpanContext(t.Context(), sc)
+
+		env := generatorEnv(ctx, []string{envTracestate + "=stale=value"})
+
+		if got, want := onlyValue(t, env, envTracestate), "vendor=value"; got != want {
+			t.Errorf("%s = %q, want %q", envTracestate, got, want)
+		}
+	})
+
+	t.Run("writes no tracestate when there is none", func(t *testing.T) {
+		ctx, span := recordedSpan(t)
+		defer span.End()
+
+		env := generatorEnv(ctx, nil)
+
+		if values := valuesOf(env, envTracestate); len(values) != 0 {
+			t.Errorf("%s = %q, want it absent", envTracestate, values)
+		}
+	})
+
+	t.Run("removes both when the run is not traced", func(t *testing.T) {
+		// The whole of the case: avroc is not tracing, its own environment carries
+		// trace context from something upstream, and passing it through would
+		// parent the generator's spans to a trace avroc is not part of.
+		environs := map[string][]string{
+			"no span at all": {
+				envTraceparent + "=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				envTracestate + "=vendor=value",
+			},
+			"the lower-case spelling": {
+				"traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				"tracestate=vendor=value",
+			},
+		}
+
+		for name, environ := range environs {
+			t.Run(name, func(t *testing.T) {
+				for _, ctx := range []context.Context{
+					t.Context(),
+					noopSpanContext(t),
+				} {
+					env := generatorEnv(ctx, environ)
+
+					if len(env) != 0 {
+						t.Errorf("the child's environment is %q, want the trace context gone", env)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("passes every other variable through unchanged", func(t *testing.T) {
+		// Setting cmd.Env at all is what makes this worth asserting: a child whose
+		// environment avroc builds is one avroc can silently truncate, and
+		// SOURCE_DATE_EPOCH is the variable docs/plugin/SPEC.md promises a
+		// generator by name.
+		environ := []string{
+			"PATH=/usr/local/bin",
+			"SOURCE_DATE_EPOCH=1700000000",
+			"OTEL_SERVICE_NAME=chosen-by-the-user",
+			"OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318",
+			"HOME=/home/nobody",
+			"AN_ENTRY_WITH_NO_EQUALS_SIGN",
+		}
+		ctx, span := recordedSpan(t)
+		defer span.End()
+
+		env := generatorEnv(ctx, environ)
+
+		if got := env[:len(environ)]; !slices.Equal(got, environ) {
+			t.Errorf("the environment reaching the child is %q, want %q with the trace context appended", got, environ)
+		}
+		if got, want := len(env), len(environ)+1; got != want {
+			t.Errorf("the child's environment holds %d entries, want %d", got, want)
+		}
+	})
+
+	t.Run("neither sets nor overrides OTEL_SERVICE_NAME", func(t *testing.T) {
+		// A generator's identity is the SDK's per-executable default, or whatever
+		// the user set for the whole build. It is not something avroc invents.
+		ctx, span := recordedSpan(t)
+		defer span.End()
+
+		for name, environ := range map[string][]string{
+			"absent": nil,
+			"set":    {"OTEL_SERVICE_NAME=chosen-by-the-user"},
+		} {
+			t.Run(name, func(t *testing.T) {
+				env := generatorEnv(ctx, environ)
+
+				if got, want := valuesOf(env, "OTEL_SERVICE_NAME"), valuesOf(environ, "OTEL_SERVICE_NAME"); !slices.Equal(got, want) {
+					t.Errorf("OTEL_SERVICE_NAME = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+}
+
+// TestATracedRunPropagatesToEveryGeneratorProcess is the story end to end,
+// through the CLI entry point and a real generator process.
+//
+// The generator is a shell script that writes down the environment it was
+// handed, which is the only place the answer actually is: what avroc put in
+// cmd.Env is not the question, and a test asserting on that would pass with the
+// process never having run.
+func TestATracedRunPropagatesToEveryGeneratorProcess(t *testing.T) {
+	// An inherited value on avroc's own process, because that is the case that
+	// distinguishes propagation from passing something through: this one is
+	// avroc's parent and must reach no child.
+	const inherited = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	t.Setenv(envTraceparent, inherited)
+	t.Setenv(envTracestate, "upstream=value")
+
+	collector := newSpanCollector(t)
+	run := generateWithEnvDump(t, collector)
+
+	spans := collector.spans(t)
+	if len(spans) == 0 {
+		t.Fatal("the run exported no spans, so there is nothing for a child to be parented to")
+	}
+
+	invocations := map[string]struct {
+		env  childEnvironment
+		span string
+	}{
+		"the generation invocation": {run.generate, spanGeneratorRun},
+		"the handshake invocation":  {run.handshake, spanGeneratorHandshake},
+	}
+
+	for name, invocation := range invocations {
+		t.Run(name, func(t *testing.T) {
+			if len(invocation.env) == 0 {
+				t.Fatal("the generator did not run, so it recorded no environment")
+			}
+
+			traceparent := onlyValue(t, invocation.env, envTraceparent)
+			if traceparent == inherited {
+				t.Fatalf("the child was handed avroc's own %s", envTraceparent)
+			}
+
+			parent := spanNamed(t, spans, invocation.span)
+			want := fmt.Sprintf("00-%s-%s-01",
+				hex.EncodeToString(parent.GetTraceId()), hex.EncodeToString(parent.GetSpanId()))
+			if traceparent != want {
+				t.Errorf("%s = %q, want %q — the span it names is not the %s span avroc exported",
+					envTraceparent, traceparent, want, invocation.span)
+			}
+		})
+	}
+
+	t.Run("the inherited tracestate is replaced too", func(t *testing.T) {
+		// avroc's own span context carries no trace state, so there is none to
+		// hand on — and the upstream one is not avroc's to forward.
+		if values := valuesOf(run.generate, envTracestate); len(values) != 0 {
+			t.Errorf("%s = %q, want it absent", envTracestate, values)
+		}
+	})
+}
+
+// TestAnUntracedRunUnsetsTheTraceContext is the other half: tracing off means
+// actively unset, not merely unmodified.
+func TestAnUntracedRunUnsetsTheTraceContext(t *testing.T) {
+	t.Setenv(envTraceparent, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	t.Setenv(envTracestate, "upstream=value")
+
+	run := generateWithEnvDump(t, nil)
+
+	for name, env := range map[string]childEnvironment{
+		"the generation invocation": run.generate,
+		"the handshake invocation":  run.handshake,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if len(env) == 0 {
+				t.Fatal("the generator did not run, so it recorded no environment")
+			}
+			for _, variable := range []string{envTraceparent, envTracestate} {
+				if values := valuesOf(env, variable); len(values) != 0 {
+					t.Errorf("%s = %q, want it absent: avroc is not tracing, so a child of that trace would have no parent", variable, values)
+				}
+			}
+		})
+	}
+}
+
+// TestAGeneratorStillGetsEverythingElseFromAvrocsEnvironment is the same
+// assertion as the unit test above, made where it can actually go wrong: avroc
+// now builds cmd.Env, and a child whose environment is built is one that can
+// silently lose the rest of it.
+func TestAGeneratorStillGetsEverythingElseFromAvrocsEnvironment(t *testing.T) {
+	t.Setenv("AVROC_TEST_UNRELATED", "reached the child")
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+
+	run := generateWithEnvDump(t, newSpanCollector(t))
+
+	for name, want := range map[string]string{
+		"AVROC_TEST_UNRELATED": "reached the child",
+		"SOURCE_DATE_EPOCH":    "1700000000",
+	} {
+		if got := onlyValue(t, run.generate, name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestGeneratedBytesAreTheSameWithATraceparentOrWithout: the trace context is an
+// input to nothing a generator writes. A run under CI, which has a TRACEPARENT,
+// and the same run on a laptop, which does not, leave the same tree behind.
+func TestGeneratedBytesAreTheSameWithATraceparentOrWithout(t *testing.T) {
+	without := generateWithEnvDump(t, nil).tree
+
+	t.Setenv(envTraceparent, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	t.Setenv(envTracestate, "upstream=value")
+	with := generateWithEnvDump(t, newSpanCollector(t)).tree
+
+	if len(without) == 0 {
+		t.Fatal("the run generated nothing, so the comparison is vacuous")
+	}
+	if len(with) != len(without) {
+		t.Fatalf("the traced run produced %d files and the untraced one %d", len(with), len(without))
+	}
+	for name, want := range without {
+		if got := with[name]; got != want {
+			t.Errorf("%q differs:\nwith a traceparent: %q\nwithout:            %q", name, got, want)
+		}
+	}
+}
+
+// envDumpRun is what one run of generateWithEnvDump observed: the environment
+// each of the two invocations was handed, and the tree the run left behind.
+type envDumpRun struct {
+	handshake childEnvironment
+	generate  childEnvironment
+	tree      map[string]string
+}
+
+// generateWithEnvDump runs avroc generate over a one-schema project with a
+// generator that writes down its environment.
+//
+// A nil collector is an untraced run, which is what an operator with no
+// collector configured gets and is the case where the variables have to be
+// removed rather than merely not set.
+func generateWithEnvDump(t *testing.T, collector *spanCollector) envDumpRun {
+	t.Helper()
+
+	projectRoot := t.TempDir()
+	dumpDir := t.TempDir()
+	handshakeDump := filepath.Join(dumpDir, "handshake.env")
+	generateDump := filepath.Join(dumpDir, "generate.env")
+
+	generatorPath := envDumpingGenerator(t, handshakeDump, generateDump)
+
+	if err := os.WriteFile(filepath.Join(projectRoot, manifestFilename), []byte(`{
+  "inputs": ["schema.avdl"],
+  "generators": [{"name": "test", "out": "gen"}]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "schema.avdl"), []byte(recordIDL("User")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := map[string]string{"PATH": filepath.Dir(generatorPath)}
+	if collector != nil {
+		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = collector.endpoint()
+	}
+
+	c := cli.Context{
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Env: cli.EnvironmentFunc(func(key string) (string, bool) {
+			value, ok := env[key]
+			return value, ok
+		}),
+		OpenDir:    func(dir string) fs.FS { return os.DirFS(dir) },
+		WorkingDir: projectRoot,
+		Args:       []string{"generate"},
+	}
+
+	if code := Main(t.Context(), c); code != 0 {
+		t.Fatalf("avroc generate exited %d", code)
+	}
+
+	return envDumpRun{
+		handshake: readChildEnvironment(t, handshakeDump),
+		generate:  readChildEnvironment(t, generateDump),
+		tree:      treeOf(t, filepath.Join(projectRoot, "gen")),
+	}
+}
+
+// envDumpingGenerator is a conforming plugin that writes its environment to the
+// file naming the invocation it is in, and is otherwise the smallest generator
+// that produces output.
+//
+// It ignores both variables, which is the acceptance criterion it is standing in
+// for as well as the one it asserts: a generator that never reads TRACEPARENT
+// behaves exactly as it did before #193.
+func envDumpingGenerator(t *testing.T, handshakeDump, generateDump string) string {
+	t.Helper()
+
+	return writeNamedShellGenerator(t, "test", fmt.Sprintf(`set -e
+if [ "$1" = "--plugin-info" ]; then
+  env > '%s'
+  printf '{"name":"test","version":"9.9.9","ir_version":%d,"options":[]}\n'
+  exit 0
+fi
+
+env > '%s'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --descriptor) shift 2 ;;
+    --out) out=$2; shift 2 ;;
+    --opt) shift 2 ;;
+    *) echo "error: unexpected argument $1" >&2; exit 1 ;;
+  esac
+done
+
+printf 'package avro\n' > "$out/generated.go"
+`, handshakeDump, ir.Version, generateDump))
+}
+
+// childEnvironment is one process's environment as env(1) wrote it: NAME=VALUE
+// per line, in whatever order the process received them.
+type childEnvironment []string
+
+func readChildEnvironment(t *testing.T, path string) childEnvironment {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return childEnvironment(strings.Split(strings.TrimSuffix(string(b), "\n"), "\n"))
+}
+
+// valuesOf is every value an environment holds for a variable, matched the way
+// generatorEnv strips them — case-insensitively, so that a lower-case
+// traceparent left behind is a failure rather than an invisible pass.
+//
+// Every value rather than one, because a duplicate is precisely the failure
+// "replaced, not appended to" is about.
+func valuesOf(env []string, name string) []string {
+	var values []string
+	for _, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if found && strings.EqualFold(key, name) {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// onlyValue is the one value an environment holds for a variable, and a failure
+// if it holds none or more than one.
+func onlyValue(t *testing.T, env []string, name string) string {
+	t.Helper()
+
+	values := valuesOf(env, name)
+	if len(values) != 1 {
+		t.Fatalf("the environment holds %d entries for %s (%q), want exactly one", len(values), name, values)
+	}
+	return values[0]
+}
+
+// spanNamed is the one exported span with a given name.
+func spanNamed(t *testing.T, spans []*tracepb.Span, name string) *tracepb.Span {
+	t.Helper()
+
+	var found []*tracepb.Span
+	for _, span := range spans {
+		if span.GetName() == name {
+			found = append(found, span)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("the run exported %d spans named %q, want exactly one", len(found), name)
+	}
+	return found[0]
+}
+
+// recordedSpan is a real, sampled span for generatorEnv to propagate.
+func recordedSpan(t *testing.T) (context.Context, oteltrace.Span) {
+	t.Helper()
+
+	provider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Error(err)
+		}
+	})
+	return provider.Tracer(tracerScope).Start(t.Context(), "invocation")
+}
+
+// noopSpanContext is a context carrying the span an untraced run produces: one
+// from the no-op provider, whose span context is not valid.
+func noopSpanContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, span := noop.NewTracerProvider().Tracer(tracerScope).Start(t.Context(), "invocation")
+	span.End()
+	return ctx
+}

--- a/internal/avroc/trace_test.go
+++ b/internal/avroc/trace_test.go
@@ -705,11 +705,24 @@ func (c *spanCollector) endpoint() string {
 func (c *spanCollector) spanNames(t *testing.T) []string {
 	t.Helper()
 
+	var names []string
+	for _, span := range c.spans(t) {
+		names = append(names, span.GetName())
+	}
+	return names
+}
+
+// spans is every span the collector was sent, decoded, in the order it received
+// them. It is what an assertion about parentage needs and spanNames does not:
+// the trace and span ids the exported bytes actually carry.
+func (c *spanCollector) spans(t *testing.T) []*tracepb.Span {
+	t.Helper()
+
 	c.mu.Lock()
 	bodies := append([][]byte(nil), c.bodies...)
 	c.mu.Unlock()
 
-	var names []string
+	var spans []*tracepb.Span
 	for _, body := range bodies {
 		for len(body) > 0 {
 			number, typ, read := protowire.ConsumeTag(body)
@@ -733,11 +746,9 @@ func (c *spanCollector) spanNames(t *testing.T) []string {
 				t.Fatalf("export body does not hold a ResourceSpans: %v", err)
 			}
 			for _, ss := range rs.GetScopeSpans() {
-				for _, span := range ss.GetSpans() {
-					names = append(names, span.GetName())
-				}
+				spans = append(spans, ss.GetSpans()...)
 			}
 		}
 	}
-	return names
+	return spans
 }


### PR DESCRIPTION
Closes #193

avroc's own spans end at the fork. A generator is a separate process, and a span it opens has no parent unless avroc hands it one — so `internal/avroc/propagate.go` builds each child's environment from avroc's own, with the span context of *that* invocation written over whatever trace context it inherited. `cmd.Env` on the generation invocation (`internal/avroc/avroc.go`) and on the `--plugin-info` handshake (`internal/avroc/plugininfo.go`) are the two places it is used.

## Acceptance criteria

- [x] Each generator process receives `TRACEPARENT` set from that invocation's span. `TestATracedRunPropagatesToEveryGeneratorProcess` runs a real generator through `Main` with a decoding collector, reads the environment the child was *handed*, and requires the traceparent to name the `avroc.generator.run` span avroc exported.
- [x] `TRACESTATE` is propagated when present, and absent when there is none.
- [x] An inherited `TRACEPARENT` is replaced, not appended to and not preserved — asserted by there being exactly one entry and it not being the inherited value, with the inherited one set on avroc's own process.
- [x] The `--plugin-info` handshake is propagated to on the same terms, against the exported `avroc.generator.handshake` span.
- [x] Tracing off means actively unset. `TestAnUntracedRunUnsetsTheTraceContext` sets both on avroc's process, runs untraced, and requires neither in either child.
- [x] Every other variable still reaches the child. `TestAGeneratorStillGetsEverythingElseFromAvrocsEnvironment` asserts an unrelated variable and `SOURCE_DATE_EPOCH` through a real child process, because setting `cmd.Env` at all is how the rest gets silently dropped.
- [x] avroc neither sets nor overrides `OTEL_SERVICE_NAME`.
- [x] A generator ignoring both behaves exactly as it does today — every other generator in the suite ignores them, and the test generator here does too.
- [x] `example/` regenerates byte-identically either way: `TestGeneratedBytesAreTheSameWithATraceparentOrWithout`, and the verify step's `avroc generate && git diff --exit-code` run again with both variables set.

## Judgment calls

- **Overwrite, and strip case-insensitively.** Only the upper-case spelling is written, but a lower-case `traceparent` left beside it is trace context avroc did not set and cannot vouch for. Both spellings are removed; everything else, including an entry with no `=` in it, passes through untouched and in order.
- **Off falls out of one code path.** The W3C propagator injects nothing for an invalid span context, and the strip has already happened — so "no span" and "tracing disabled" need no separate branch.
- **`docs/plugin/SPEC.md` gets a normative "Trace context" subsection.** The variables are a convention rather than a ratified specification, and a plugin author needs to be told that ignoring them is allowed, that the value is per-invocation, and that they are absent when avroc is not tracing. "a trace id" was added to Determinism's `MUST NOT` embed list, since it is now something every plugin receives.

## Verification

Every command in `.claude/backlog.json`'s `verify`: `go build`, `gofmt -l`, `go vet`, `go test -race -cover ./...`, `golangci-lint run`, and the `example/` round trip. The new tests were checked against a mutant that passes `os.Environ()` through unchanged — four of them fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)