### PR TITLE
story(plugin): the determinism check tells a clock read from a clock in a file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,12 @@ Three checks, because no one of them sees all of it:
 - **`internal/plugin.TestNoGeneratorReadsTheClock`** parses the source of every
   package that can put a byte in a generated file and fails on any *reference* —
   called, assigned or passed — to something that could not give the same answer
-  twice: `time.Now`, `os.Hostname`, `os.Getenv`, `os/user`, either random.
-  Repetition cannot catch a clock read, because two runs a moment apart agree on
-  the date.
+  twice. `forbiddenFuncs` and `forbiddenImports` in `determinism_test.go` are the
+  list; `time.Now`, `os.Hostname`, `os.Getenv`, `os/user` and either random are
+  examples from it and not the whole of it — every other way of reading the
+  environment (`os.LookupEnv`, `os.Environ`) or the machine (`os.Getwd`,
+  `os.Getpid`, `os.UserHomeDir`, …) is in there too. Repetition cannot catch a
+  clock read, because two runs a moment apart agree on the date.
 
 What the rule protects is that no non-reproducible value reaches a generated
 *byte*, and that is a data flow no file-at-a-time source scan can see. The ban

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ go test -v ./...
 - **`internal/avroc-gen-pcf/`** — Parsing Canonical Form generator plugin. Reads the descriptor it is handed and writes one canonical `.avsc` per schema beneath `--out`. Its files are `ir.CanonicalJSON`'s bytes verbatim — no trailing newline, no re-indentation — because they are fingerprint input rather than a rendering for a person.
 - **`internal/plugin/`** — The generator's half of `docs/plugin/SPEC.md`: parsing the argument vector, reading the descriptor it names, and writing files beneath `--out`. Every generator here routes its `Main` through it and produces its output through `plugin.FileWriter` — one call per file, path and whole content — with `plugin.OutputDir` the implementation that owns the path check, the directory creation and the record of what was written. avroc's half — discovery and building the vector — is `internal/avroc`'s, and the two are separate on purpose: a third-party generator implements the contract without importing anything from this repository.
 - **`internal/cli/`** — Shared CLI context type (`cli.Context`) providing structured logger, environment, filesystem, and args.
-- **`internal/telemetry/`** — avroc's tracer provider, and nothing that uses it (#191). See "Tracing" below.
+- **`internal/telemetry/`** — avroc's tracer provider, and nothing that uses it (#191). See "Tracing" below. It is also the one package the determinism ban exempts (#195), because it produces nothing through `plugin.FileWriter`; see "Determinism".
 - **`internal/ir/`** — Operations every generator performs on the resolved IR: the repository's single Avro Parsing Canonical Form implementation (shared by `avroc-gen-pcf` and `avroc-gen-go`'s fingerprint), plus name and filename helpers. No symbol table, no namespace qualification, no primitive list. `ir.SchemaBaseName` is the one every generator's filename comes from, and it names the schema after what its **root type** is about: a named type is about itself, an array and a map are about what they contain (so `schema array<Event>;` is `event.go`, not the namespace's last component, #172), and anything else — a primitive, a union with no single subject — falls through to the additional types, then the namespace, then `schema`.
 - **`internal/docs/`** — No implementation; it is where the published documentation is checked from. `TestEveryRelativeLinkInTheDocumentationResolves` walks every Markdown file in the repository and requires each relative link to resolve *from the file it is written in*, fragment included, because a link is the one part of a document that breaks silently — renaming a heading breaks every reference to it without touching the files carrying them. Links inside fenced blocks are skipped: `docs/CONVENTIONS.md` quotes the conformance-language template, whose `../CONVENTIONS.md` is a path for the *quoting* document to write and not one to resolve from there. Nothing external is fetched, so the check is the same offline.
 - **`avrocpb/`** — Generated Go code from the protobuf definitions, and the only package here a third-party generator imports. Public rather than internal because the IR is a contract; do not edit the generated files directly.
@@ -305,11 +305,40 @@ Three checks, because no one of them sees all of it:
   many times in one process. That is what exercises Go's randomised map iteration
   order, which is the usual way the rule gets broken and the one that breaks
   intermittently.
-- **`internal/plugin.TestNoGeneratorReadsTheClock`** parses every generator's
-  source and fails on any *reference* — called, assigned or passed — to
-  something that could not give the same answer twice: `time.Now`,
-  `os.Hostname`, `os.Getenv`, `os/user`, either random. Repetition cannot catch
-  a clock read, because two runs a moment apart agree on the date.
+- **`internal/plugin.TestNoGeneratorReadsTheClock`** parses the source of every
+  package that can put a byte in a generated file and fails on any *reference* —
+  called, assigned or passed — to something that could not give the same answer
+  twice: `time.Now`, `os.Hostname`, `os.Getenv`, `os/user`, either random.
+  Repetition cannot catch a clock read, because two runs a moment apart agree on
+  the date.
+
+What the rule protects is that no non-reproducible value reaches a generated
+*byte*, and that is a data flow no file-at-a-time source scan can see. The ban
+is an over-approximation of it, and it was absolute — naming `time.Now` at all,
+anywhere the generators are built from — for as long as no such package had a
+use for a clock. #196 gives one a use: a generator that opens a span reaches
+both of the banned things through the SDK, because a span is two wall-clock
+timestamps and an exporter finds its collector in the environment.
+
+The resolution (#195) is **not** a carve-out in `forbiddenFuncs`, which would
+allow `time.Now` in the file-writing packages too. The over-approximation is
+shrunk by exactly the amount the new use requires: telemetry lives in one
+package that produces nothing through `plugin.FileWriter`, and
+`determinism_test.go` names it in `exemptPackages` — by **package identity**,
+never a name pattern, a build tag or a comment directive — while every package
+that can produce output stays in `bannedPackages` under the absolute ban. Three
+checks keep the exemption from widening, because an exemption whose only
+evidence is the exempt package passing would go on passing if it covered the
+whole repository: the banned set is written out again as literals, so narrowing
+the ban takes a change to the test as well as to the list; the exempt package's
+module-local import graph is walked and required not to reach
+`internal/plugin`, which declares `FileWriter`; and a clock read and an
+environment read are injected into a **copy of `avroc-gen-go`'s own
+`Generate`** — the function that calls `WriteFile` — with the check required to
+report each one by name. Reachability is a necessary condition and not a
+sufficient one — `internal/ir` cannot reach `FileWriter` either, and its bytes
+are generated output — which is why the exempt list is explicit and one entry
+long rather than derived from the graph.
 
 `internal/plugin.SourceDateEpoch` is the only sanctioned way to get a timestamp:
 it reads `SOURCE_DATE_EPOCH`, returns UTC, and reports a malformed value rather

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -12,18 +12,76 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-// generatorPackages are the directories that make up the generator half of
-// docs/plugin/SPEC.md: the three built-in generators, the shared IR operations
-// they perform, and this package, through which all three run.
+// What the rule protects, and why the ban has the shape it has.
+//
+// docs/plugin/SPEC.md's "Determinism" says one thing: no value that differs
+// between two runs may reach a generated *byte*. That is a property of a data
+// flow, and a data flow is not something a file-at-a-time source scan can see.
+// So the check below approximates it, and the approximation used to be as
+// coarse as it could be — naming time.Now at all, anywhere in a package the
+// generators are built from, was the finding. That cost nothing for as long as
+// no such package had a use for a clock, and for a long time none did.
+//
+// #196 gives one a use. A generator that opens a span reaches, through the
+// OpenTelemetry SDK, both of the things the ban names: a span is two wall-clock
+// timestamps, and an exporter finds its collector in the environment.
+//
+// The resolution is deliberately not a carve-out in [forbiddenFuncs]. Allowing
+// time.Now there would allow it in every package at once, including the ones
+// that write files, which is the whole of what the rule is for. What is done
+// instead is to shrink the over-approximation by exactly the amount the new use
+// requires: telemetry lives in one package that produces nothing through
+// [FileWriter], that package is named — by identity, in [exemptPackages], not
+// by a name pattern, a build tag or a comment directive — and every package
+// that can produce output stays under the absolute ban.
+//
+// An exemption is only worth as much as the checks around it, so there are
+// three, and none of them is satisfied by the exempt package merely passing:
+//
+//   - [TestEveryPackageThatCanProduceOutputIsStillUnderTheBan] writes the
+//     banned set out as literals, so the ban cannot be narrowed by editing the
+//     list the check reads.
+//   - [TestTheExemptPackageCannotProduceGeneratedOutput] walks the exempt
+//     package's module-local import graph and requires that it cannot reach
+//     this package, which declares [FileWriter]. That is a necessary condition
+//     and not a sufficient one — internal/ir cannot reach [FileWriter] either,
+//     and its bytes are generated output — which is exactly why the list is
+//     explicit and short rather than derived from the graph.
+//   - [TestTheBanStillCatchesNondeterminismOnAGeneratorsOutputPath] puts a
+//     clock read and an environment read into a copy of a generator's own
+//     output-writing source and requires the check to report both. A check
+//     whose failure path has never run is a check nobody knows the state of.
+
+// fileWriterPackage is the import path of the package declaring [FileWriter],
+// which is the whole of how a generator produces a byte. A package that cannot
+// reach it cannot write generated output.
+const fileWriterPackage = "github.com/z5labs/avroc/internal/plugin"
+
+// modulePath is this repository's module path, and the prefix that tells an
+// import of a package the ban has jurisdiction over from an import of one it
+// does not.
+const modulePath = "github.com/z5labs/avroc"
+
+// moduleRoot is the module's root directory, relative to this package, which is
+// where a module-local import path is resolved from.
+func moduleRoot() string {
+	return filepath.Join("..", "..")
+}
+
+// bannedPackages are the directories that can put a byte in a generated file:
+// the three built-in generators, the shared IR operations they perform, and
+// this package, through which all three run and which owns the writing. Every
+// one of them is under the absolute ban.
 //
 // They are named as paths rather than imported because the check below is a
 // property of the source, not of a running program.
-func generatorPackages() []string {
+func bannedPackages() []string {
 	return []string{
 		".",
 		filepath.Join("..", "avroc-gen-go"),
@@ -33,11 +91,28 @@ func generatorPackages() []string {
 	}
 }
 
+// exemptPackages are the directories linked into a generator that the absolute
+// ban does not apply to, because they produce nothing through [FileWriter].
+//
+// There is one, internal/telemetry, and the shortness of the list is the
+// point: this is the entire amount by which the over-approximation described
+// at the top of this file has been shrunk. A package earns a place here by
+// being unable to write output at all, which is asserted rather than asserted
+// of it — see [TestTheExemptPackageCannotProduceGeneratedOutput] — and not by
+// having a good reason to read a clock.
+func exemptPackages() []string {
+	return []string{filepath.Join("..", "telemetry")}
+}
+
 // forbiddenFuncs maps an import path to the functions in it whose result
 // differs between two runs of the same executable over the same descriptor.
 // docs/plugin/SPEC.md's "Determinism" forbids their results reaching a
-// generator's output; forbidding them outright is the checkable form of that,
-// and costs nothing, because no generator here has a use for one.
+// generator's output; forbidding them outright, in every package that can
+// produce output, is the checkable form of that.
+//
+// Nothing is ever added here as an exception. The unit of exemption is a
+// package, in [exemptPackages], because a function allowed here is allowed in
+// the file-writing packages too.
 //
 // What is forbidden is naming one of them at all, not calling one: the check
 // below matches any reference, so `at := time.Now` is a finding as much as
@@ -95,7 +170,7 @@ func forbiddenImports() map[string]string {
 
 // TestNoGeneratorReadsTheClock is the static half of #120: no built-in
 // generator embeds a timestamp, a hostname, a username or a random value,
-// because none of them can reach one.
+// because no package that can write one can reach one.
 //
 // It is static on purpose. The dynamic half — running a generator twice and
 // comparing the bytes, in each generator's own determinism test and in
@@ -108,33 +183,187 @@ func forbiddenImports() map[string]string {
 // Test files are excluded. A test may read the clock freely; what it must not
 // do is put the result in a generator's output, and none does.
 func TestNoGeneratorReadsTheClock(t *testing.T) {
-	for _, dir := range generatorPackages() {
-		sources := nonTestSources(t, dir)
-		if len(sources) == 0 {
-			t.Fatalf("no non-test Go source found in %s: the check is looking in the wrong place", dir)
+	for _, dir := range bannedPackages() {
+		findings, err := scanPackage(dir)
+		if err != nil {
+			t.Fatalf("failed to scan %s: %v", dir, err)
 		}
-
-		for _, path := range sources {
-			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-			if err != nil {
-				t.Fatalf("failed to parse %s: %v", path, err)
-			}
-			for _, finding := range nondeterminismIn(fset, file) {
-				t.Errorf("%s (docs/plugin/SPEC.md, Determinism)", finding)
-			}
+		for _, finding := range findings {
+			t.Errorf("%s (docs/plugin/SPEC.md, Determinism)", finding)
 		}
 	}
 }
 
+// TestEveryPackageThatCanProduceOutputIsStillUnderTheBan writes the banned set
+// out as literals, so that narrowing the ban takes a change to this test and
+// not only to the list the check reads. An exemption granted by quietly
+// dropping a directory from [bannedPackages] would leave every other check here
+// passing.
+func TestEveryPackageThatCanProduceOutputIsStillUnderTheBan(t *testing.T) {
+	want := []string{
+		".",
+		"../avroc-gen-go",
+		"../avroc-gen-json",
+		"../avroc-gen-pcf",
+		"../ir",
+	}
+
+	got := bannedPackages()
+	for _, dir := range want {
+		if !slices.Contains(got, filepath.FromSlash(dir)) {
+			t.Errorf("%s can produce generated output and is no longer under the determinism ban", dir)
+		}
+	}
+
+	// Scanning a package that is not there passes vacuously, so every banned
+	// directory has to hold source the check actually read.
+	for _, dir := range got {
+		sources, err := nonTestSources(dir)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", dir, err)
+		}
+		if len(sources) == 0 {
+			t.Errorf("no non-test Go source found in %s: the ban is looking in the wrong place", dir)
+		}
+	}
+}
+
+// TestTheExemptPackageCannotProduceGeneratedOutput is what makes the exemption
+// narrow rather than merely stated. A package is exempt only because nothing it
+// contains can become a generated byte, and the whole of how a byte becomes one
+// is [FileWriter]; so an exempt package that could reach [FileWriter] would be
+// an exemption from the rule itself.
+//
+// Reachability is the necessary condition and not the sufficient one — see the
+// note at the top of this file — so the exempt set stays explicit, and this
+// test is what stops it being widened to a package that writes files.
+func TestTheExemptPackageCannotProduceGeneratedOutput(t *testing.T) {
+	// Asked of this package rather than assumed of it: if FileWriter moves, the
+	// reachability question below would go on being asked about the wrong
+	// package and go on being answered no.
+	if !declaresFileWriter(t, ".") {
+		t.Fatalf("FileWriter is no longer declared in %s: the exemption is asking about the wrong package", fileWriterPackage)
+	}
+
+	exempt := exemptPackages()
+	if len(exempt) == 0 {
+		t.Fatal("no exempt package: the check below would pass with the exemption widened to anything")
+	}
+
+	banned := bannedPackages()
+	for _, dir := range exempt {
+		if slices.Contains(banned, dir) {
+			t.Errorf("%s is both banned and exempt", dir)
+			continue
+		}
+
+		sources, err := nonTestSources(dir)
+		if err != nil {
+			t.Fatalf("failed to read the exempt package %s: %v", dir, err)
+		}
+		if len(sources) == 0 {
+			t.Errorf("no non-test Go source found in the exempt package %s", dir)
+			continue
+		}
+
+		chain, err := importPathTo(dir, fileWriterPackage)
+		if err != nil {
+			t.Fatalf("failed to walk the imports of %s: %v", dir, err)
+		}
+		if chain != nil {
+			t.Errorf("%s is exempt from the determinism ban but reaches %s, so it can produce generated output: %s",
+				dir, fileWriterPackage, strings.Join(chain, " -> "))
+		}
+	}
+}
+
+// TestTheBanStillCatchesNondeterminismOnAGeneratorsOutputPath is the negative
+// case the exemption is worthless without. It takes a generator's own source —
+// a copy of it, so nothing in the repository is edited — puts a clock read and
+// then an environment read into the function that writes the files, and
+// requires the check to report each one, naming it.
+//
+// The source is copied rather than written out here so that the case cannot
+// drift into a hand-made snippet that merely resembles a generator. If the
+// exemption were ever widened to cover a package that writes output, this is
+// what would notice.
+func TestTheBanStillCatchesNondeterminismOnAGeneratorsOutputPath(t *testing.T) {
+	const (
+		generator = "avroc-gen-go"
+		file      = "generate.go"
+		fn        = "Generate"
+	)
+
+	testCases := []struct {
+		name       string
+		importPath string
+		stmt       string
+		want       string
+	}{
+		{
+			name:       "a clock read",
+			importPath: "time",
+			stmt:       "_ = time.Now()",
+			want:       "time.Now",
+		},
+		{
+			name:       "an environment read",
+			importPath: "os",
+			stmt:       `_ = os.Getenv("SOURCE_DATE_EPOCH")`,
+			want:       "os.Getenv",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := injectedCopy(t, filepath.Join("..", generator), file, fn, tc.importPath, tc.stmt)
+
+			findings, err := scanPackage(dir)
+			if err != nil {
+				t.Fatalf("failed to scan the patched copy of %s: %v", generator, err)
+			}
+
+			named := slices.ContainsFunc(findings, func(finding string) bool {
+				return strings.Contains(finding, tc.want) && strings.Contains(finding, file)
+			})
+			if !named {
+				t.Errorf("the determinism check accepted %s in %s.%s, which writes generated files; findings: %v",
+					tc.stmt, file, fn, findings)
+			}
+		})
+	}
+}
+
+// scanPackage reports every finding in the non-test sources of one directory.
+// It is the check itself, separated from the test that runs it over the
+// repository so that it can be run over source that must fail it.
+func scanPackage(dir string) ([]string, error) {
+	sources, err := nonTestSources(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("no non-test Go source found in %s: the check is looking in the wrong place", dir)
+	}
+
+	var findings []string
+	for _, path := range sources {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+		findings = append(findings, nondeterminismIn(fset, file)...)
+	}
+	return findings, nil
+}
+
 // nonTestSources lists the Go source files in dir that are compiled into the
 // generator, which is every .go file that is not a test.
-func nonTestSources(t *testing.T, dir string) []string {
-	t.Helper()
-
+func nonTestSources(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("failed to read %s: %v", dir, err)
+		return nil, err
 	}
 
 	var sources []string
@@ -145,7 +374,7 @@ func nonTestSources(t *testing.T, dir string) []string {
 		}
 		sources = append(sources, filepath.Join(dir, name))
 	}
-	return sources
+	return sources, nil
 }
 
 // nondeterminismIn reports every forbidden import and every reference to a
@@ -219,6 +448,204 @@ func nondeterminismIn(fset *token.FileSet, file *ast.File) []string {
 	})
 
 	return findings
+}
+
+// declaresFileWriter reports whether dir declares the FileWriter type.
+func declaresFileWriter(t *testing.T, dir string) bool {
+	t.Helper()
+
+	sources, err := nonTestSources(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+
+	for _, path := range sources {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", path, err)
+		}
+
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			spec, ok := n.(*ast.TypeSpec)
+			if ok && spec.Name.Name == "FileWriter" {
+				found = true
+			}
+			return !found
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// importPathTo walks the module-local import graph from dir, breadth first, and
+// returns the chain of import paths by which it reaches target, or nil when it
+// does not. Imports of other modules are not followed: nothing outside this
+// repository can reach [FileWriter], which is unexported to it.
+func importPathTo(dir, target string) ([]string, error) {
+	type node struct {
+		dir   string
+		chain []string
+	}
+
+	seen := make(map[string]bool)
+	queue := []node{{dir: dir}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		imports, err := importsOf(current.dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range imports {
+			if path != modulePath && !strings.HasPrefix(path, modulePath+"/") {
+				continue
+			}
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+
+			chain := append(append([]string(nil), current.chain...), path)
+			if path == target {
+				return chain, nil
+			}
+			rel := filepath.FromSlash(strings.TrimPrefix(path, modulePath+"/"))
+			queue = append(queue, node{dir: filepath.Join(moduleRoot(), rel), chain: chain})
+		}
+	}
+	return nil, nil
+}
+
+// importsOf lists the import paths named by dir's non-test sources.
+func importsOf(dir string) ([]string, error) {
+	sources, err := nonTestSources(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, source := range sources {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, source, nil, parser.ImportsOnly|parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", source, err)
+		}
+		for _, spec := range file.Imports {
+			path, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				return nil, fmt.Errorf("%s: unparseable import path %s", source, spec.Path.Value)
+			}
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
+}
+
+// injectedCopy copies dir's non-test sources into a temporary directory and
+// rewrites the copy of file so that the body of fn begins with stmt, adding an
+// import of importPath if the file does not already have one. It returns the
+// temporary directory, for the check to be run over.
+//
+// fn is required to be on the output-writing path — its body must call
+// WriteFile — so that a restructuring which moves the write elsewhere fails
+// here, loudly, instead of leaving the negative case pointed at a function that
+// no longer produces a byte.
+func injectedCopy(t *testing.T, dir, file, fn, importPath, stmt string) string {
+	t.Helper()
+
+	sources, err := nonTestSources(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	if len(sources) == 0 {
+		t.Fatalf("no non-test Go source found in %s", dir)
+	}
+
+	tmp := t.TempDir()
+	patched := false
+	for _, source := range sources {
+		content, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", source, err)
+		}
+		if filepath.Base(source) == file {
+			content = inject(t, source, content, fn, importPath, stmt)
+			patched = true
+		}
+		if err := os.WriteFile(filepath.Join(tmp, filepath.Base(source)), content, 0o600); err != nil {
+			t.Fatalf("failed to write the copy of %s: %v", source, err)
+		}
+	}
+	if !patched {
+		t.Fatalf("%s has no %s to patch", dir, file)
+	}
+	return tmp
+}
+
+// inject rewrites one file's source so that the body of fn begins with stmt.
+func inject(t *testing.T, name string, src []byte, fn, importPath, stmt string) []byte {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, name, src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("failed to parse %s: %v", name, err)
+	}
+
+	var decl *ast.FuncDecl
+	for _, d := range file.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if ok && fd.Name.Name == fn && fd.Body != nil {
+			decl = fd
+			break
+		}
+	}
+	if decl == nil {
+		t.Fatalf("%s declares no func %s to inject into", name, fn)
+	}
+	if !callsWriteFile(decl) {
+		t.Fatalf("%s.%s is not on the output-writing path: nothing in its body calls WriteFile", name, fn)
+	}
+
+	needsImport := true
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err == nil && path == importPath {
+			needsImport = false
+			break
+		}
+	}
+
+	// The body first, because inserting the import ahead of it would move the
+	// offset the statement goes at.
+	at := fset.Position(decl.Body.Lbrace).Offset + 1
+	out := slices.Concat(src[:at], []byte("\n\t"+stmt+"\n"), src[at:])
+	if needsImport {
+		at = fset.Position(file.Name.End()).Offset
+		out = slices.Concat(out[:at], []byte("\n\nimport "+strconv.Quote(importPath)), out[at:])
+	}
+	return out
+}
+
+// callsWriteFile reports whether anything in fn's body calls a WriteFile.
+func callsWriteFile(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return !found
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WriteFile" {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // TestDeterminismCheckSeesAForbiddenReference guards the check against its own

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -97,7 +97,7 @@ func bannedPackages() []string {
 // There is one, internal/telemetry, and the shortness of the list is the
 // point: this is the entire amount by which the over-approximation described
 // at the top of this file has been shrunk. A package earns a place here by
-// being unable to write output at all, which is asserted rather than asserted
+// being unable to write output at all, which is asserted rather than assumed
 // of it — see [TestTheExemptPackageCannotProduceGeneratedOutput] — and not by
 // having a good reason to read a clock.
 func exemptPackages() []string {


### PR DESCRIPTION
Closes #195

The determinism ban in `internal/plugin/determinism_test.go` was absolute: naming
`time.Now` — or `os.Getenv`, or either random — anywhere in the packages the
generators are built from was the finding. Its own comment said why that cost
nothing: "no generator here has a use for one." A generator that opens a span
(#196) has a use for two, because a span is two wall-clock timestamps and an
exporter finds its collector in the environment.

The resolution is **not** a carve-out in `forbiddenFuncs`, which would allow
`time.Now` in the file-writing packages too. What the rule protects is that no
non-reproducible value reaches a generated *byte*; the absolute ban was a cheap
over-approximation of that, and this shrinks it by exactly the amount the new use
requires:

- `bannedPackages()` — this package, `internal/ir` and the three generators, the
  set scanned today, unchanged and still under the absolute ban.
- `exemptPackages()` — `internal/telemetry`, named by **package identity**. Not a
  name pattern, not a build tag, not a comment directive.

## The exemption is checked, not stated

An exemption whose only evidence is the exempt package passing would go on
passing if somebody widened it to the whole repository. Three checks:

- `TestEveryPackageThatCanProduceOutputIsStillUnderTheBan` writes the banned set
  out again as literals, so narrowing the ban takes a change to the test as well
  as to the list the check reads, and requires each banned directory to actually
  hold source (a scan of a directory that is not there passes vacuously).
- `TestTheExemptPackageCannotProduceGeneratedOutput` walks the exempt package's
  module-local import graph and requires that it cannot reach
  `github.com/z5labs/avroc/internal/plugin`, which declares `FileWriter` — that
  the declaration is still here is itself asserted, so the question cannot go on
  being asked about the wrong package. Verified both ways during development:
  exempting `avroc-gen-go` fails on the banned/exempt overlap, and exempting
  `cmd/avroc-gen-go` fails naming the chain
  `internal/avroc-gen-go -> internal/plugin`.
- `TestTheBanStillCatchesNondeterminismOnAGeneratorsOutputPath` copies
  `internal/avroc-gen-go`'s non-test source into a temp directory, injects
  `_ = time.Now()` (and, in the second case, `_ = os.Getenv(...)`) at the top of
  `Generate` — the function that calls `WriteFile` — and requires the check to
  report each finding by name. The injection refuses to run if the target
  function's body no longer calls `WriteFile`, so a restructuring that moves the
  write fails here loudly rather than leaving the case pointed at a function that
  produces no byte.

## Judgment calls

- **Reachability is necessary, not sufficient.** `internal/ir` cannot reach
  `FileWriter` either and its bytes are generated output, so the exempt set could
  not be *derived* from the import graph. It stays an explicit, one-entry list
  with the graph walk as a guard on it. That reasoning is recorded in the file.
- **The import graph is walked by parsing, not by shelling out to `go list`.** The
  check was already a source scan; keeping it one means it needs no toolchain
  beyond the parser and stays the same offline.
- **`nonTestSources` and the scan no longer take `*testing.T`.** `scanPackage(dir)`
  returns findings and an error, which is what lets the negative case run the real
  check over patched source instead of a re-implementation of it.

## Acceptance criteria

- [x] The determinism check distinguishes packages that may produce generated
      bytes (`bannedPackages`) from a named telemetry package that cannot
      (`exemptPackages`).
- [x] The exemption is by explicit package identity — a path in a list — not by
      name pattern, build tag or comment directive.
- [x] The exempt package has no path to `plugin.FileWriter`, asserted by an import
      graph walk that names the chain when it finds one.
- [x] Every package scanned today remains under the absolute ban; `internal/ir`
      and the three generators are unchanged, and the banned set is re-asserted as
      literals.
- [x] A test introduces a clock read into a generator's output-writing path over a
      copy of the source and requires the check to fail, naming the finding.
- [x] The same negative test covers an environment read.
- [x] The rationale — what the rule protects, why the ban was absolute, why the
      exemption is this narrow — is recorded at the top of `determinism_test.go`,
      and `CLAUDE.md`'s Determinism section is updated.
- [x] `TestGenerateIsDeterministic` and the `example/` round trip are unchanged.

## Verification

Every command in `.claude/backlog.json`'s `verify`, from the worktree:

- `go build ./...`
- `gofmt -l .` (empty)
- `go vet ./...`
- `go test -race -cover ./...` — all packages pass; `internal/plugin` 95.1%
- `golangci-lint run` — 0 issues
- the four binaries built, `example/` regenerated, `git diff --exit-code -- example` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)