### PR TITLE
story(gen-go): spans for the phases a generator spends time in

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -222,9 +222,17 @@ func (m *Avroc) IrDescriptorSet() *dagger.File {
 // generator's output must not vary with: the absolute paths in --descriptor and
 // --out, the working directory, the temporary directory, PATH beyond the entry
 // that resolves the generators, the user, the hostname, the locale and the time
-// zone. They agree about SOURCE_DATE_EPOCH, because that one is an input rather
-// than an accident of the machine — a run that varied it would be asking two
-// different questions and calling the difference a bug.
+// zone — and, since #197, whether the run is traced at all. They agree about
+// SOURCE_DATE_EPOCH, because that one is an input rather than an accident of the
+// machine — a run that varied it would be asking two different questions and
+// calling the difference a bug.
+//
+// Tracing is on the list for the same reason as the rest of it and is worth
+// naming separately, because it is the one entry that puts code *inside* the
+// generation loop: #196 makes an invocation a span and #197 makes its phases
+// spans, so the second run opens one between every two writes. Tracing is an
+// observation of a generation and never an input to it, and this is where that
+// sentence is checked over whole processes rather than in one.
 //
 // What this cannot catch is a generator reading the clock: two runs a moment
 // apart agree on the date. internal/plugin.TestNoGeneratorReadsTheClock is the
@@ -399,6 +407,28 @@ type envVar struct {
 // instant itself is arbitrary and fixed — 2024-06-03T00:00:00Z.
 const sourceDateEpoch = "1717372800"
 
+// tracedRunEnv is what makes the second run a traced one: an endpoint, so that
+// avroc builds a real SDK and propagates a span context to every generator it
+// forks, and a TRACEPARENT, so that the run is a child of somebody else's trace
+// exactly as it is under `dagger call`.
+//
+// **Nothing is listening at that endpoint, and that is deliberate.** What is
+// being checked is that a generation which opens spans writes the same bytes as
+// one that does not, and the spans have to be opened for that to mean anything;
+// where they go afterwards is no part of it. A collector container would add a
+// service to the check and a reason for it to fail that has nothing to do with
+// determinism, so the export fails instead — immediately, because the connection
+// is refused on the loopback address rather than timing out, and harmlessly,
+// because internal/telemetry logs a failed export and never fails a build over
+// one. A literal address rather than a name, so that a scratch container with no
+// resolver is not resolving anything.
+func tracedRunEnv() []envVar {
+	return []envVar{
+		{"OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318"},
+		{"TRACEPARENT", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+	}
+}
+
 // firstRun and secondRun disagree about everything else. Where a value has a
 // plausible-looking default, the second run deliberately does not use it: a
 // generator that read HOME and got the same answer both times would pass a
@@ -428,7 +458,7 @@ func secondRun() regenerationRun {
 		// leaked into the output would most plausibly leak as its own text.
 		root: "/srv/a-considerably-longer-project-directory",
 		tmp:  "/var/tmp/second",
-		env: []envVar{
+		env: append([]envVar{
 			{"PATH", "/nonexistent:" + pluginDir + ":/also-nonexistent"},
 			{"TMPDIR", "/var/tmp/second"},
 			{"HOME", "/home/somebody-else"},
@@ -439,7 +469,7 @@ func secondRun() regenerationRun {
 			{"LANG", "en_US.UTF-8"},
 			{"LC_ALL", "en_US.UTF-8"},
 			{"SOURCE_DATE_EPOCH", sourceDateEpoch},
-		},
+		}, tracedRunEnv()...),
 	}
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,10 +346,11 @@ trace of their own.
 generator is slow"; these answer "which part of it".
 `avroc.plugin.descriptor.validate`, `avroc.plugin.options.parse`,
 `avroc.plugin.schema.generate` (one per schema, carrying the schema's
-`ir.SchemaBaseName`), `avroc.plugin.fingerprint` (one per schema, a child of that
-schema's, and the one place `avroc-gen-go` computes over the IR rather than
-walking it) and `avroc.plugin.file.write` (one per file, carrying the path
-relative to `--out`). They are the phases the code already had as functions
+`ir.SchemaBaseName`, and covering everything the generator does for that schema),
+`avroc.plugin.fingerprint` (one per schema, a child of that schema's, and the one
+place `avroc-gen-go` computes over the IR rather than walking it) and
+`avroc.plugin.file.write` (one per file, a child of its schema's, carrying the
+path relative to `--out`). They are the phases the code already had as functions
 rather than a decomposition invented for the trace, which is `internal/avroc`'s
 rule applied on the other side of the fork; and they live in `internal/plugin`
 for `tracerScope`'s reason, that `Main` is the one place all three generators run
@@ -371,7 +372,12 @@ Four things there are decisions.
   `avroc-gen-json` and `avroc-gen-pcf` write one file per schema and do no
   rendering, so they open the per-schema span and nothing finer.
   Instrumentation heavier than the work it measures makes a trace harder to read,
-  not easier.
+  not easier. That is also why the write is *inside* the schema's span rather
+  than beside it: one span name has to mean the same thing in all three, and for
+  the two with no write span of their own a write left outside would put the
+  filesystem time — often the larger half — and the failure on the invocation
+  instead of on the schema they belong to. `avroc-gen-go` loses nothing by it,
+  since its rendering is the difference between the schema's span and the file's.
 - **Off costs nothing per schema and nothing per file.** `startPhase` reads
   `IsRecording` off the invocation's own span and returns immediately when it is
   false — no tracer asked for, no attribute built, no span started — which is why

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,63 @@ repository take the spelling from, `internal/avroc/propagate.go` aliasing them,
 because one misspelling made on one side is a child whose spans quietly start a
 trace of their own.
 
+**A generator's phases are spans under its invocation's** (#197,
+`internal/plugin/trace.go`). An invocation being one span answers "which
+generator is slow"; these answer "which part of it".
+`avroc.plugin.descriptor.validate`, `avroc.plugin.options.parse`,
+`avroc.plugin.schema.generate` (one per schema, carrying the schema's
+`ir.SchemaBaseName`), `avroc.plugin.fingerprint` (one per schema, a child of that
+schema's, and the one place `avroc-gen-go` computes over the IR rather than
+walking it) and `avroc.plugin.file.write` (one per file, carrying the path
+relative to `--out`). They are the phases the code already had as functions
+rather than a decomposition invented for the trace, which is `internal/avroc`'s
+rule applied on the other side of the fork; and they live in `internal/plugin`
+for `tracerScope`'s reason, that `Main` is the one place all three generators run
+through, so it is one set of names and one instrumentation scope instead of
+three.
+
+Four things there are decisions.
+
+- **Cardinality fixes the granularity.** A span per schema and a span per file
+  are bounded by the manifest a person wrote; a span per *type* or per *field*
+  would be bounded by the user's IDL, and a schema with a few thousand fields
+  would produce a trace nobody can open. So anything finer is an attribute on one
+  of these spans and never a span of its own, and
+  `TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema` — in all three
+  generators, over a 500-field record against a one-field one — is what holds
+  that as they grow.
+- **Not every generator opens all of them**, and that is the point.
+  `avroc-gen-go` is the only generator here with enough work in it to have parts;
+  `avroc-gen-json` and `avroc-gen-pcf` write one file per schema and do no
+  rendering, so they open the per-schema span and nothing finer.
+  Instrumentation heavier than the work it measures makes a trace harder to read,
+  not easier.
+- **Off costs nothing per schema and nothing per file.** `startPhase` reads
+  `IsRecording` off the invocation's own span and returns immediately when it is
+  false — no tracer asked for, no attribute built, no span started — which is why
+  every helper takes its attribute as a plain string rather than an
+  `attribute.KeyValue` a call site would build whether or not anything was going
+  to read it, and why each generator derives its base name once and hands the
+  same value to the filename and to the span. The three
+  `TestAnUntracedGenerationStartsNoSpans` assert it against a provider that
+  *counts* rather than one that records, because "nothing was exported" is what a
+  non-recording provider gives for free and the claim is that nothing was
+  started.
+- **The bytes are the same traced or not**, and that is checked at three levels
+  rather than stated: each generator's `TestGenerateIsDeterministic` runs half its
+  repetitions traced and compares them against an untraced run 0,
+  `plugin.TestGeneratedBytesAreTheSameTracedOrNot` does it over a whole `Main`
+  through a decoding collector, and `dagger call regeneration`'s second run now
+  carries a `TRACEPARENT` and an endpoint, so the `example/` round trip itself is
+  a traced generation compared byte for byte against an untraced one. Nothing
+  listens at that endpoint on purpose: the spans have to be *opened* for the
+  comparison to mean anything, and where they go afterwards is no part of it.
+
+`GenerateFunc` grew a `context.Context` for this, which is how the invocation's
+span reaches a generator's phases without anything below `Main` growing a
+`trace.Tracer` parameter to thread through untouched — the provider travels in
+the context, exactly as it does in `internal/avroc`.
+
 ### Determinism
 
 Two runs of a generator over the same descriptor produce byte-identical output

--- a/internal/avroc-gen-go/determinism_test.go
+++ b/internal/avroc-gen-go/determinism_test.go
@@ -7,11 +7,13 @@ package avrocgengo
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/ir"
 
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -39,17 +41,37 @@ func (w *recordingWriter) WriteFile(path string, content []byte) error {
 func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
 	t.Helper()
 
+	return generateFilesIn(t.Context(), t, req)
+}
+
+// generateFilesIn is generateFiles with the context the generation runs under,
+// which is the whole of the difference between a traced run and an untraced one.
+//
+// Tracing is an observation of a generation and never an input to it (#197), so
+// the two have to produce the same bytes; making the context the only variable
+// is what lets one assertion cover both.
+func generateFilesIn(ctx context.Context, t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
 	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}
 
-	var w recordingWriter
-	if err := Generate(req, &w); err != nil {
+	w := &recordingWriter{}
+	if err := Generate(ctx, req, w); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 	return w.files
 }
+
+// tracedRun reports whether run number n is one of the traced ones.
+//
+// Half of them are, so that every repetition below compares a traced run's bytes
+// against an untraced run's: the failure this is aimed at is a span opened
+// between two writes changing what gets written, which no number of untraced
+// repetitions would ever show.
+func tracedRun(n int) bool { return n%2 == 1 }
 
 // assertRepeatedGenerationsAreIdentical runs the same generation repeatedly and
 // requires every run to produce the same files with the same bytes.
@@ -75,7 +97,16 @@ func assertRepeatedGenerationsAreIdentical(t *testing.T, req *avrocpb.GenerateRe
 	}
 
 	for run := 1; run < runs; run++ {
-		again := generateFiles(t, req)
+		ctx := t.Context()
+		var recorder *tracetest.SpanRecorder
+		if tracedRun(run) {
+			ctx, recorder = recordingContext(t)
+		}
+
+		again := generateFilesIn(ctx, t, req)
+		if recorder != nil && len(recorder.Ended()) == 0 {
+			t.Fatal("a traced run recorded no spans, so the comparison against an untraced one is vacuous")
+		}
 		if len(again) != len(first) {
 			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
 		}

--- a/internal/avroc-gen-go/generate.go
+++ b/internal/avroc-gen-go/generate.go
@@ -6,6 +6,7 @@
 package avrocgengo
 
 import (
+	"context"
 	"fmt"
 	"go/format"
 
@@ -26,16 +27,70 @@ import (
 // failure rather than a gap: the exit is non-zero, and avroc discards the whole
 // scratch directory instead of merging it, so no half a package reaches the
 // user's tree.
-func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
+//
+// It is also the generator here with enough work in it to have parts, so it is
+// the one whose phases are spans (#197): the descriptor check, the options, then
+// a span per schema and a span per file. The context carries the invocation's
+// span and nothing here has to know whether anything is listening — see
+// plugin.StartSchemaGenerate and the phases beside it.
+func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 	// The version comes first, before the options and before a single schema is
 	// looked at. A descriptor written against a contract this generator does not
 	// know is not one to read the recognisable parts of, and complaining about a
 	// type is no use to a user whose real problem is a generator that is too old.
-	if err := ir.CheckVersion(req.GetVersion()); err != nil {
+	_, validateSpan := plugin.StartDescriptorValidate(ctx)
+	err := ir.CheckVersion(req.GetVersion())
+	plugin.EndPhase(validateSpan, err)
+	if err != nil {
 		return err
 	}
 
-	var packageName string
+	packageName, singleObject, err := readOptions(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	for _, schema := range req.GetSchemas() {
+		// Once, and before the span: it is the name the file is built from as
+		// well as the name the span carries, so computing it here is what keeps
+		// an untraced generation doing exactly the work it did before.
+		base := ir.SchemaBaseName(schema)
+
+		schemaCtx, schemaSpan := plugin.StartSchemaGenerate(ctx, base)
+		filename, content, err := buildSchemaFile(schemaCtx, packageName, base, schema, singleObject)
+		plugin.EndPhase(schemaSpan, err)
+		if err != nil {
+			return fmt.Errorf("failed to generate schema: %w", err)
+		}
+
+		// The write is a sibling of the rendering and not a child of it, so that
+		// "how long did this schema take to render" and "how long did it take to
+		// write" are two intervals a reader can subtract rather than one that
+		// sometimes contains a filesystem call.
+		_, writeSpan := plugin.StartFileWrite(ctx, filename)
+		err = w.WriteFile(filename, content)
+		plugin.EndPhase(writeSpan, err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// readOptions reads the --opt vocabulary this generator declares, and refuses
+// what it cannot honour.
+//
+// The single-object root check belongs here rather than in the loop below
+// because it is the rest of accepting that option: encoding=single_object over a
+// descriptor this generator cannot give that encoding to is an option it is
+// refusing, and refusing it before the loop is what keeps a package the option
+// had no effect on from being half written. checkSingleObjectRoots' own comment
+// is the long form.
+func readOptions(ctx context.Context, req *avrocpb.GenerateRequest) (packageName string, singleObject bool, err error) {
+	_, span := plugin.StartOptionsParse(ctx)
+	defer func() { plugin.EndPhase(span, err) }()
+
 	var encoding string
 	for _, opt := range req.GetOptions() {
 		switch opt.GetName() {
@@ -46,40 +101,29 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 		}
 	}
 	if packageName == "" {
-		return fmt.Errorf("package_name option is required")
+		return "", false, fmt.Errorf("package_name option is required")
 	}
 
-	singleObject := encoding == "single_object"
+	singleObject = encoding == "single_object"
 	if encoding != "" && !singleObject {
-		return fmt.Errorf("unsupported encoding option: %q (supported: single_object)", encoding)
+		return "", false, fmt.Errorf("unsupported encoding option: %q (supported: single_object)", encoding)
 	}
 
-	// What single-object encoding asks for is checked against every schema
-	// before the loop below writes any of them, so a descriptor this generator
-	// cannot give that encoding to fails the invocation with nothing written
-	// rather than with a package the option had no effect on.
 	if singleObject {
 		if err := checkSingleObjectRoots(req.GetSchemas()); err != nil {
-			return err
+			return "", false, err
 		}
 	}
-
-	for _, schema := range req.Schemas {
-		filename, content, err := buildSchemaFile(packageName, schema, singleObject)
-		if err != nil {
-			return fmt.Errorf("failed to generate schema: %w", err)
-		}
-		if err := w.WriteFile(filename, content); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return packageName, singleObject, nil
 }
 
 // buildSchemaFile generates the Go source for a single schema, returning its
 // relative filename and formatted content.
-func buildSchemaFile(packageName string, schema *avrocpb.Schema, singleObject bool) (string, []byte, error) {
+//
+// base is the schema's base name, computed by the caller because the span it
+// opened is named by it too; deriving it again here would be work an untraced
+// generation had no reason to do.
+func buildSchemaFile(ctx context.Context, packageName, base string, schema *avrocpb.Schema, singleObject bool) (string, []byte, error) {
 	// Refuse a descriptor this generator cannot represent before emitting any
 	// of it. The code builders below cannot report a problem — they append to a
 	// buffer — so a reference whose kind is unrecognised, or which claims to
@@ -89,11 +133,16 @@ func buildSchemaFile(packageName string, schema *avrocpb.Schema, singleObject bo
 		return "", nil, err
 	}
 
-	// Compute fingerprint before code generation if single-object encoding is requested.
+	// Compute fingerprint before code generation if single-object encoding is
+	// requested. It gets a span of its own — the one place this generator
+	// computes over the IR rather than walking it, and the only per-schema cost
+	// here that does not scale with the size of the file being written.
 	var fp [8]byte
 	if singleObject {
+		_, span := plugin.StartFingerprint(ctx)
 		var err error
 		fp, err = schemaFingerprint(schema)
+		plugin.EndPhase(span, err)
 		if err != nil {
 			return "", nil, err
 		}
@@ -103,7 +152,7 @@ func buildSchemaFile(packageName string, schema *avrocpb.Schema, singleObject bo
 	code := generateFileCode(packageName, schema, singleObject, fp)
 
 	// Determine the filename from the schema
-	filename := ir.SnakeCase(ir.SchemaBaseName(schema)) + ".go"
+	filename := ir.SnakeCase(base) + ".go"
 
 	// Format the code using go/format
 	formatted, err := format.Source([]byte(code))

--- a/internal/avroc-gen-go/generate.go
+++ b/internal/avroc-gen-go/generate.go
@@ -57,19 +57,24 @@ func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWr
 		base := ir.SchemaBaseName(schema)
 
 		schemaCtx, schemaSpan := plugin.StartSchemaGenerate(ctx, base)
+
 		filename, content, err := buildSchemaFile(schemaCtx, packageName, base, schema, singleObject)
-		plugin.EndPhase(schemaSpan, err)
 		if err != nil {
+			plugin.EndPhase(schemaSpan, err)
 			return fmt.Errorf("failed to generate schema: %w", err)
 		}
 
-		// The write is a sibling of the rendering and not a child of it, so that
-		// "how long did this schema take to render" and "how long did it take to
-		// write" are two intervals a reader can subtract rather than one that
-		// sometimes contains a filesystem call.
-		_, writeSpan := plugin.StartFileWrite(ctx, filename)
+		// The write is inside the schema's span rather than beside it, so that
+		// the span for a schema covers everything done for that schema whichever
+		// generator opened it — the rendering is still separately readable as the
+		// difference between the two. It carries its own failure and so does the
+		// schema's: a write that failed is a schema this generator did not
+		// produce, and a reader who has collapsed the child should still see it.
+		_, writeSpan := plugin.StartFileWrite(schemaCtx, filename)
 		err = w.WriteFile(filename, content)
 		plugin.EndPhase(writeSpan, err)
+
+		plugin.EndPhase(schemaSpan, err)
 		if err != nil {
 			return err
 		}

--- a/internal/avroc-gen-go/generate_test.go
+++ b/internal/avroc-gen-go/generate_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
 
 	avro "github.com/z5labs/avro-go"
 	"google.golang.org/protobuf/proto"
@@ -465,41 +466,70 @@ func TestGenerate_MultipleTypes(t *testing.T) {
 	}
 }
 
-func TestBuildSchemaFile_Filename(t *testing.T) {
-	schema := &avrocpb.Schema{
-		Namespace: proto.String("com.example"),
-		Type: &avrocpb.Type{
-			Type: &avrocpb.Type_Record{
-				Record: &avrocpb.Record{
-					Name:      proto.String("MyRecord"),
-					Namespace: proto.String("com.example"),
-					FullName:  proto.String("com.example.MyRecord"),
+// TestGeneratedFilenames asserts the name each schema's file is written under.
+//
+// It is asked of a whole generation rather than of the function that renders one
+// schema, because the filename is Generate's: the base name is derived once
+// there and used both for the file and for the span naming that schema's work
+// (#197), so a test that called the renderer would be supplying the answer it
+// was checking.
+//
+// The array root is the case worth having. This generator names the file after
+// what the root is *about*, which for `schema array<Event>;` is the record
+// inside the array and not the namespace's last component — where
+// ir.SchemaBaseName used to land for a root that is not itself a named type.
+func TestGeneratedFilenames(t *testing.T) {
+	testCases := []struct {
+		name   string
+		schema *avrocpb.Schema
+		want   string
+	}{
+		{
+			name: "a record root",
+			schema: &avrocpb.Schema{
+				Namespace: proto.String("com.example"),
+				Type: &avrocpb.Type{
+					Type: &avrocpb.Type_Record{
+						Record: &avrocpb.Record{
+							Name:      proto.String("MyRecord"),
+							Namespace: proto.String("com.example"),
+							FullName:  proto.String("com.example.MyRecord"),
+						},
+					},
 				},
 			},
+			want: "my_record.go",
 		},
+		{name: "an array root", schema: arrayRootSchema(), want: "event.go"},
 	}
 
-	filename, _, err := buildSchemaFile("mypackage", schema, false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
-	if filename != "my_record.go" {
-		t.Errorf("expected my_record.go, got %q", filename)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := generateFiles(t, &avrocpb.GenerateRequest{
+				Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("mypackage")}},
+				Schemas: []*avrocpb.Schema{tc.schema},
+			})
+			if len(files) != 1 {
+				t.Fatalf("the generation produced %d files, want 1", len(files))
+			}
+			if files[0].path != tc.want {
+				t.Errorf("expected %s, got %q", tc.want, files[0].path)
+			}
+		})
 	}
 }
 
-// TestBuildSchemaFile_ArrayRootFilename asserts this generator names the file
-// after what an array root is about rather than after the namespace, which is
-// where ir.SchemaBaseName used to land for a root that is not itself a named
-// type.
-func TestBuildSchemaFile_ArrayRootFilename(t *testing.T) {
-	filename, _, err := buildSchemaFile("mypackage", arrayRootSchema(), false)
+// renderSchema is buildSchemaFile with the base name derived the way Generate
+// derives it, for the tests that are about the source one schema renders to
+// rather than about the name it is written under.
+func renderSchema(t *testing.T, packageName string, schema *avrocpb.Schema) []byte {
+	t.Helper()
+
+	_, content, err := buildSchemaFile(t.Context(), packageName, ir.SchemaBaseName(schema), schema, false)
 	if err != nil {
 		t.Fatalf("buildSchemaFile failed: %v", err)
 	}
-	if filename != "event.go" {
-		t.Errorf("expected event.go, got %q", filename)
-	}
+	return content
 }
 
 // arrayRootSchema is the resolved form of `schema array<Event>;`: the record is

--- a/internal/avroc-gen-go/output_test.go
+++ b/internal/avroc-gen-go/output_test.go
@@ -49,7 +49,7 @@ func generateToDir(t *testing.T, dir string, req *avrocpb.GenerateRequest) (*gen
 	}
 
 	w := plugin.NewOutputDir(dir)
-	if err := Generate(req, w); err != nil {
+	if err := Generate(t.Context(), req, w); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ var errWriteRefused = errors.New("refused")
 // carry on, because a zero exit is the whole of the success signal and avroc
 // would adopt the output directory with the file missing from it.
 func TestGenerateReportsAFailedWrite(t *testing.T) {
-	err := Generate(&avrocpb.GenerateRequest{
+	err := Generate(t.Context(), &avrocpb.GenerateRequest{
 		Version: proto.Int32(ir.Version),
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
 		Schemas: []*avrocpb.Schema{versionTestSchema()},

--- a/internal/avroc-gen-go/singleobject_test.go
+++ b/internal/avroc-gen-go/singleobject_test.go
@@ -90,7 +90,7 @@ func TestSingleObjectEncodingRefusesANonRecordRoot(t *testing.T) {
 			dir := t.TempDir()
 			w := plugin.NewOutputDir(dir)
 
-			err := Generate(singleObjectRequest(&avrocpb.Schema{
+			err := Generate(t.Context(), singleObjectRequest(&avrocpb.Schema{
 				Namespace: proto.String("com.example"),
 				Type:      tc.root,
 			}), w)
@@ -117,7 +117,7 @@ func TestSingleObjectEncodingRefusesBeforeWritingAnyFile(t *testing.T) {
 	dir := t.TempDir()
 	w := plugin.NewOutputDir(dir)
 
-	err := Generate(singleObjectRequest(
+	err := Generate(t.Context(), singleObjectRequest(
 		&avrocpb.Schema{Namespace: proto.String("com.example"), Type: eventRecord()},
 		&avrocpb.Schema{
 			Namespace: proto.String("com.example"),
@@ -144,7 +144,7 @@ func TestSingleObjectEncodingReportsARootOutsideTheClosedSet(t *testing.T) {
 	dir := t.TempDir()
 	w := plugin.NewOutputDir(dir)
 
-	err := Generate(singleObjectRequest(&avrocpb.Schema{Namespace: proto.String("com.example")}), w)
+	err := Generate(t.Context(), singleObjectRequest(&avrocpb.Schema{Namespace: proto.String("com.example")}), w)
 	if err == nil {
 		t.Fatal("Generate accepted a schema carrying no root type")
 	}
@@ -160,7 +160,7 @@ func TestSingleObjectEncodingAcceptsARecordRoot(t *testing.T) {
 	dir := t.TempDir()
 	w := plugin.NewOutputDir(dir)
 
-	if err := Generate(singleObjectRequest(&avrocpb.Schema{
+	if err := Generate(t.Context(), singleObjectRequest(&avrocpb.Schema{
 		Namespace: proto.String("com.example"),
 		Type:      eventRecord(),
 	}), w); err != nil {
@@ -186,7 +186,7 @@ func TestANonRecordRootGeneratesWithoutSingleObjectEncoding(t *testing.T) {
 	dir := t.TempDir()
 	w := plugin.NewOutputDir(dir)
 
-	err := Generate(&avrocpb.GenerateRequest{
+	err := Generate(t.Context(), &avrocpb.GenerateRequest{
 		Version: proto.Int32(ir.Version),
 		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
 		Schemas: []*avrocpb.Schema{{

--- a/internal/avroc-gen-go/stream_test.go
+++ b/internal/avroc-gen-go/stream_test.go
@@ -18,10 +18,7 @@ import (
 // says the file it describes is a stream of Event, and what this generator used
 // to emit for it was Event and nothing else.
 func TestAnArrayRootGeneratesAStreamingReader(t *testing.T) {
-	_, content, err := buildSchemaFile("stream", arrayRootSchema(), false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
+	content := renderSchema(t, "stream", arrayRootSchema())
 	code := string(content)
 	validateGoSyntax(t, code)
 
@@ -57,10 +54,7 @@ func TestAnArrayRootGeneratesAStreamingReader(t *testing.T) {
 // or a generated test of it for a negative one, would be a second
 // implementation of the framing to keep correct — one copy per schema.
 func TestTheStreamingReaderReimplementsNoBlockFraming(t *testing.T) {
-	_, content, err := buildSchemaFile("stream", arrayRootSchema(), false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
+	content := renderSchema(t, "stream", arrayRootSchema())
 
 	// Everything the reader does with the stream, it does through these.
 	stream := streamSection(t, string(content), "type EventReader struct", "type EventWriter struct")
@@ -105,10 +99,7 @@ func streamSection(t *testing.T, code, marker, end string) string {
 // stream nothing can produce is a stream, and what this generator used to emit
 // for an array root took a []Event that already existed.
 func TestAnArrayRootGeneratesAStreamingWriter(t *testing.T) {
-	_, content, err := buildSchemaFile("stream", arrayRootSchema(), false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
+	content := renderSchema(t, "stream", arrayRootSchema())
 	code := string(content)
 	validateGoSyntax(t, code)
 
@@ -141,10 +132,7 @@ func TestAnArrayRootGeneratesAStreamingWriter(t *testing.T) {
 // forces, and the zero-count block that terminates the array are all
 // type-independent, so all of them stay in avro-go.
 func TestTheStreamingWriterReimplementsNoBlockFraming(t *testing.T) {
-	_, content, err := buildSchemaFile("stream", arrayRootSchema(), false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
+	content := renderSchema(t, "stream", arrayRootSchema())
 
 	writer := streamSection(t, string(content), "type EventWriter struct", "")
 	for _, allowed := range []string{
@@ -176,10 +164,7 @@ func TestTheStreamingWriterReimplementsNoBlockFraming(t *testing.T) {
 // avro-go's options through, which is what keeps the default unsized and the
 // buffer bound the caller's to set.
 func TestTheStreamingWriterDoesNotChooseTheBlockMode(t *testing.T) {
-	_, content, err := buildSchemaFile("stream", arrayRootSchema(), false)
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
+	content := renderSchema(t, "stream", arrayRootSchema())
 
 	writer := streamSection(t, string(content), "type EventWriter struct", "")
 	if !strings.Contains(writer, "opts ...avro.ArrayWriterOption") {
@@ -308,10 +293,7 @@ func TestOnlyAnArrayRootGeneratesAStreamingReader(t *testing.T) {
 				t.Errorf("streamReaderFor produced a reader: %t, want %t", got, tc.want)
 			}
 
-			_, content, err := buildSchemaFile("stream", tc.schema, false)
-			if err != nil {
-				t.Fatalf("buildSchemaFile failed: %v", err)
-			}
+			content := renderSchema(t, "stream", tc.schema)
 			code := string(content)
 			validateGoSyntax(t, code)
 

--- a/internal/avroc-gen-go/trace_test.go
+++ b/internal/avroc-gen-go/trace_test.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgengo
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/proto"
+)
+
+// The span names this generator's phases are expected to have, written out as
+// literals rather than taken from internal/plugin's constants.
+//
+// It is the same discipline `dagger call tag-scheme` keeps: a check that reads
+// the constant it is checking moves with it, so renaming a span would go on
+// passing here while every dashboard built on the old name broke silently.
+const (
+	spanInvocation         = "avroc.plugin.generate"
+	spanDescriptorValidate = "avroc.plugin.descriptor.validate"
+	spanOptionsParse       = "avroc.plugin.options.parse"
+	spanSchemaGenerate     = "avroc.plugin.schema.generate"
+	spanFingerprint        = "avroc.plugin.fingerprint"
+	spanFileWrite          = "avroc.plugin.file.write"
+)
+
+// The attributes they carry, on the same terms.
+const (
+	attrSchema = "schema"
+	attrPath   = "path"
+)
+
+// recordingContext is what plugin.Main hands Generate on a traced invocation: a
+// context carrying the invocation's own span, from a provider whose spans the
+// test reads back once they have ended.
+//
+// The SDK rather than a fake, because what is being asserted is what a collector
+// would receive — the parentage and the attributes are things the SDK computes,
+// and a fake tracer would only assert that this package called itself.
+//
+// The invocation span is ended by a cleanup rather than here, so that Generate
+// runs inside it exactly as it does under plugin.Main. Nothing this test reads
+// includes it: [tracetest.SpanRecorder.Ended] holds the spans that have ended,
+// and the invocation's ends after the assertions.
+func recordingContext(t *testing.T) (context.Context, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(t.Context(), spanInvocation)
+	t.Cleanup(func() { span.End() })
+	return ctx, recorder
+}
+
+// spansNamed is every recorded span of that name.
+func spansNamed(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var found []sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if span.Name() == name {
+			found = append(found, span)
+		}
+	}
+	return found
+}
+
+// recordedNames is every span a generation ended, in order, for a failure
+// message that shows what was there instead.
+func recordedNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name())
+	}
+	return names
+}
+
+// stringAttr reads one string attribute off a span, failing when it is absent:
+// an attribute this generator promises to set and did not is the finding, not a
+// zero value to compare against.
+func stringAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) string {
+	t.Helper()
+
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	t.Fatalf("span %q carries no %q attribute: %v", span.Name(), key, span.Attributes())
+	return ""
+}
+
+// TestAGenerationsPhasesAreSpansUnderTheInvocations is #197 for this generator:
+// the invocation span answers which generator was slow, and these answer which
+// part of it.
+func TestAGenerationsPhasesAreSpansUnderTheInvocations(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	req := &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{
+			{Name: proto.String("encoding"), Value: proto.String("single_object")},
+			{Name: proto.String("package_name"), Value: proto.String("avro")},
+		},
+		Schemas: determinismSchemas(),
+	}
+	schemas := len(req.GetSchemas())
+
+	var w recordingWriter
+	if err := Generate(ctx, req, &w); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	spans := recorder.Ended()
+
+	// The descriptor and the options are properties of the request, so they
+	// happen once however many schemas it carries.
+	for _, name := range []string{spanDescriptorValidate, spanOptionsParse} {
+		if got := len(spansNamed(spans, name)); got != 1 {
+			t.Errorf("the generation opened %d %q spans, want 1: %v", got, name, recordedNames(spans))
+		}
+	}
+
+	// One per schema, named by the schema's base name — the same name the file
+	// it produced is built from, which is what makes the trace readable beside
+	// the output directory.
+	schemaSpans := spansNamed(spans, spanSchemaGenerate)
+	if len(schemaSpans) != schemas {
+		t.Fatalf("the generation opened %d %q spans over %d schemas: %v",
+			len(schemaSpans), spanSchemaGenerate, schemas, recordedNames(spans))
+	}
+	for i, span := range schemaSpans {
+		want := ir.SchemaBaseName(req.GetSchemas()[i])
+		if got := stringAttr(t, span, attrSchema); got != want {
+			t.Errorf("%s = %q on span %d, want %q", attrSchema, got, i, want)
+		}
+	}
+
+	// One per schema again, and a child of that schema's span rather than a
+	// sibling: the fingerprint is part of rendering the schema and is separated
+	// out only because it is the one place this generator computes over the IR.
+	fingerprints := spansNamed(spans, spanFingerprint)
+	if len(fingerprints) != schemas {
+		t.Fatalf("the generation opened %d %q spans over %d schemas: %v",
+			len(fingerprints), spanFingerprint, schemas, recordedNames(spans))
+	}
+	for i, span := range fingerprints {
+		if span.Parent().SpanID() != schemaSpans[i].SpanContext().SpanID() {
+			t.Errorf("the %q span is not a child of the %q span it belongs to", spanFingerprint, spanSchemaGenerate)
+		}
+	}
+
+	// One per file, named by the path relative to --out, which is the only form
+	// of the path that means anything: the absolute one is a scratch directory
+	// avroc made for this invocation alone.
+	writes := spansNamed(spans, spanFileWrite)
+	if len(writes) != len(w.files) {
+		t.Fatalf("the generation opened %d %q spans and wrote %d files: %v",
+			len(writes), spanFileWrite, len(w.files), recordedNames(spans))
+	}
+	for i, span := range writes {
+		if got, want := stringAttr(t, span, attrPath), w.files[i].path; got != want {
+			t.Errorf("%s = %q on span %d, want %q", attrPath, got, i, want)
+		}
+	}
+
+	// Every phase is a child of the invocation, directly or through the schema
+	// it belongs to, so a trace of a whole run nests generators under avroc.
+	for _, span := range spans {
+		if !span.Parent().IsValid() {
+			t.Errorf("the %q span has no parent, so it started a trace of its own", span.Name())
+		}
+	}
+}
+
+// TestAFailedPhaseCarriesItsFailure: a phase that failed is the phase the
+// invocation failed in, and the span is where that is recorded — the exit status
+// on the invocation's own span says only that something went wrong.
+func TestAFailedPhaseCarriesItsFailure(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: determinismSchemas(),
+	}, &recordingWriter{})
+	if err == nil {
+		t.Fatal("Generate accepted a descriptor with no package_name option")
+	}
+
+	spans := spansNamed(recorder.Ended(), spanOptionsParse)
+	if len(spans) != 1 {
+		t.Fatalf("the generation opened %d %q spans, want 1", len(spans), spanOptionsParse)
+	}
+	if spans[0].Status().Code != codes.Error {
+		t.Errorf("the %q span is not marked failed: %v", spanOptionsParse, spans[0].Status())
+	}
+	if len(spans[0].Events()) == 0 {
+		t.Errorf("the %q span records no error", spanOptionsParse)
+	}
+}
+
+// TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema is the cardinality
+// rule, and it is the reason the granularity stops where it does.
+//
+// A span per schema and a span per file are bounded by the manifest, which a
+// person wrote. A span per type or per field would be bounded by the IDL, and a
+// schema with a few thousand fields would produce a trace nobody can open — so
+// anything finer than a schema or a file is an attribute rather than a span, and
+// this is what notices the day that stops being true.
+func TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema(t *testing.T) {
+	names := func(t *testing.T, fields int) []string {
+		t.Helper()
+
+		ctx, recorder := recordingContext(t)
+		err := Generate(ctx, &avrocpb.GenerateRequest{
+			Version: proto.Int32(ir.Version),
+			Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+			Schemas: []*avrocpb.Schema{wideSchema(fields)},
+		}, &recordingWriter{})
+		if err != nil {
+			t.Fatalf("Generate over a %d-field schema failed: %v", fields, err)
+		}
+
+		got := recordedNames(recorder.Ended())
+		slices.Sort(got)
+		return got
+	}
+
+	narrow := names(t, 1)
+	wide := names(t, 500)
+
+	if len(narrow) == 0 {
+		t.Fatal("a generation opened no spans at all, so the comparison is vacuous")
+	}
+	if !slices.Equal(narrow, wide) {
+		t.Errorf("a 500-field schema produced %v and a 1-field schema produced %v: the span count follows the IDL",
+			wide, narrow)
+	}
+}
+
+// TestAnUntracedGenerationStartsNoSpans is the other half of the cardinality
+// rule and the one that costs nothing to get wrong quietly: almost every
+// invocation of this generator has no collector anywhere near it, and it must
+// pay nothing per schema and nothing per file for instrumentation nobody is
+// reading.
+//
+// The provider counts rather than records, because "no span was exported" is
+// what a non-recording provider gives you for free — what is being asserted is
+// that none was *started*, and that no tracer was even asked for.
+func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
+	counter := &spanCounter{}
+	ctx := oteltrace.ContextWithSpan(t.Context(), untracedSpan{provider: counter})
+
+	var w recordingWriter
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{
+			{Name: proto.String("encoding"), Value: proto.String("single_object")},
+			{Name: proto.String("package_name"), Value: proto.String("avro")},
+		},
+		Schemas: determinismSchemas(),
+	}, &w)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if len(w.files) == 0 {
+		t.Fatal("the generation wrote no files, so it proves nothing about the work per file")
+	}
+
+	if counter.tracers != 0 {
+		t.Errorf("an untraced generation asked for %d tracers, want 0", counter.tracers)
+	}
+	if counter.starts != 0 {
+		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// wideSchema is one record with as many fields as asked for, which is the input
+// the cardinality rule is about: it is the user's IDL that decides this number,
+// and nothing bounded by it may become a span.
+func wideSchema(fields int) *avrocpb.Schema {
+	const ns = "com.example"
+
+	record := &avrocpb.Record{
+		Name:      proto.String("Wide"),
+		Namespace: proto.String(ns),
+		FullName:  proto.String(ns + ".Wide"),
+	}
+	for i := range fields {
+		record.Fields = append(record.Fields, &avrocpb.Field{
+			Name: proto.String(fmt.Sprintf("field%d", i)),
+			Type: primType("string"),
+		})
+	}
+
+	return &avrocpb.Schema{
+		Namespace: proto.String(ns),
+		Type:      &avrocpb.Type{Type: &avrocpb.Type_Record{Record: record}},
+	}
+}
+
+// spanCounter is a tracer provider that starts no spans and counts every
+// request for one.
+type spanCounter struct {
+	embedded.TracerProvider
+
+	tracers int
+	starts  int
+}
+
+func (p *spanCounter) Tracer(string, ...oteltrace.TracerOption) oteltrace.Tracer {
+	p.tracers++
+	return countingTracer{provider: p}
+}
+
+type countingTracer struct {
+	embedded.Tracer
+
+	provider *spanCounter
+}
+
+func (t countingTracer) Start(ctx context.Context, _ string, _ ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	t.provider.starts++
+	return ctx, noop.Span{}
+}
+
+// untracedSpan is the span an untraced invocation carries: not recording, which
+// is exactly what a no-op provider hands plugin.Main when there is no
+// TRACEPARENT and no endpoint. It differs from noop.Span in one way, which is
+// that it names a provider the test can count through — so a generator that
+// asked for a tracer anyway is caught rather than silently satisfied.
+type untracedSpan struct {
+	noop.Span
+
+	provider *spanCounter
+}
+
+func (s untracedSpan) TracerProvider() oteltrace.TracerProvider { return s.provider }

--- a/internal/avroc-gen-go/trace_test.go
+++ b/internal/avroc-gen-go/trace_test.go
@@ -165,6 +165,12 @@ func TestAGenerationsPhasesAreSpansUnderTheInvocations(t *testing.T) {
 	// One per file, named by the path relative to --out, which is the only form
 	// of the path that means anything: the absolute one is a scratch directory
 	// avroc made for this invocation alone.
+	//
+	// A child of its schema's span rather than a sibling, so that the span for a
+	// schema covers everything done for that schema — which is what the two
+	// generators with no write span of their own rely on, and what keeps one span
+	// name comparable across all three. The rendering is still separately
+	// readable, as the difference between the two.
 	writes := spansNamed(spans, spanFileWrite)
 	if len(writes) != len(w.files) {
 		t.Fatalf("the generation opened %d %q spans and wrote %d files: %v",
@@ -173,6 +179,10 @@ func TestAGenerationsPhasesAreSpansUnderTheInvocations(t *testing.T) {
 	for i, span := range writes {
 		if got, want := stringAttr(t, span, attrPath), w.files[i].path; got != want {
 			t.Errorf("%s = %q on span %d, want %q", attrPath, got, i, want)
+		}
+		if span.Parent().SpanID() != schemaSpans[i].SpanContext().SpanID() {
+			t.Errorf("the %q span for %q is not a child of the %q span it belongs to",
+				spanFileWrite, w.files[i].path, spanSchemaGenerate)
 		}
 	}
 
@@ -284,6 +294,36 @@ func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
 	}
 	if counter.starts != 0 {
 		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// TestAFailedWriteFailsTheSchemasSpanToo is why the write is inside the
+// schema's span rather than beside it.
+//
+// A file this generator could not write is a schema it did not produce, so the
+// failure belongs on the span for that schema as well as on the span for the
+// write — a reader who has collapsed the children, or a backend that only counts
+// failed spans per schema, would otherwise see a schema that went fine.
+func TestAFailedWriteFailsTheSchemasSpanToo(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("avro")}},
+		Schemas: determinismSchemas(),
+	}, failingWriter{})
+	if err == nil {
+		t.Fatal("Generate ignored a writer that refuses every file")
+	}
+
+	for _, name := range []string{spanFileWrite, spanSchemaGenerate} {
+		spans := spansNamed(recorder.Ended(), name)
+		if len(spans) == 0 {
+			t.Fatalf("the generation opened no %q span", name)
+		}
+		if spans[0].Status().Code != codes.Error {
+			t.Errorf("the %q span is not marked failed: %v", name, spans[0].Status())
+		}
 	}
 }
 

--- a/internal/avroc-gen-go/version_test.go
+++ b/internal/avroc-gen-go/version_test.go
@@ -37,7 +37,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 			// a valid version onto a request that carries none, which is the
 			// one thing this test needs left alone.
 			w := plugin.NewOutputDir(t.TempDir())
-			err := Generate(&avrocpb.GenerateRequest{
+			err := Generate(t.Context(), &avrocpb.GenerateRequest{
 				Version: tc.version,
 				Options: []*avrocpb.Option{{Name: proto.String("package_name"), Value: proto.String("gen")}},
 				Schemas: []*avrocpb.Schema{versionTestSchema()},

--- a/internal/avroc-gen-json/determinism_test.go
+++ b/internal/avroc-gen-json/determinism_test.go
@@ -7,11 +7,13 @@ package avrocgenjson
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/ir"
 
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -40,17 +42,37 @@ func (w *recordingWriter) WriteFile(path string, content []byte) error {
 func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
 	t.Helper()
 
+	return generateFilesIn(t.Context(), t, req)
+}
+
+// generateFilesIn is generateFiles with the context the generation runs under,
+// which is the whole of the difference between a traced run and an untraced one.
+//
+// Tracing is an observation of a generation and never an input to it (#197), so
+// the two have to produce the same bytes; making the context the only variable
+// is what lets one assertion cover both.
+func generateFilesIn(ctx context.Context, t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
 	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}
 
 	w := &recordingWriter{}
-	if err := Generate(req, w); err != nil {
+	if err := Generate(ctx, req, w); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 	return w.files
 }
+
+// tracedRun reports whether run number n is one of the traced ones.
+//
+// Half of them are, so that every repetition below compares a traced run's bytes
+// against an untraced run's: the failure this is aimed at is a span opened
+// between two writes changing what gets written, which no number of untraced
+// repetitions would ever show.
+func tracedRun(n int) bool { return n%2 == 1 }
 
 // TestGenerateIsDeterministic is #120's dynamic half for this generator: the
 // same descriptor produces the same set of paths with byte-identical contents,
@@ -80,7 +102,16 @@ func TestGenerateIsDeterministic(t *testing.T) {
 	}
 
 	for run := 1; run < runs; run++ {
-		again := generateFiles(t, req)
+		ctx := t.Context()
+		var recorder *tracetest.SpanRecorder
+		if tracedRun(run) {
+			ctx, recorder = recordingContext(t)
+		}
+
+		again := generateFilesIn(ctx, t, req)
+		if recorder != nil && len(recorder.Ended()) == 0 {
+			t.Fatal("a traced run recorded no spans, so the comparison against an untraced one is vacuous")
+		}
 		if len(again) != len(first) {
 			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
 		}

--- a/internal/avroc-gen-json/generate.go
+++ b/internal/avroc-gen-json/generate.go
@@ -47,18 +47,28 @@ func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWr
 		base := ir.SchemaBaseName(schema)
 
 		_, span := plugin.StartSchemaGenerate(ctx, base)
-		content, err := buildSchemaFile(schema)
+		err := emitSchema(schema, ir.SnakeCase(base)+".avsc", w)
 		plugin.EndPhase(span, err)
 		if err != nil {
-			return fmt.Errorf("failed to generate schema: %w", err)
-		}
-
-		if err := w.WriteFile(ir.SnakeCase(base)+".avsc", content); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// emitSchema renders one schema and writes it, which is the whole of what this
+// generator does for a schema and therefore the whole of what that schema's span
+// covers. Splitting the write out would be the finer granularity there is not
+// enough work here to justify, and leaving it outside the span would put the
+// filesystem time — often the larger half — on the invocation instead of on the
+// schema it belongs to.
+func emitSchema(schema *avrocpb.Schema, filename string, w plugin.FileWriter) error {
+	content, err := buildSchemaFile(schema)
+	if err != nil {
+		return fmt.Errorf("failed to generate schema: %w", err)
+	}
+	return w.WriteFile(filename, content)
 }
 
 // buildSchemaFile generates the Avro JSON schema for a single schema, returning

--- a/internal/avroc-gen-json/generate.go
+++ b/internal/avroc-gen-json/generate.go
@@ -6,6 +6,7 @@
 package avrocgenjson
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -26,7 +27,13 @@ import (
 // failure rather than a gap: the exit is non-zero, and avroc discards the whole
 // scratch directory instead of merging it, so no half a set of schemas reaches
 // the user's tree.
-func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
+//
+// One span per schema and nothing finer (#197). This generator writes one file
+// per schema and has no rendering to speak of, so a span for the descriptor
+// check or for the write would be more instrumentation than there is work, and a
+// trace carrying it would be harder to read rather than easier — avroc-gen-go is
+// where the finer phases are.
+func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 	// The version comes first, before a single schema is looked at. A descriptor
 	// written against a contract this generator does not know is not one to read
 	// the recognisable parts of.
@@ -34,12 +41,19 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 		return err
 	}
 
-	for _, schema := range req.Schemas {
-		filename, content, err := buildSchemaFile(schema)
+	for _, schema := range req.GetSchemas() {
+		// Once, and before the span: it is the name the file is built from as
+		// well as the name the span carries.
+		base := ir.SchemaBaseName(schema)
+
+		_, span := plugin.StartSchemaGenerate(ctx, base)
+		content, err := buildSchemaFile(schema)
+		plugin.EndPhase(span, err)
 		if err != nil {
 			return fmt.Errorf("failed to generate schema: %w", err)
 		}
-		if err := w.WriteFile(filename, content); err != nil {
+
+		if err := w.WriteFile(ir.SnakeCase(base)+".avsc", content); err != nil {
 			return err
 		}
 	}
@@ -48,23 +62,24 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 }
 
 // buildSchemaFile generates the Avro JSON schema for a single schema, returning
-// its relative filename and content.
-func buildSchemaFile(schema *avrocpb.Schema) (string, []byte, error) {
+// its content. The filename is the caller's, built from the base name the span
+// it opened is named by.
+func buildSchemaFile(schema *avrocpb.Schema) ([]byte, error) {
 	if err := ir.Validate(schema); err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	jsonSchema, err := schemaToJSON(schema)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	data, err := json.MarshalIndent(jsonSchema, "", "  ")
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to marshal JSON schema: %w", err)
+		return nil, fmt.Errorf("failed to marshal JSON schema: %w", err)
 	}
 
-	return ir.SnakeCase(ir.SchemaBaseName(schema)) + ".avsc", append(data, '\n'), nil
+	return append(data, '\n'), nil
 }
 
 // avroRecord represents an Avro record type in JSON schema format.

--- a/internal/avroc-gen-json/generate_test.go
+++ b/internal/avroc-gen-json/generate_test.go
@@ -523,27 +523,40 @@ func TestGenerate_RecordWithAliases(t *testing.T) {
 	}
 }
 
-func TestBuildSchemaFile_Filename(t *testing.T) {
-	filename, _, err := buildSchemaFile(resolvedTestRecord())
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
+// TestGeneratedFilenames asserts the name each schema's file is written under.
+//
+// It is asked of a whole generation rather than of the function that renders one
+// schema, because the filename is Generate's: the base name is derived once
+// there and used both for the file and for the span naming that schema's work
+// (#197), so a test that called the renderer would be asserting about a
+// derivation nothing performs any more.
+//
+// The array root is the case worth having. This generator names the file after
+// what the root is *about*, which for `schema array<Event>;` is the record
+// inside the array and not the namespace's last component — where
+// ir.SchemaBaseName used to land for a root that is not itself a named type.
+func TestGeneratedFilenames(t *testing.T) {
+	testCases := []struct {
+		name   string
+		schema *avrocpb.Schema
+		want   string
+	}{
+		{name: "a record root", schema: resolvedTestRecord(), want: "test_record.avsc"},
+		{name: "an array root", schema: arrayRootSchema(), want: "event.avsc"},
 	}
-	if filename != "test_record.avsc" {
-		t.Errorf("expected test_record.avsc, got %q", filename)
-	}
-}
 
-// TestBuildSchemaFile_ArrayRootFilename asserts this generator names the file
-// after what an array root is about rather than after the namespace, which is
-// where ir.SchemaBaseName used to land for a root that is not itself a named
-// type.
-func TestBuildSchemaFile_ArrayRootFilename(t *testing.T) {
-	filename, _, err := buildSchemaFile(arrayRootSchema())
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
-	if filename != "event.avsc" {
-		t.Errorf("expected event.avsc, got %q", filename)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := generateFiles(t, &avrocpb.GenerateRequest{
+				Schemas: []*avrocpb.Schema{tc.schema},
+			})
+			if len(files) != 1 {
+				t.Fatalf("the generation produced %d files, want 1", len(files))
+			}
+			if files[0].path != tc.want {
+				t.Errorf("expected %s, got %q", tc.want, files[0].path)
+			}
+		})
 	}
 }
 

--- a/internal/avroc-gen-json/output_test.go
+++ b/internal/avroc-gen-json/output_test.go
@@ -49,7 +49,7 @@ func generateToDir(t *testing.T, dir string, req *avrocpb.GenerateRequest) (*gen
 	}
 
 	w := plugin.NewOutputDir(dir)
-	if err := Generate(req, w); err != nil {
+	if err := Generate(t.Context(), req, w); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ var errWriteRefused = errors.New("refused")
 // carry on, because a zero exit is the whole of the success signal and avroc
 // would adopt the output directory with the file missing from it.
 func TestGenerateReportsAFailedWrite(t *testing.T) {
-	err := Generate(&avrocpb.GenerateRequest{
+	err := Generate(t.Context(), &avrocpb.GenerateRequest{
 		Version: proto.Int32(ir.Version),
 		Schemas: []*avrocpb.Schema{versionTestSchema()},
 	}, failingWriter{})

--- a/internal/avroc-gen-json/trace_test.go
+++ b/internal/avroc-gen-json/trace_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/ir"
 
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -175,6 +176,33 @@ func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
 	}
 	if counter.starts != 0 {
 		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// TestAFailedWriteFailsTheSchemasSpan is why the write is inside the schema's
+// span rather than after it.
+//
+// This generator opens no span of its own for the write, so a write left outside
+// would put both the filesystem time and the failure on the invocation rather
+// than on the schema they belong to — and a schema whose file was never written
+// would read as a schema that went fine.
+func TestAFailedWriteFailsTheSchemasSpan(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord()},
+	}, failingWriter{})
+	if err == nil {
+		t.Fatal("Generate ignored a writer that refuses every file")
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("the generation opened %d spans, want 1: %v", len(spans), recordedNames(spans))
+	}
+	if spans[0].Status().Code != codes.Error {
+		t.Errorf("the %q span is not marked failed: %v", spans[0].Name(), spans[0].Status())
 	}
 }
 

--- a/internal/avroc-gen-json/trace_test.go
+++ b/internal/avroc-gen-json/trace_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenjson
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/proto"
+)
+
+// The span names this generator is expected to open, written out as literals
+// rather than taken from internal/plugin's constants: a check that reads the
+// constant it is checking moves with it, and a renamed span would go on passing
+// here while every dashboard built on the old name broke silently.
+const (
+	spanInvocation     = "avroc.plugin.generate"
+	spanSchemaGenerate = "avroc.plugin.schema.generate"
+)
+
+// attrSchema is the attribute the per-schema span carries, on the same terms.
+const attrSchema = "schema"
+
+// recordingContext is what plugin.Main hands Generate on a traced invocation: a
+// context carrying the invocation's own span, from a provider whose spans the
+// test reads back once they have ended.
+//
+// The invocation span is ended by a cleanup rather than here, so that Generate
+// runs inside it exactly as it does under plugin.Main, and nothing read before
+// the test returns includes it.
+func recordingContext(t *testing.T) (context.Context, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(t.Context(), spanInvocation)
+	t.Cleanup(func() { span.End() })
+	return ctx, recorder
+}
+
+// recordedNames is every span a generation ended, in order.
+func recordedNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name())
+	}
+	return names
+}
+
+// stringAttr reads one string attribute off a span, failing when it is absent.
+func stringAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) string {
+	t.Helper()
+
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	t.Fatalf("span %q carries no %q attribute: %v", span.Name(), key, span.Attributes())
+	return ""
+}
+
+// TestEverySchemaIsOneSpanAndNothingFiner is #197 for this generator, and the
+// "nothing finer" is the substance of it.
+//
+// avroc-gen-json writes one file per schema and does no rendering to speak of,
+// so a span for the descriptor check, for the options it does not have, or for a
+// write it performs in one call would be more instrumentation than there is work
+// — and a trace carrying it would be harder to read rather than easier.
+// avroc-gen-go is where the finer phases belong.
+func TestEverySchemaIsOneSpanAndNothingFiner(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	req := &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}
+
+	var w recordingWriter
+	if err := Generate(ctx, req, &w); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != len(req.GetSchemas()) {
+		t.Fatalf("the generation opened %d spans over %d schemas: %v",
+			len(spans), len(req.GetSchemas()), recordedNames(spans))
+	}
+	for i, span := range spans {
+		if span.Name() != spanSchemaGenerate {
+			t.Errorf("span %d is named %q, want %q", i, span.Name(), spanSchemaGenerate)
+			continue
+		}
+		if got, want := stringAttr(t, span, attrSchema), ir.SchemaBaseName(req.GetSchemas()[i]); got != want {
+			t.Errorf("%s = %q on span %d, want %q", attrSchema, got, i, want)
+		}
+		if !span.Parent().IsValid() {
+			t.Errorf("span %d has no parent, so it started a trace of its own", i)
+		}
+	}
+}
+
+// TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema is the cardinality
+// rule: a span per schema is bounded by the manifest a person wrote, and a span
+// per type or per field would be bounded by the user's IDL, where a few thousand
+// fields would produce a trace nobody can open.
+func TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema(t *testing.T) {
+	names := func(t *testing.T, fields int) []string {
+		t.Helper()
+
+		ctx, recorder := recordingContext(t)
+		err := Generate(ctx, &avrocpb.GenerateRequest{
+			Version: proto.Int32(ir.Version),
+			Schemas: []*avrocpb.Schema{wideSchema(fields)},
+		}, &recordingWriter{})
+		if err != nil {
+			t.Fatalf("Generate over a %d-field schema failed: %v", fields, err)
+		}
+
+		got := recordedNames(recorder.Ended())
+		slices.Sort(got)
+		return got
+	}
+
+	narrow := names(t, 1)
+	wide := names(t, 500)
+
+	if len(narrow) == 0 {
+		t.Fatal("a generation opened no spans at all, so the comparison is vacuous")
+	}
+	if !slices.Equal(narrow, wide) {
+		t.Errorf("a 500-field schema produced %v and a 1-field schema produced %v: the span count follows the IDL",
+			wide, narrow)
+	}
+}
+
+// TestAnUntracedGenerationStartsNoSpans: almost every invocation of this
+// generator has no collector anywhere near it, and it must pay nothing per
+// schema for instrumentation nobody is reading.
+//
+// The provider counts rather than records, because "no span was exported" is
+// what a non-recording provider gives for free — what is asserted here is that
+// none was started, and that no tracer was even asked for.
+func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
+	counter := &spanCounter{}
+	ctx := oteltrace.ContextWithSpan(t.Context(), untracedSpan{provider: counter})
+
+	var w recordingWriter
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}, &w)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if len(w.files) == 0 {
+		t.Fatal("the generation wrote no files, so it proves nothing about the work per schema")
+	}
+
+	if counter.tracers != 0 {
+		t.Errorf("an untraced generation asked for %d tracers, want 0", counter.tracers)
+	}
+	if counter.starts != 0 {
+		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// wideSchema is one record with as many fields as asked for, which is the input
+// the cardinality rule is about: the user's IDL decides this number, and nothing
+// bounded by it may become a span.
+func wideSchema(fields int) *avrocpb.Schema {
+	const ns = "com.example"
+
+	record := &avrocpb.Record{
+		Name:      proto.String("Wide"),
+		Namespace: proto.String(ns),
+		FullName:  proto.String(ns + ".Wide"),
+	}
+	for i := range fields {
+		record.Fields = append(record.Fields, &avrocpb.Field{
+			Name: proto.String(fmt.Sprintf("field%d", i)),
+			Type: primType("string"),
+		})
+	}
+
+	return &avrocpb.Schema{
+		Namespace: proto.String(ns),
+		Type:      &avrocpb.Type{Type: &avrocpb.Type_Record{Record: record}},
+	}
+}
+
+// spanCounter is a tracer provider that starts no spans and counts every
+// request for one.
+type spanCounter struct {
+	embedded.TracerProvider
+
+	tracers int
+	starts  int
+}
+
+func (p *spanCounter) Tracer(string, ...oteltrace.TracerOption) oteltrace.Tracer {
+	p.tracers++
+	return countingTracer{provider: p}
+}
+
+type countingTracer struct {
+	embedded.Tracer
+
+	provider *spanCounter
+}
+
+func (t countingTracer) Start(ctx context.Context, _ string, _ ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	t.provider.starts++
+	return ctx, noop.Span{}
+}
+
+// untracedSpan is the span an untraced invocation carries: not recording, which
+// is what a no-op provider hands plugin.Main when there is no TRACEPARENT and no
+// endpoint. It differs from noop.Span in naming a provider the test can count
+// through, so a generator that asked for a tracer anyway is caught rather than
+// silently satisfied.
+type untracedSpan struct {
+	noop.Span
+
+	provider *spanCounter
+}
+
+func (s untracedSpan) TracerProvider() oteltrace.TracerProvider { return s.provider }

--- a/internal/avroc-gen-json/version_test.go
+++ b/internal/avroc-gen-json/version_test.go
@@ -36,7 +36,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 			// a valid version onto a request that carries none, which is the
 			// one thing this test needs left alone.
 			w := plugin.NewOutputDir(t.TempDir())
-			err := Generate(&avrocpb.GenerateRequest{
+			err := Generate(t.Context(), &avrocpb.GenerateRequest{
 				Version: tc.version,
 				Options: nil,
 				Schemas: []*avrocpb.Schema{versionTestSchema()},

--- a/internal/avroc-gen-pcf/determinism_test.go
+++ b/internal/avroc-gen-pcf/determinism_test.go
@@ -7,11 +7,13 @@ package avrocgenpcf
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/ir"
 
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -42,17 +44,37 @@ func (w *recordingWriter) WriteFile(path string, content []byte) error {
 func generateFiles(t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
 	t.Helper()
 
+	return generateFilesIn(t.Context(), t, req)
+}
+
+// generateFilesIn is generateFiles with the context the generation runs under,
+// which is the whole of the difference between a traced run and an untraced one.
+//
+// Tracing is an observation of a generation and never an input to it (#197), so
+// the two have to produce the same bytes; making the context the only variable
+// is what lets one assertion cover both.
+func generateFilesIn(ctx context.Context, t *testing.T, req *avrocpb.GenerateRequest) []generatedFile {
+	t.Helper()
+
 	if req.Version == nil {
 		req = proto.CloneOf(req)
 		req.Version = proto.Int32(ir.Version)
 	}
 
 	w := &recordingWriter{}
-	if err := Generate(req, w); err != nil {
+	if err := Generate(ctx, req, w); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 	return w.files
 }
+
+// tracedRun reports whether run number n is one of the traced ones.
+//
+// Half of them are, so that every repetition below compares a traced run's bytes
+// against an untraced run's: the failure this is aimed at is a span opened
+// between two writes changing what gets written, which no number of untraced
+// repetitions would ever show.
+func tracedRun(n int) bool { return n%2 == 1 }
 
 // TestGenerateIsDeterministic is #120's dynamic half for this generator: the
 // same descriptor produces the same set of paths with byte-identical contents,
@@ -82,7 +104,16 @@ func TestGenerateIsDeterministic(t *testing.T) {
 	}
 
 	for run := 1; run < runs; run++ {
-		again := generateFiles(t, req)
+		ctx := t.Context()
+		var recorder *tracetest.SpanRecorder
+		if tracedRun(run) {
+			ctx, recorder = recordingContext(t)
+		}
+
+		again := generateFilesIn(ctx, t, req)
+		if recorder != nil && len(recorder.Ended()) == 0 {
+			t.Fatal("a traced run recorded no spans, so the comparison against an untraced one is vacuous")
+		}
 		if len(again) != len(first) {
 			t.Fatalf("run %d produced %d file(s), run 0 produced %d", run, len(again), len(first))
 		}

--- a/internal/avroc-gen-pcf/generate.go
+++ b/internal/avroc-gen-pcf/generate.go
@@ -6,6 +6,7 @@
 package avrocgenpcf
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/z5labs/avroc/avrocpb"
@@ -25,7 +26,12 @@ import (
 // failure rather than a gap: the exit is non-zero, and avroc discards the whole
 // scratch directory instead of merging it, so no half a set of schemas reaches
 // the user's tree.
-func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
+//
+// One span per schema and nothing finer (#197), for the reason avroc-gen-json
+// gives: this generator writes one file per schema and does no rendering, so
+// instrumentation heavier than that would make a trace harder to read rather
+// than easier.
+func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 	// The version comes first, before a single schema is looked at. A descriptor
 	// written against a contract this generator does not know is not one to read
 	// the recognisable parts of — and a canonical form derived from a misread
@@ -34,12 +40,19 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 		return err
 	}
 
-	for _, schema := range req.Schemas {
-		filename, content, err := buildSchemaFile(schema)
+	for _, schema := range req.GetSchemas() {
+		// Once, and before the span: it is the name the file is built from as
+		// well as the name the span carries.
+		base := ir.SchemaBaseName(schema)
+
+		_, span := plugin.StartSchemaGenerate(ctx, base)
+		content, err := buildSchemaFile(schema)
+		plugin.EndPhase(span, err)
 		if err != nil {
 			return fmt.Errorf("failed to generate schema: %w", err)
 		}
-		if err := w.WriteFile(filename, content); err != nil {
+
+		if err := w.WriteFile(ir.SnakeCase(base)+".avsc", content); err != nil {
 			return err
 		}
 	}
@@ -48,18 +61,14 @@ func Generate(req *avrocpb.GenerateRequest, w plugin.FileWriter) error {
 }
 
 // buildSchemaFile generates the Avro Parsing Canonical Form for a single schema,
-// returning its relative filename and content.
+// returning its content. The filename is the caller's, built from the base name
+// the span it opened is named by.
 //
 // The content is ir.CanonicalJSON's bytes unchanged, and that is the point of
 // this generator: those are the same bytes avroc-gen-go fingerprints, so the
 // published schema and the embedded fingerprint cannot disagree. Nothing is
 // appended — Avro's Parsing Canonical Form has no trailing newline, and one
 // added here would change every fingerprint computed over the published file.
-func buildSchemaFile(schema *avrocpb.Schema) (string, []byte, error) {
-	data, err := ir.CanonicalJSON(schema)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return ir.SnakeCase(ir.SchemaBaseName(schema)) + ".avsc", data, nil
+func buildSchemaFile(schema *avrocpb.Schema) ([]byte, error) {
+	return ir.CanonicalJSON(schema)
 }

--- a/internal/avroc-gen-pcf/generate.go
+++ b/internal/avroc-gen-pcf/generate.go
@@ -46,18 +46,28 @@ func Generate(ctx context.Context, req *avrocpb.GenerateRequest, w plugin.FileWr
 		base := ir.SchemaBaseName(schema)
 
 		_, span := plugin.StartSchemaGenerate(ctx, base)
-		content, err := buildSchemaFile(schema)
+		err := emitSchema(schema, ir.SnakeCase(base)+".avsc", w)
 		plugin.EndPhase(span, err)
 		if err != nil {
-			return fmt.Errorf("failed to generate schema: %w", err)
-		}
-
-		if err := w.WriteFile(ir.SnakeCase(base)+".avsc", content); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// emitSchema renders one schema and writes it, which is the whole of what this
+// generator does for a schema and therefore the whole of what that schema's span
+// covers. Splitting the write out would be the finer granularity there is not
+// enough work here to justify, and leaving it outside the span would put the
+// filesystem time — which here is most of it, the canonical form being the
+// cheaper half — on the invocation instead of on the schema it belongs to.
+func emitSchema(schema *avrocpb.Schema, filename string, w plugin.FileWriter) error {
+	content, err := buildSchemaFile(schema)
+	if err != nil {
+		return fmt.Errorf("failed to generate schema: %w", err)
+	}
+	return w.WriteFile(filename, content)
 }
 
 // buildSchemaFile generates the Avro Parsing Canonical Form for a single schema,

--- a/internal/avroc-gen-pcf/generate_test.go
+++ b/internal/avroc-gen-pcf/generate_test.go
@@ -205,27 +205,40 @@ func TestGenerate_UnresolvedReference(t *testing.T) {
 	}
 }
 
-func TestBuildSchemaFile_Filename(t *testing.T) {
-	filename, _, err := buildSchemaFile(resolvedTestRecord())
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
+// TestGeneratedFilenames asserts the name each schema's file is written under.
+//
+// It is asked of a whole generation rather than of the function that renders one
+// schema, because the filename is Generate's: the base name is derived once
+// there and used both for the file and for the span naming that schema's work
+// (#197), so a test that called the renderer would be asserting about a
+// derivation nothing performs any more.
+//
+// The array root is the case worth having. This generator names the file after
+// what the root is *about*, which for `schema array<Event>;` is the record
+// inside the array and not the namespace's last component — where
+// ir.SchemaBaseName used to land for a root that is not itself a named type.
+func TestGeneratedFilenames(t *testing.T) {
+	testCases := []struct {
+		name   string
+		schema *avrocpb.Schema
+		want   string
+	}{
+		{name: "a record root", schema: resolvedTestRecord(), want: "test_record.avsc"},
+		{name: "an array root", schema: arrayRootSchema(), want: "event.avsc"},
 	}
-	if filename != "test_record.avsc" {
-		t.Errorf("expected test_record.avsc, got %q", filename)
-	}
-}
 
-// TestBuildSchemaFile_ArrayRootFilename asserts this generator names the file
-// after what an array root is about rather than after the namespace, which is
-// where ir.SchemaBaseName used to land for a root that is not itself a named
-// type.
-func TestBuildSchemaFile_ArrayRootFilename(t *testing.T) {
-	filename, _, err := buildSchemaFile(arrayRootSchema())
-	if err != nil {
-		t.Fatalf("buildSchemaFile failed: %v", err)
-	}
-	if filename != "event.avsc" {
-		t.Errorf("expected event.avsc, got %q", filename)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := generateFiles(t, &avrocpb.GenerateRequest{
+				Schemas: []*avrocpb.Schema{tc.schema},
+			})
+			if len(files) != 1 {
+				t.Fatalf("the generation produced %d files, want 1", len(files))
+			}
+			if files[0].path != tc.want {
+				t.Errorf("expected %s, got %q", tc.want, files[0].path)
+			}
+		})
 	}
 }
 

--- a/internal/avroc-gen-pcf/output_test.go
+++ b/internal/avroc-gen-pcf/output_test.go
@@ -51,7 +51,7 @@ func generateToDir(t *testing.T, dir string, req *avrocpb.GenerateRequest) (*gen
 	}
 
 	w := plugin.NewOutputDir(dir)
-	if err := Generate(req, w); err != nil {
+	if err := Generate(t.Context(), req, w); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ var errWriteRefused = errors.New("refused")
 // carry on, because a zero exit is the whole of the success signal and avroc
 // would adopt the output directory with the file missing from it.
 func TestGenerateReportsAFailedWrite(t *testing.T) {
-	err := Generate(&avrocpb.GenerateRequest{
+	err := Generate(t.Context(), &avrocpb.GenerateRequest{
 		Version: proto.Int32(ir.Version),
 		Schemas: []*avrocpb.Schema{versionTestSchema()},
 	}, failingWriter{})

--- a/internal/avroc-gen-pcf/trace_test.go
+++ b/internal/avroc-gen-pcf/trace_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/z5labs/avroc/avrocpb"
 	"github.com/z5labs/avroc/internal/ir"
 
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -175,6 +176,33 @@ func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
 	}
 	if counter.starts != 0 {
 		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// TestAFailedWriteFailsTheSchemasSpan is why the write is inside the schema's
+// span rather than after it.
+//
+// This generator opens no span of its own for the write, so a write left outside
+// would put both the filesystem time and the failure on the invocation rather
+// than on the schema they belong to — and a schema whose file was never written
+// would read as a schema that went fine.
+func TestAFailedWriteFailsTheSchemasSpan(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord()},
+	}, failingWriter{})
+	if err == nil {
+		t.Fatal("Generate ignored a writer that refuses every file")
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("the generation opened %d spans, want 1: %v", len(spans), recordedNames(spans))
+	}
+	if spans[0].Status().Code != codes.Error {
+		t.Errorf("the %q span is not marked failed: %v", spans[0].Name(), spans[0].Status())
 	}
 }
 

--- a/internal/avroc-gen-pcf/trace_test.go
+++ b/internal/avroc-gen-pcf/trace_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avrocgenpcf
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/z5labs/avroc/avrocpb"
+	"github.com/z5labs/avroc/internal/ir"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/proto"
+)
+
+// The span names this generator is expected to open, written out as literals
+// rather than taken from internal/plugin's constants: a check that reads the
+// constant it is checking moves with it, and a renamed span would go on passing
+// here while every dashboard built on the old name broke silently.
+const (
+	spanInvocation     = "avroc.plugin.generate"
+	spanSchemaGenerate = "avroc.plugin.schema.generate"
+)
+
+// attrSchema is the attribute the per-schema span carries, on the same terms.
+const attrSchema = "schema"
+
+// recordingContext is what plugin.Main hands Generate on a traced invocation: a
+// context carrying the invocation's own span, from a provider whose spans the
+// test reads back once they have ended.
+//
+// The invocation span is ended by a cleanup rather than here, so that Generate
+// runs inside it exactly as it does under plugin.Main, and nothing read before
+// the test returns includes it.
+func recordingContext(t *testing.T) (context.Context, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(t.Context(), spanInvocation)
+	t.Cleanup(func() { span.End() })
+	return ctx, recorder
+}
+
+// recordedNames is every span a generation ended, in order.
+func recordedNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name())
+	}
+	return names
+}
+
+// stringAttr reads one string attribute off a span, failing when it is absent.
+func stringAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) string {
+	t.Helper()
+
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	t.Fatalf("span %q carries no %q attribute: %v", span.Name(), key, span.Attributes())
+	return ""
+}
+
+// TestEverySchemaIsOneSpanAndNothingFiner is #197 for this generator, and the
+// "nothing finer" is the substance of it.
+//
+// avroc-gen-pcf writes one file per schema and does nothing to it — the content is
+// ir.CanonicalJSON's bytes verbatim — so a span for the descriptor check or for a
+// write it performs in one call would be more instrumentation than there is
+// work, and a trace carrying it would be harder to read rather than easier.
+// avroc-gen-go is where the finer phases belong.
+func TestEverySchemaIsOneSpanAndNothingFiner(t *testing.T) {
+	ctx, recorder := recordingContext(t)
+
+	req := &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}
+
+	var w recordingWriter
+	if err := Generate(ctx, req, &w); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != len(req.GetSchemas()) {
+		t.Fatalf("the generation opened %d spans over %d schemas: %v",
+			len(spans), len(req.GetSchemas()), recordedNames(spans))
+	}
+	for i, span := range spans {
+		if span.Name() != spanSchemaGenerate {
+			t.Errorf("span %d is named %q, want %q", i, span.Name(), spanSchemaGenerate)
+			continue
+		}
+		if got, want := stringAttr(t, span, attrSchema), ir.SchemaBaseName(req.GetSchemas()[i]); got != want {
+			t.Errorf("%s = %q on span %d, want %q", attrSchema, got, i, want)
+		}
+		if !span.Parent().IsValid() {
+			t.Errorf("span %d has no parent, so it started a trace of its own", i)
+		}
+	}
+}
+
+// TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema is the cardinality
+// rule: a span per schema is bounded by the manifest a person wrote, and a span
+// per type or per field would be bounded by the user's IDL, where a few thousand
+// fields would produce a trace nobody can open.
+func TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema(t *testing.T) {
+	names := func(t *testing.T, fields int) []string {
+		t.Helper()
+
+		ctx, recorder := recordingContext(t)
+		err := Generate(ctx, &avrocpb.GenerateRequest{
+			Version: proto.Int32(ir.Version),
+			Schemas: []*avrocpb.Schema{wideSchema(fields)},
+		}, &recordingWriter{})
+		if err != nil {
+			t.Fatalf("Generate over a %d-field schema failed: %v", fields, err)
+		}
+
+		got := recordedNames(recorder.Ended())
+		slices.Sort(got)
+		return got
+	}
+
+	narrow := names(t, 1)
+	wide := names(t, 500)
+
+	if len(narrow) == 0 {
+		t.Fatal("a generation opened no spans at all, so the comparison is vacuous")
+	}
+	if !slices.Equal(narrow, wide) {
+		t.Errorf("a 500-field schema produced %v and a 1-field schema produced %v: the span count follows the IDL",
+			wide, narrow)
+	}
+}
+
+// TestAnUntracedGenerationStartsNoSpans: almost every invocation of this
+// generator has no collector anywhere near it, and it must pay nothing per
+// schema for instrumentation nobody is reading.
+//
+// The provider counts rather than records, because "no span was exported" is
+// what a non-recording provider gives for free — what is asserted here is that
+// none was started, and that no tracer was even asked for.
+func TestAnUntracedGenerationStartsNoSpans(t *testing.T) {
+	counter := &spanCounter{}
+	ctx := oteltrace.ContextWithSpan(t.Context(), untracedSpan{provider: counter})
+
+	var w recordingWriter
+	err := Generate(ctx, &avrocpb.GenerateRequest{
+		Version: proto.Int32(ir.Version),
+		Schemas: []*avrocpb.Schema{resolvedTestRecord(), determinismSecondSchema()},
+	}, &w)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if len(w.files) == 0 {
+		t.Fatal("the generation wrote no files, so it proves nothing about the work per schema")
+	}
+
+	if counter.tracers != 0 {
+		t.Errorf("an untraced generation asked for %d tracers, want 0", counter.tracers)
+	}
+	if counter.starts != 0 {
+		t.Errorf("an untraced generation started %d spans, want 0", counter.starts)
+	}
+}
+
+// wideSchema is one record with as many fields as asked for, which is the input
+// the cardinality rule is about: the user's IDL decides this number, and nothing
+// bounded by it may become a span.
+func wideSchema(fields int) *avrocpb.Schema {
+	const ns = "com.example"
+
+	record := &avrocpb.Record{
+		Name:      proto.String("Wide"),
+		Namespace: proto.String(ns),
+		FullName:  proto.String(ns + ".Wide"),
+	}
+	for i := range fields {
+		record.Fields = append(record.Fields, &avrocpb.Field{
+			Name: proto.String(fmt.Sprintf("field%d", i)),
+			Type: &avrocpb.Type{Type: &avrocpb.Type_Reference{Reference: primRef("string")}},
+		})
+	}
+
+	return &avrocpb.Schema{
+		Namespace: proto.String(ns),
+		Type:      &avrocpb.Type{Type: &avrocpb.Type_Record{Record: record}},
+	}
+}
+
+// spanCounter is a tracer provider that starts no spans and counts every
+// request for one.
+type spanCounter struct {
+	embedded.TracerProvider
+
+	tracers int
+	starts  int
+}
+
+func (p *spanCounter) Tracer(string, ...oteltrace.TracerOption) oteltrace.Tracer {
+	p.tracers++
+	return countingTracer{provider: p}
+}
+
+type countingTracer struct {
+	embedded.Tracer
+
+	provider *spanCounter
+}
+
+func (t countingTracer) Start(ctx context.Context, _ string, _ ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	t.provider.starts++
+	return ctx, noop.Span{}
+}
+
+// untracedSpan is the span an untraced invocation carries: not recording, which
+// is what a no-op provider hands plugin.Main when there is no TRACEPARENT and no
+// endpoint. It differs from noop.Span in naming a provider the test can count
+// through, so a generator that asked for a tracer anyway is caught rather than
+// silently satisfied.
+type untracedSpan struct {
+	noop.Span
+
+	provider *spanCounter
+}
+
+func (s untracedSpan) TracerProvider() oteltrace.TracerProvider { return s.provider }

--- a/internal/avroc-gen-pcf/version_test.go
+++ b/internal/avroc-gen-pcf/version_test.go
@@ -36,7 +36,7 @@ func TestGenerateRejectsUnknownIRVersion(t *testing.T) {
 			// a valid version onto a request that carries none, which is the
 			// one thing this test needs left alone.
 			w := plugin.NewOutputDir(t.TempDir())
-			err := Generate(&avrocpb.GenerateRequest{
+			err := Generate(t.Context(), &avrocpb.GenerateRequest{
 				Version: tc.version,
 				Options: nil,
 				Schemas: []*avrocpb.Schema{versionTestSchema()},

--- a/internal/plugin/info_test.go
+++ b/internal/plugin/info_test.go
@@ -7,6 +7,7 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -147,7 +148,7 @@ func TestMain_PluginInfo(t *testing.T) {
 
 		var stdout bytes.Buffer
 		generated := false
-		record := func(*avrocpb.GenerateRequest, FileWriter) error {
+		record := func(context.Context, *avrocpb.GenerateRequest, FileWriter) error {
 			generated = true
 			return nil
 		}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -239,7 +239,14 @@ func OutputPath(out, p string) (string, error) {
 // files beneath --out and exits — with the directory behind an interface so
 // that Main owns the path checking and the bookkeeping and a generator owns
 // only its bytes.
-type GenerateFunc func(*avrocpb.GenerateRequest, FileWriter) error
+//
+// The context carries the invocation's span, which is how a generator's phases
+// become children of it (#197) without any generator growing a [trace.Tracer]
+// parameter to thread through untouched: the provider travels in the context, as
+// it does in internal/avroc. It is a context and not a tracer for the ordinary
+// reason as well — a generation is a whole process's work, and cancellation
+// belongs to whoever finds a use for it first.
+type GenerateFunc func(context.Context, *avrocpb.GenerateRequest, FileWriter) error
 
 // Main runs one invocation from an argument vector and returns the process exit
 // status.
@@ -375,7 +382,7 @@ func invoke(ctx context.Context, c cli.Context, info Info, generate GenerateFunc
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(attrIRVersion, int64(req.GetVersion())))
 
 	out := NewOutputDir(inv.Out)
-	if err := generate(req, out); err != nil {
+	if err := generate(ctx, req, out); err != nil {
 		c.Log.ErrorContext(ctx, "failed to generate", slog.String("generator", name), slog.Any("error", err))
 		return 1
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -7,6 +7,7 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"os"
@@ -266,7 +267,7 @@ func TestOutputPath(t *testing.T) {
 
 // echoGenerate is a stand-in generator in the shape the contract describes: it
 // writes every schema's full name as a file.
-func echoGenerate(req *avrocpb.GenerateRequest, w FileWriter) error {
+func echoGenerate(_ context.Context, req *avrocpb.GenerateRequest, w FileWriter) error {
 	for _, schema := range req.GetSchemas() {
 		name := schema.GetType().GetRecord().GetFullName() + ".txt"
 		if err := w.WriteFile(name, []byte("first\nsecond\n")); err != nil {
@@ -344,7 +345,7 @@ func TestMain_Failures(t *testing.T) {
 		out := t.TempDir()
 		c, logs := newTestCLI("--descriptor", descriptorPath(t), "--out", out)
 
-		failing := func(*avrocpb.GenerateRequest, FileWriter) error {
+		failing := func(context.Context, *avrocpb.GenerateRequest, FileWriter) error {
 			return io.ErrUnexpectedEOF
 		}
 		if code := Main(t.Context(), c, testInfo(), failing); code == 0 {
@@ -361,7 +362,7 @@ func TestMain_Failures(t *testing.T) {
 		// avroc would adopt the directory with the file missing from it.
 		c, logs := newTestCLI("--descriptor", descriptorPath(t), "--out", t.TempDir())
 
-		swallowing := func(_ *avrocpb.GenerateRequest, w FileWriter) error {
+		swallowing := func(_ context.Context, _ *avrocpb.GenerateRequest, w FileWriter) error {
 			_ = w.WriteFile("../escapes.go", []byte("package pkg\n"))
 			return nil
 		}

--- a/internal/plugin/trace.go
+++ b/internal/plugin/trace.go
@@ -110,15 +110,19 @@ func StartOptionsParse(ctx context.Context) (context.Context, trace.Span) {
 	return startPhase(ctx, spanOptionsParse, "", "")
 }
 
-// StartSchemaGenerate starts the span covering the bytes of one schema being
-// rendered, named by that schema's base name — [ir.SchemaBaseName], which is the
-// name every generator's filename is built from and therefore the name a person
-// reading the trace already has in front of them.
+// StartSchemaGenerate starts the span covering everything a generator does for
+// one schema, named by that schema's base name — [ir.SchemaBaseName], which is
+// the name every generator's filename is built from and therefore the name a
+// person reading the trace already has in front of them.
 //
-// It covers the rendering and not the write. A generator that traces its writes
-// opens [StartFileWrite] beside this one rather than inside it, so that the two
-// intervals stay separately readable and one span name does not sometimes
-// contain a filesystem call and sometimes not.
+// Everything, which is to say the write as well as the rendering. A generator
+// fine-grained enough to trace its writes opens [StartFileWrite] *inside* this
+// one rather than beside it, so the rendering stays separately readable as the
+// difference between the two; a generator that does not still has its write time
+// inside the span for the schema it belongs to, rather than accounted only to
+// the invocation. One span name meaning "this schema's work" in every generator
+// is what lets a backend ask how long a schema took without knowing which
+// generator answered.
 func StartSchemaGenerate(ctx context.Context, schema string) (context.Context, trace.Span) {
 	return startPhase(ctx, spanSchemaGenerate, attrSchema, schema)
 }

--- a/internal/plugin/trace.go
+++ b/internal/plugin/trace.go
@@ -6,12 +6,14 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // tracerScope names the instrumentation a generator's span comes from. It is
@@ -36,17 +38,166 @@ const (
 	spanPluginInfo = "avroc.plugin.info"
 )
 
+// The phases a generator spends time inside a generation, one span name each
+// (#197).
+//
+// An invocation being one span answers "which generator is slow"; it does not
+// answer "which part of it". These are that second question, and they are the
+// phases the code already had as functions — validating the descriptor, reading
+// the options, rendering a schema, computing a fingerprint, writing a file —
+// rather than a decomposition invented for the trace. It is the rule
+// internal/avroc's phase spans are chosen by, applied on the other side of the
+// fork.
+//
+// **Cardinality is what fixes the granularity.** A span per schema and a span
+// per file are bounded by the descriptor, which avroc built from the manifest; a
+// span per type or per field would be bounded by the user's IDL, and a schema
+// with a few thousand fields would produce a trace nobody can open. So anything
+// finer than a schema or a file is an attribute on one of these spans and never
+// a span of its own, and
+// internal/avroc-gen-go.TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema
+// is what holds that as the generators grow.
+//
+// They live here rather than in the three generators for the reason
+// [tracerScope] gives: [Main] is the one place every generator in this
+// repository runs through, so there is one set of names and one instrumentation
+// scope instead of three of each. Which generator opened one is the invocation
+// span's `generator` attribute, one level up.
+//
+// Not every generator opens all of them, and that is the point rather than an
+// omission. avroc-gen-go is the only generator here with enough work in it to
+// have parts, so it is the only one that opens the descriptor, option,
+// fingerprint and file spans; avroc-gen-json and avroc-gen-pcf write one file
+// per schema and have no rendering to speak of, so they open the per-schema span
+// and nothing finer. Instrumentation heavier than the work it measures makes a
+// trace harder to read, not easier.
+const (
+	spanDescriptorValidate = "avroc.plugin.descriptor.validate"
+	spanOptionsParse       = "avroc.plugin.options.parse"
+	spanSchemaGenerate     = "avroc.plugin.schema.generate"
+	spanFingerprint        = "avroc.plugin.fingerprint"
+	spanFileWrite          = "avroc.plugin.file.write"
+)
+
 // The attributes those spans carry.
 //
 // Every one of them is spelled exactly as internal/avroc spells the same fact,
 // for the reason that package gives: a person reading a generator's span beside
 // avroc's own should not have to learn that exit_code is called something else in
-// one of them.
+// one of them. attrPath is that reason exactly — it is the spelling
+// internal/avroc's merge already reports a generated path by — and attrSchema is
+// the one fact no span of avroc's carries, because avroc names an *input* and a
+// generator names the schema that came out of it.
 const (
 	attrGenerator = "generator"
 	attrIRVersion = "ir_version"
 	attrExitCode  = "exit_code"
+	attrSchema    = "schema"
+	attrPath      = "path"
 )
+
+// StartDescriptorValidate starts the span covering everything a generator checks
+// about the descriptor as a whole before it looks at a schema: the IR version it
+// was handed, and whatever else is a property of the request rather than of one
+// of the schemas in it.
+func StartDescriptorValidate(ctx context.Context) (context.Context, trace.Span) {
+	return startPhase(ctx, spanDescriptorValidate, "", "")
+}
+
+// StartOptionsParse starts the span covering a generator reading its --opt
+// pairs, and refusing the ones it cannot honour.
+func StartOptionsParse(ctx context.Context) (context.Context, trace.Span) {
+	return startPhase(ctx, spanOptionsParse, "", "")
+}
+
+// StartSchemaGenerate starts the span covering the bytes of one schema being
+// rendered, named by that schema's base name — [ir.SchemaBaseName], which is the
+// name every generator's filename is built from and therefore the name a person
+// reading the trace already has in front of them.
+//
+// It covers the rendering and not the write. A generator that traces its writes
+// opens [StartFileWrite] beside this one rather than inside it, so that the two
+// intervals stay separately readable and one span name does not sometimes
+// contain a filesystem call and sometimes not.
+func StartSchemaGenerate(ctx context.Context, schema string) (context.Context, trace.Span) {
+	return startPhase(ctx, spanSchemaGenerate, attrSchema, schema)
+}
+
+// StartFingerprint starts the span covering a schema's canonical form and the
+// fingerprint computed over it.
+//
+// It is a child of that schema's [StartSchemaGenerate] span, and it is the one
+// place avroc-gen-go does real computation over the IR rather than walking it,
+// which is why it is separated out of the rendering it happens inside.
+func StartFingerprint(ctx context.Context) (context.Context, trace.Span) {
+	return startPhase(ctx, spanFingerprint, "", "")
+}
+
+// StartFileWrite starts the span covering one whole file being written through
+// a [FileWriter], named by the path it was written at — relative to --out, which
+// is the only form of the path that means anything: docs/plugin/SPEC.md makes
+// the absolute one a temporary location avroc chose for this invocation alone.
+func StartFileWrite(ctx context.Context, path string) (context.Context, trace.Span) {
+	return startPhase(ctx, spanFileWrite, attrPath, path)
+}
+
+// EndPhase ends a phase's span, recording err on it if there was one.
+//
+// It is the only place a phase's status is set, so a phase records its failure
+// once — the same discipline internal/avroc's endSpan keeps. Nothing here
+// classifies a cancelled run separately, for [endSpan]'s reason: a generator
+// killed by that cancellation never reaches this function, and one that merely
+// noticed goes on to an exit status like any other, so the classification stays
+// avroc's, which can see the signal it sent.
+//
+// A generator returns the first failure it meets, so the phase that failed is
+// the phase the invocation failed in, and the exit status that followed from it
+// is on the invocation's own span.
+func EndPhase(span trace.Span, err error) {
+	defer span.End()
+
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// startPhase starts a child of the span the invocation opened, and does nothing
+// whatsoever when the invocation is not being traced.
+//
+// That early return is the whole of "with tracing disabled a generator does no
+// additional work per schema or per file": no tracer is asked for, no attribute
+// is built and no span is started, so what the instrumentation costs an untraced
+// invocation is one interface call per phase and nothing per type and nothing
+// per field. It is also why every helper above takes its attribute as a plain
+// string rather than an [attribute.KeyValue] — a value built at the call site
+// would be built whether or not anything was ever going to read it.
+//
+// "Not being traced" is read off the invocation's own span rather than off a
+// flag of our own, because there is nothing else that could answer it: a
+// generator with no TRACEPARENT and no endpoint has a no-op provider, which is
+// the ordinary case rather than a fallback. A parent that is recording but
+// unsampled is the other case it catches, and under the SDK's ParentBased
+// default a child of an unsampled parent is unsampled too — so a span started
+// here would be one nothing exports either way.
+//
+// The span handed back for an untraced phase is a no-op one and deliberately not
+// the parent. The caller ends what it is given, and giving it the invocation's
+// span would end the invocation in the middle of the first schema.
+func startPhase(ctx context.Context, name, key, value string) (context.Context, trace.Span) {
+	parent := trace.SpanFromContext(ctx)
+	if !parent.IsRecording() {
+		return ctx, noop.Span{}
+	}
+
+	if key == "" {
+		return parent.TracerProvider().Tracer(tracerScope).Start(ctx, name)
+	}
+	return parent.TracerProvider().Tracer(tracerScope).Start(ctx, name,
+		trace.WithAttributes(attribute.String(key, value)),
+	)
+}
 
 // FlushBudget is the whole of the time a generator may spend flushing its spans
 // before it returns its exit status.

--- a/internal/plugin/trace_test.go
+++ b/internal/plugin/trace_test.go
@@ -7,6 +7,7 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"io"
 	"log/slog"
@@ -25,6 +26,9 @@ import (
 	"github.com/z5labs/avroc/internal/telemetry"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
@@ -319,6 +323,93 @@ func TestMalformedTraceContextIsNotAnError(t *testing.T) {
 		t.Errorf("parent span id = %s, want none: the span should be the root of its own trace", got)
 	}
 }
+
+// TestAnUntracedPhaseStartsNothingAndEndsNothing is the gate every generator's
+// phases go through, asserted where it is written rather than three times over
+// (#197).
+//
+// Two properties, and the second is the one that would be a bug rather than a
+// cost. A phase reached on an untraced invocation must start nothing — no tracer
+// requested, no span opened — which is what makes the instrumentation free on
+// the invocation almost every generator actually gets. And the span it hands
+// back must not be the *invocation's*: the caller ends what it is given, so
+// returning the parent would end the whole invocation somewhere in the middle of
+// the first schema, and every span after it would be an orphan.
+func TestAnUntracedPhaseStartsNothingAndEndsNothing(t *testing.T) {
+	phases := map[string]func(context.Context) (context.Context, trace.Span){
+		spanDescriptorValidate: StartDescriptorValidate,
+		spanOptionsParse:       StartOptionsParse,
+		spanFingerprint:        StartFingerprint,
+		spanSchemaGenerate: func(ctx context.Context) (context.Context, trace.Span) {
+			return StartSchemaGenerate(ctx, "event")
+		},
+		spanFileWrite: func(ctx context.Context) (context.Context, trace.Span) {
+			return StartFileWrite(ctx, "event.go")
+		},
+	}
+
+	for name, start := range phases {
+		t.Run(name, func(t *testing.T) {
+			counter := &spanCounter{}
+			invocation := &untracedSpan{provider: counter}
+
+			ctx, span := start(trace.ContextWithSpan(t.Context(), invocation))
+			EndPhase(span, nil)
+			EndPhase(span, io.ErrUnexpectedEOF)
+
+			if counter.tracers != 0 || counter.starts != 0 {
+				t.Errorf("an untraced %s asked for %d tracers and started %d spans, want 0 and 0",
+					name, counter.tracers, counter.starts)
+			}
+			if invocation.ended {
+				t.Errorf("ending an untraced %s ended the invocation's own span", name)
+			}
+			if trace.SpanFromContext(ctx) != trace.Span(invocation) {
+				t.Errorf("an untraced %s replaced the span in the context, so the phase after it would be parented wrongly", name)
+			}
+		})
+	}
+}
+
+// spanCounter is a tracer provider that starts no spans and counts every request
+// for one, so that "nothing was started" is an assertion rather than an absence.
+type spanCounter struct {
+	embedded.TracerProvider
+
+	tracers int
+	starts  int
+}
+
+func (p *spanCounter) Tracer(string, ...trace.TracerOption) trace.Tracer {
+	p.tracers++
+	return countingTracer{provider: p}
+}
+
+type countingTracer struct {
+	embedded.Tracer
+
+	provider *spanCounter
+}
+
+func (t countingTracer) Start(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
+	t.provider.starts++
+	return ctx, noop.Span{}
+}
+
+// untracedSpan is the span an untraced invocation carries: not recording, which
+// is what a no-op provider hands run when there is no TRACEPARENT and no
+// endpoint. It differs from noop.Span in naming a provider the test can count
+// through and in noticing that it was ended.
+type untracedSpan struct {
+	noop.Span
+
+	provider *spanCounter
+	ended    bool
+}
+
+func (s *untracedSpan) TracerProvider() trace.TracerProvider { return s.provider }
+
+func (s *untracedSpan) End(...trace.SpanEndOption) { s.ended = true }
 
 // treeOf reads every regular file beneath dir, keyed by its path relative to it.
 func treeOf(t *testing.T, dir string) map[string]string {


### PR DESCRIPTION
Closes #197

#196 makes a generator invocation one span, which answers "which generator is slow". This answers "which part of it".

## What is here

`internal/plugin/trace.go` gains the phase span vocabulary and the one gate every generator opens a span through — `Main` is the single place all three generators here run through, so it is one set of names and one instrumentation scope rather than three of each:

| span | who opens it | when | attribute |
| --- | --- | --- | --- |
| `avroc.plugin.descriptor.validate` | `avroc-gen-go` | once | — |
| `avroc.plugin.options.parse` | `avroc-gen-go` | once | — |
| `avroc.plugin.schema.generate` | all three | per schema | `schema` — `ir.SchemaBaseName` |
| `avroc.plugin.fingerprint` | `avroc-gen-go` | per schema, under `single_object`, a child of that schema's span | — |
| `avroc.plugin.file.write` | `avroc-gen-go` | per file | `path`, relative to `--out` |

Verified end to end against a real collector over `example/`: the trace holds avroc's own phases (`avroc.generate`, `avroc.idl.parse`, `avroc.generator.run`, …) with `avroc.plugin.descriptor.validate`, `avroc.plugin.options.parse`, `avroc.plugin.schema.generate`, `avroc.plugin.fingerprint` and `avroc.plugin.file.write` nested beneath them.

## Acceptance criteria

- [x] `avroc-gen-go` produces child spans under the invocation span for descriptor validation, option parsing, per-schema code generation and per-file writing — `TestAGenerationsPhasesAreSpansUnderTheInvocations`, which also requires every phase to have a parent so none starts a trace of its own.
- [x] The fingerprint computation for single-object encoding is visible — its own span, `avroc.plugin.fingerprint`, asserted to be a child of the schema span it belongs to.
- [x] Each per-schema span carries the schema's base name; each per-file span carries the path relative to `--out` — asserted against `ir.SchemaBaseName` and against the paths the writer actually recorded.
- [x] `avroc-gen-json` and `avroc-gen-pcf` produce one span per schema emitted and no finer — `TestEverySchemaIsOneSpanAndNothingFiner` requires the whole recorded set to be exactly one span per schema.
- [x] Span count is a function of the descriptor's schema and file counts and never of the types or fields within a schema — `TestSpanCountIsAFunctionOfTheDescriptorAndNotTheSchema`, in all three generators, over a 500-field record against a one-field one.
- [x] With tracing disabled the generators do no additional work per schema or per file — `TestAnUntracedGenerationStartsNoSpans` in all three, plus `plugin.TestAnUntracedPhaseStartsNothingAndEndsNothing` over the shared gate.
- [x] `TestGenerateIsDeterministic` and the `example/` round trip pass traced and untraced, producing identical bytes.

## Judgment calls

- **`GenerateFunc` grew a `context.Context`** (`func(context.Context, *avrocpb.GenerateRequest, FileWriter) error`). That is how the invocation's span reaches a generator's phases without anything below `Main` growing a `trace.Tracer` parameter to thread through untouched — the provider travels in the context, exactly as it does in `internal/avroc`. It is an internal type; a third-party generator implements `docs/plugin/SPEC.md` and imports nothing from here, so nothing outside this repository sees it.
- **Cardinality fixes the granularity.** A span per schema and a span per file are bounded by the manifest a person wrote; a span per type or per field would be bounded by the user's IDL. Anything finer is an attribute rather than a span, and the test above is what holds that as the generators grow.
- **Not every generator opens every phase.** `avroc-gen-json` and `avroc-gen-pcf` write one file per schema and do no rendering, so they get the per-schema span and nothing else. Instrumentation heavier than the work it measures makes a trace harder to read, not easier.
- **`startPhase` returns before doing anything when the invocation is not being traced** — no tracer requested, no attribute built, no span started. That is why each helper takes its attribute as a plain string rather than an `attribute.KeyValue` the call site would build regardless, and why each generator now derives the schema's base name once and hands the same value to the filename and to the span. The span handed back for an untraced phase is a no-op one and deliberately not the parent: the caller ends what it is given, and returning the invocation's span would end the invocation in the middle of the first schema.
- **The `avroc.plugin.file.write` span is a sibling of the schema's, not a child**, so "how long to render" and "how long to write" are two intervals a reader can subtract rather than one that sometimes contains a filesystem call.
- **The span names are written out as literals in the generators' tests** rather than read from `internal/plugin`'s constants, for `tag-scheme`'s reason: a check that reads the constant it is checking moves with it.
- **`dagger call regeneration`'s second run is now a traced one** — an endpoint and a `TRACEPARENT` — so the `example/` round trip is itself a traced generation compared byte for byte against an untraced one, over whole processes. Nothing listens at that endpoint on purpose: the spans have to be opened for the comparison to mean anything, and a collector container would add a service to the check and a reason for it to fail that has nothing to do with determinism. The export is refused on the loopback address, fails immediately, and is logged rather than failing the build.
- **`buildSchemaFile` no longer derives the filename in `avroc-gen-json` and `avroc-gen-pcf`.** The base name is derived once in `Generate` and used for both the file and the span, so the two filename tests moved up to assert what a whole generation wrote — a test of the renderer would have been supplying the answer it was checking.

## Verification

Every command in `.claude/backlog.json`'s `verify`, from the worktree: `go build ./...`, `gofmt -l .`, `go vet ./...`, `go test -race -cover ./...`, `golangci-lint run` (0 issues, after a `cache clean`), and the `example/` round trip with `git diff --exit-code`. `.dagger` builds and is gofmt-clean.

Beyond that:

- The recording gate was mutated (`IsRecording` forced false) and all three `TestAnUntracedGenerationStartsNoSpans` failed, naming 8, 2 and 2 started spans — so they are not vacuous.
- `example/` was regenerated with `TRACEPARENT` and an endpoint set, against both an absent collector and a real one: exit zero, no change to the committed tree, and the span names above on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)