### PR TITLE
story(avroc): write each invocation's descriptor beside its output rather than under TMPDIR

### DIFF
--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -75,20 +75,16 @@ const (
 	// workDir is the working directory a caller mounts a project at.
 	workDir = "/work"
 
-	// tmpDir is a writable temporary directory, and it is the one thing in the
-	// image that docs/container/SPEC.md does not name — deliberately, since that
-	// document lists it under everything in the filesystem that is
-	// implementation detail rather than a covered guarantee.
-	//
-	// It is here because avroc writes each invocation's descriptor into a
-	// directory it creates under os.TempDir, so a scratch image without one
-	// fails every generation with `stat /tmp: no such file or directory` — the
-	// first thing ImageContract caught. tmpDirMode is 1777, root-owned,
-	// world-writable and sticky, which is the ordinary arrangement and the one
-	// that keeps working when a caller overrides the UID with
-	// `--user $(id -u):$(id -g)`.
-	tmpDir     = "/tmp"
-	tmpDirMode = 0o1777
+	// There is no temporary directory in this image, and its absence is a
+	// decision (#218). A 1777 /tmp used to be grafted on here, because avroc
+	// wrote each invocation's descriptor into a directory it created under
+	// os.TempDir and a scratch image without one failed every generation with
+	// `stat /tmp: no such file or directory` — the first thing ImageContract
+	// caught. avroc writes the descriptor into the generator's own output tree
+	// instead, so the requirement is gone rather than carried: the `docker run`
+	// lines docs/container/SPEC.md and the README print need no
+	// `--tmpfs /tmp:mode=1777`, and the image is once again exactly scratch plus
+	// the files that document names.
 
 	// imageUID and imageGID are the pinned non-root identity the image runs as.
 	// They are numbers rather than a name because the image has no /etc/passwd
@@ -314,10 +310,6 @@ func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
 		WithDirectory(workDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
-		// A temporary directory, because avroc writes each invocation's
-		// descriptor into one. Not owned by the image's user: 1777 is what makes
-		// it usable by whichever UID the container is actually running as.
-		WithDirectory("/", tmpDirectory()).
 		// PATH is set outright rather than appended to, because a scratch image
 		// has no PATH to append to. Only the guarantee that it contains the
 		// plugin directory is covered; the rest of the value is not.
@@ -343,25 +335,6 @@ func (m *Avroc) binaries(platform dagger.Platform) *dagger.Directory {
 		Platform:   string(platform),
 		DisableCgo: true,
 	})
-}
-
-// tmpDirectory is a directory holding nothing but `tmp`, with mode 1777, for
-// grafting onto the image's root.
-//
-// It is staged by a real mkdir in a container that has one rather than by
-// WithDirectory's permissions argument, because that argument sets the mode of
-// the files copied *into* a directory and not the mode of the directory itself
-// — which leaves /tmp root-owned at 0755, and every generation failing with
-// `permission denied` the moment the process is not root. That was the second
-// thing ImageContract caught, and it is the reason the check runs the image
-// rather than only reading its configuration.
-func tmpDirectory() *dagger.Directory {
-	const staging = "/staging"
-
-	return dag.Go().
-		Container(dag.Directory()).
-		WithExec([]string{"install", "-d", "-m", "1777", staging + tmpDir}).
-		Directory(staging)
 }
 
 // imageContractOn checks one platform's image.
@@ -512,7 +485,6 @@ func imageContents(executables []string) map[string]imageEntry {
 		descriptorSetPath:        {imageUID, imageGID, dataMode},
 		pluginDir:                {imageUID, imageGID, dirMode},
 		workDir:                  {imageUID, imageGID, dirMode},
-		tmpDir:                   {0, 0, tmpDirMode},
 	}
 	for _, name := range executables {
 		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -344,12 +344,14 @@ func (m *Avroc) regenerationOn(ctx context.Context, platform dagger.Platform) er
 // generateWorkedExample runs `avroc generate` once over a pristine copy of the
 // worked example and returns the tree it left behind.
 //
-// The container is scratch, holding the four statically linked binaries, an
-// empty temporary directory and the example: nothing else is in it, so nothing
-// else can be what the output depended on. It is also the shape
-// docs/container/SPEC.md publishes — the CLI and the generators on PATH, no
-// shell — so a generation that needs anything more than that is a finding about
-// the image as much as about determinism.
+// The container is scratch, holding the four statically linked binaries and the
+// example: nothing else is in it, so nothing else can be what the output depended
+// on. **There is no temporary directory in it**, which is #218 executed — avroc
+// writes each invocation's descriptor into the generator's own output tree, so a
+// generation that needed one would fail here rather than in an adopter's scratch
+// container. It is also the shape docs/container/SPEC.md publishes — the CLI and
+// the generators on PATH, no shell — so a generation that needs anything more
+// than that is a finding about the image as much as about determinism.
 func generateWorkedExample(
 	binaries *dagger.Directory,
 	example *dagger.Directory,
@@ -358,7 +360,6 @@ func generateWorkedExample(
 ) *dagger.Directory {
 	c := dag.Container(dagger.ContainerOpts{Platform: platform}).
 		WithDirectory(pluginDir, binaries).
-		WithDirectory(run.tmp, dag.Directory()).
 		WithDirectory(run.root, example).
 		WithWorkdir(run.root)
 
@@ -387,13 +388,18 @@ const pluginDir = "/usr/local/bin"
 // regenerationRun is one generation's arrangement of everything the output must
 // not depend on.
 type regenerationRun struct {
-	// root is the directory the worked example is copied to, and so the prefix
-	// of every absolute path avroc passes a generator in --out.
+	// root is the directory the worked example is copied to, and so the prefix of
+	// both absolute paths avroc passes a generator: --out, and — since #218 —
+	// --descriptor, whose per-invocation directory avroc creates inside the
+	// generator's own output tree.
+	//
+	// It is the axis that carries the descriptor's path, and it carries it alone.
+	// TMPDIR used to, and the two runs still disagree about that variable for the
+	// opposite reason: neither container has the directory it names, so an avroc
+	// that went back to reading it would fail the stage outright rather than pass
+	// it with the axis watching nothing.
 	root string
-	// tmp is TMPDIR, and so where the descriptor avroc passes in --descriptor is
-	// written.
-	tmp string
-	env []envVar
+	env  []envVar
 }
 
 type envVar struct {
@@ -442,10 +448,15 @@ func tracedRunEnv() []envVar {
 // plausible-looking default, the second run deliberately does not use it: a
 // generator that read HOME and got the same answer both times would pass a
 // check that was not looking.
+//
+// TMPDIR is set on both and neither container holds the directory it names. Since
+// #218 nothing in avroc reads it, so what it varies is no longer where the
+// descriptor goes — see regenerationRun.root — and what it is still here for is
+// the claim that avroc no longer reads it: a MkdirTemp("", …) put back anywhere
+// would fail both runs with `no such file or directory`.
 func firstRun() regenerationRun {
 	return regenerationRun{
 		root: "/work",
-		tmp:  "/tmp",
 		env: []envVar{
 			{"PATH", pluginDir},
 			{"TMPDIR", "/tmp"},
@@ -466,7 +477,6 @@ func secondRun() regenerationRun {
 		// Longer than the first, and at a different depth, because a path that
 		// leaked into the output would most plausibly leak as its own text.
 		root: "/srv/a-considerably-longer-project-directory",
-		tmp:  "/var/tmp/second",
 		env: append([]envVar{
 			{"PATH", "/nonexistent:" + pluginDir + ":/also-nonexistent"},
 			{"TMPDIR", "/var/tmp/second"},

--- a/.dagger/trace_propagation.go
+++ b/.dagger/trace_propagation.go
@@ -115,11 +115,21 @@ const (
 	// It is in a directory this check adds to the image, at a path that is part
 	// of nothing: the image carries no temporary directory since #218, and the
 	// two directories it does carry are both wrong for this — /work is the tree
-	// the generated output is compared against, so a record left in it would fail
-	// that comparison, and the plugin directory is where a file is a generator.
-	// A derived image adding a directory of its own is what any adopter does, and
-	// it is not the image gaining a writable path to make avroc work: avroc needs
-	// none.
+	// checkOneConnectedTrace byte-compares against the committed example/, so a
+	// record left in it would fail that comparison, and the plugin directory is
+	// where a file is a generator. A derived image adding a directory of its own
+	// is what any adopter does, and it is not the image gaining a writable path
+	// to make avroc work: avroc needs none, which is the whole of #218.
+	//
+	// The negative control gets it too, because it goes through the same
+	// tracedGeneration — which is what keeps it able to reach a *fetched trace*
+	// before the assertions reject it, rather than failing on a missing record and
+	// checking nothing.
+	//
+	// Standard output would need no directory at all and was rejected: the
+	// launcher re-execs avroc with its streams inherited, so the record would have
+	// to be picked back out of avroc's own output, and a generator writing to
+	// stdout (which the contract permits for --plugin-info) would corrupt it.
 	traceRecordDir    = "/record"
 	traceparentRecord = traceRecordDir + "/traceparent"
 

--- a/.dagger/trace_propagation.go
+++ b/.dagger/trace_propagation.go
@@ -110,10 +110,18 @@ const (
 	traceLauncher = pluginDir + "/trace-launch"
 
 	// traceparentRecord is where the launcher writes the TRACEPARENT Dagger
-	// handed the exec. It is under the image's temporary directory because that
-	// is the one writable path a scratch image running as 65532 has, and
-	// because nothing about it should look like part of the contract.
-	traceparentRecord = tmpDir + "/traceparent"
+	// handed the exec.
+	//
+	// It is in a directory this check adds to the image, at a path that is part
+	// of nothing: the image carries no temporary directory since #218, and the
+	// two directories it does carry are both wrong for this — /work is the tree
+	// the generated output is compared against, so a record left in it would fail
+	// that comparison, and the plugin directory is where a file is a generator.
+	// A derived image adding a directory of its own is what any adopter does, and
+	// it is not the image gaining a writable path to make avroc work: avroc needs
+	// none.
+	traceRecordDir    = "/record"
+	traceparentRecord = traceRecordDir + "/traceparent"
 
 	// tracePropagationPkg is the fixture on both ends of this check.
 	tracePropagationPkg = "./internal/tools/trace-propagation"
@@ -319,6 +327,11 @@ func (m *Avroc) tracedGeneration(platform dagger.Platform, collector *dagger.Ser
 		}).
 		WithServiceBinding(collectorHostname, collector).
 		WithDirectory(workDir, m.Source.Directory("example"), dagger.ContainerWithDirectoryOpts{
+			Owner: imageUser,
+		}).
+		// The launcher's own scratch directory, owned by the image's user so it
+		// can write the record into it. See traceparentRecord.
+		WithDirectory(traceRecordDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
 		WithExec([]string{

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,32 @@ directory created for that invocation alone, read-only, complete before the
 generator starts and removed once it has exited. `docs/plugin/SPEC.md`'s
 "Location and lifetime" is normative; nothing may derive meaning from the path.
 
+**Where the descriptor is written** is the generator's own output tree, in a
+hidden per-invocation directory beside the scratch directory `--out` names
+(`newDescriptorDir`, #218). It used to be `os.MkdirTemp("", …)`, and that one line
+was the whole reason `.dagger/image.go` grafted a 1777 `/tmp` into a `scratch`
+image. Keeping it would have cost every `docker run` line in `README.md`, in
+`docs/container/SPEC.md` and in the worked example a `--tmpfs /tmp:mode=1777` —
+and an adopter who forgot it a Go standard library message about a directory they
+never asked for, from a program that has not reached its own argument parsing — so
+the requirement was removed instead. **avroc reads no ambient temporary directory
+at all**, which `internal/avroc.TestAvrocReadsNoAmbientTemporaryDirectory` holds
+as a property of the source across `internal/`, `cmd/` and `avrocpb/`: no
+`os.TempDir`, no `MkdirTemp`/`CreateTemp` without a parent, and no `TMPDIR` by
+name. It is a source scan for the same reason the determinism ban is one — every
+machine the tests run on has a temporary directory, and only the published image
+does not. `dagger call regeneration` runs in scratch containers that now have no
+`/tmp` while still disagreeing about `TMPDIR`, so a read put back anywhere fails
+the stage outright; the axis that carries the descriptor's absolute path is
+`regenerationRun.root`, which is the prefix of both paths on the vector.
+
+Nothing in `docs/plugin/SPEC.md` changed for it: the path is implementation, and
+a plugin that noticed the move had already broken the rule forbidding it to derive
+anything from the descriptor's name or its directory. The consequence accepted
+rather than discovered is that a `SIGKILL` now leaves a dot-directory in the
+project's output tree instead of in `/tmp` — which `merge.go` already accepts for
+the scratch directory, and the name says what left it.
+
 The file **is** the value the generator received: its path is what `--descriptor`
 names, so there is no second encoding of the same inputs that could drift from
 it. The generator's options travel twice — in the descriptor, which
@@ -503,8 +529,9 @@ generator**, the CLI as `Entrypoint` with an empty `Cmd`, `/work` as
 `WorkingDir`, UID and GID 65532 owning both directories and running the process,
 the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a `scratch`
 base — no shell, no libc, no package manager, so extension is `COPY`-only. The
-one thing in the filesystem the document does not name is a 1777 `/tmp`, which
-avroc needs because it writes each invocation's descriptor under `os.TempDir`.
+filesystem is now exactly the files that document names and nothing else: a 1777
+`/tmp` used to be grafted on for the descriptor, and #218 removed the reason for
+it rather than the mount that carried it (see "Where the descriptor is written").
 
 `.dagger/generator_image.go` builds the three images that carry avroc's own
 generators, each of them the base plus one executable in the plugin directory

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -284,15 +284,14 @@ hard way by somebody:
   arguments, or against an image built `FROM` this one with a busybox copied in
   for the purpose.
 
-One directory in the image holds no file and is worth naming anyway: there is a
-writable temporary directory, because avroc writes each invocation's descriptor
-into a directory it creates under one. It is **not covered** — its path, its
-mode and its existence are [implementation
-detail](#compatibility-guarantees) like everything else in the filesystem that
-is not named above, and a derived image that wrote into it by path would be
-depending on something that may change in a patch release. It is mentioned here
-only so that "scratch plus the files named above" is not read as a promise that
-the image cannot write anywhere at all.
+One thing the image does **not** have is worth naming: there is no temporary
+directory in it, and none is needed. avroc writes each invocation's descriptor
+into a directory beneath the output tree the generator is writing to, so a
+`docker run` that mounts a project at `/work` needs no `--tmpfs`, no volume and
+no writable path anywhere else. Where the descriptor goes is
+[implementation detail](#compatibility-guarantees) like everything else in the
+filesystem that is not named above, and a derived image that wrote into it by
+path would be depending on something that may change in a patch release.
 
 Keeping the shell out is the same decision as having no plugin registry: the
 image's contents are exactly the executables somebody deliberately put there,

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -263,6 +263,16 @@ func (g generator) run(ctx context.Context, output string, options []*avrocpb.Op
 	// to an absolute path first, which is what makes both of the paths on the
 	// child's argument vector absolute — so that two runs of the same generator
 	// from different working directories are the same invocation.
+	//
+	// Creating it this early means an invocation that then fails — on the
+	// descriptor's directory, or on writing the descriptor — leaves the directory
+	// tree behind, and that is accepted rather than unwound. It is a directory and
+	// never a file, which is the line the merge already draws (mergeOutputs
+	// creates destination directories in a phase a later collision can still
+	// refuse); it may be a directory the project already had, since avroc cannot
+	// tell one it created from one a person did; and it is shared with every other
+	// generator the manifest points at the same tree, all of which run
+	// concurrently, so removing it here would race a generator writing into it.
 	outputDir, err := filepath.Abs(output)
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to resolve output directory", slog.String("generator", g.name), slog.Any("error", err))

--- a/internal/avroc/avroc.go
+++ b/internal/avroc/avroc.go
@@ -257,12 +257,29 @@ func (g generator) run(ctx context.Context, output string, options []*avrocpb.Op
 
 	desc := newDescriptor(options, schemas)
 
+	// The project's own output tree, which avroc owns and creates: a generator
+	// never learns where it is, and it has to exist before either of this
+	// invocation's two private directories can be made inside it. It is resolved
+	// to an absolute path first, which is what makes both of the paths on the
+	// child's argument vector absolute — so that two runs of the same generator
+	// from different working directories are the same invocation.
+	outputDir, err := filepath.Abs(output)
+	if err != nil {
+		g.log.ErrorContext(ctx, "failed to resolve output directory", slog.String("generator", g.name), slog.Any("error", err))
+		return nil, err
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		g.log.ErrorContext(ctx, "failed to create output directory", slog.String("generator", g.name), slog.Any("error", err))
+		return nil, err
+	}
+
 	// One descriptor file per generator invocation, in a directory created for
 	// that invocation and nothing else, removed once the generator has exited.
 	// docs/plugin/SPEC.md's "Location and lifetime" is normative for all three,
-	// and this defer is registered first so that it unwinds last — after the
-	// generator process has been waited on, never while it may still be reading.
-	descriptorDir, err := os.MkdirTemp("", g.name+"-descriptor-*")
+	// and this defer is registered first of the two removals so that it unwinds
+	// last — after the generator process has been waited on, never while it may
+	// still be reading.
+	descriptorDir, err := newDescriptorDir(outputDir, g.name)
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to create descriptor directory", slog.String("generator", g.name), slog.Any("error", err))
 		return nil, err
@@ -274,27 +291,6 @@ func (g generator) run(ctx context.Context, output string, options []*avrocpb.Op
 	descriptorPath, err := writeDescriptor(descriptorDir, desc)
 	if err != nil {
 		g.log.ErrorContext(ctx, "failed to write descriptor", slog.String("generator", g.name), slog.Any("error", err))
-		return nil, err
-	}
-
-	// Both paths go across as absolute ones, so that two runs of the same
-	// generator from different working directories are the same invocation.
-	descriptorPath, err = filepath.Abs(descriptorPath)
-	if err != nil {
-		g.log.ErrorContext(ctx, "failed to resolve descriptor path", slog.String("generator", g.name), slog.Any("error", err))
-		return nil, err
-	}
-	outputDir, err := filepath.Abs(output)
-	if err != nil {
-		g.log.ErrorContext(ctx, "failed to resolve output directory", slog.String("generator", g.name), slog.Any("error", err))
-		return nil, err
-	}
-
-	// The project's own output tree, which avroc owns and creates: a generator
-	// never learns where it is, and it has to exist before a scratch directory
-	// can be made inside it.
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		g.log.ErrorContext(ctx, "failed to create output directory", slog.String("generator", g.name), slog.Any("error", err))
 		return nil, err
 	}
 

--- a/internal/avroc/avroc_test.go
+++ b/internal/avroc/avroc_test.go
@@ -415,13 +415,10 @@ func TestGeneratorGenerate(t *testing.T) {
 	}
 	schema := testSchema("User")
 
-	// The descriptor's lifetime ends when the generator exits, so the set of
-	// descriptor directories on disk must not grow across an invocation. Taken
-	// before rather than asserted as "none afterwards", because a crashed
-	// earlier run may have left one and that is not this test's failure.
-	before := descriptorDirs(t)
-
-	// A directory avroc has to create: a plugin may assume --out exists.
+	// A directory avroc has to create: a plugin may assume --out exists. Since
+	// #218 it is also where the descriptor's own private directory is made, so
+	// avroc creating it is a precondition of the descriptor rather than only of
+	// the scratch directory.
 	projectRoot, outputDir := newProject(t)
 
 	if err := generateOne(ctx, g, projectRoot, outputDir, options, schema); err != nil {
@@ -447,6 +444,20 @@ func TestGeneratorGenerate(t *testing.T) {
 	absOutput, err := filepath.Abs(outputDir)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// The descriptor lives in a directory of its own beneath the same output tree
+	// (#218), which is what lets the published image be scratch with no /tmp in
+	// it. It is a sibling of the scratch directory and never inside it, so a
+	// generator walking its own --out never finds the descriptor there.
+	descriptorDir := filepath.Dir(args[1])
+	if filepath.Dir(descriptorDir) != absOutput {
+		t.Errorf("--descriptor %q is not in a directory beneath %q", args[1], absOutput)
+	}
+	if within(descriptorDir, args[3]) {
+		t.Errorf("the descriptor directory %q is inside the scratch directory %q", descriptorDir, args[3])
+	}
+	if within(args[3], descriptorDir) {
+		t.Errorf("--out %q resolves inside the descriptor directory %q", args[3], descriptorDir)
 	}
 	if !filepath.IsAbs(args[3]) {
 		t.Errorf("--out %q is not an absolute path", args[3])
@@ -500,10 +511,8 @@ func TestGeneratorGenerate(t *testing.T) {
 		t.Errorf("the output directory holds %v, want just the merged pkg directory", entries)
 	}
 
-	for dir := range descriptorDirs(t) {
-		if _, ok := before[dir]; !ok {
-			t.Errorf("descriptor directory %q survived the invocation that created it", dir)
-		}
+	if dirs := descriptorDirs(t, outputDir); len(dirs) != 0 {
+		t.Errorf("descriptor directories %v survived the invocation that created them", dirs)
 	}
 }
 
@@ -535,8 +544,6 @@ printf 'package half\n' > "$out/half.go"
 exit 3
 `))
 	g.log = log
-
-	before := descriptorDirs(t)
 
 	projectRoot, outputDir := newProject(t)
 	err := generateOne(ctx, g, projectRoot, outputDir, nil, testSchema("User"))
@@ -585,10 +592,8 @@ exit 3
 		t.Errorf("nothing in the log reports the exit status: %v", records())
 	}
 
-	for dir := range descriptorDirs(t) {
-		if _, ok := before[dir]; !ok {
-			t.Errorf("descriptor directory %q survived a failed invocation", dir)
-		}
+	if dirs := descriptorDirs(t, outputDir); len(dirs) != 0 {
+		t.Errorf("descriptor directories %v survived a failed invocation", dirs)
 	}
 }
 
@@ -1513,8 +1518,6 @@ func TestGeneratorGenerateCancellation(t *testing.T) {
 	// streams, and the test binary would then outlive its own generator.
 	g := testGenerator(t, writeShellGenerator(t, fmt.Sprintf(": > '%s'\nexec sleep 300\n", started)))
 
-	before := descriptorDirs(t)
-
 	projectRoot, outputDir := newProject(t)
 	done := make(chan error, 1)
 	go func() {
@@ -1545,10 +1548,8 @@ func TestGeneratorGenerateCancellation(t *testing.T) {
 		t.Fatal("generate did not return after its context was cancelled")
 	}
 
-	for dir := range descriptorDirs(t) {
-		if _, ok := before[dir]; !ok {
-			t.Errorf("descriptor directory %q survived a cancelled invocation", dir)
-		}
+	if dirs := descriptorDirs(t, outputDir); len(dirs) != 0 {
+		t.Errorf("descriptor directories %v survived a cancelled invocation", dirs)
 	}
 
 	// The scratch directory goes with it. Cancellation is the case that used to
@@ -1564,20 +1565,28 @@ func TestGeneratorGenerateCancellation(t *testing.T) {
 	}
 }
 
-// descriptorDirs is the set of per-invocation descriptor directories currently
-// on disk for the stand-in generator.
-func descriptorDirs(t *testing.T) map[string]struct{} {
+// descriptorDirs is every per-invocation descriptor directory the stand-in
+// generator has left in one output tree.
+//
+// It looks in the output tree rather than under os.TempDir since #218, and the
+// assertion it supports got stronger for it: the output tree is created by the
+// test that asks, so "none of these" is a claim about this invocation alone.
+// Under the old location a leftover from a crashed earlier run — or from another
+// package's temporary files — had to be subtracted first.
+func descriptorDirs(t *testing.T, output string) []string {
 	t.Helper()
 
-	matches, err := filepath.Glob(filepath.Join(os.TempDir(), testGeneratorName+"-descriptor-*"))
+	matches, err := filepath.Glob(filepath.Join(output, "."+testGeneratorName+"-descriptor-*"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	dirs := make(map[string]struct{}, len(matches))
-	for _, m := range matches {
-		dirs[m] = struct{}{}
-	}
-	return dirs
+	slices.Sort(matches)
+	return matches
+}
+
+// within reports whether path is dir or is beneath it.
+func within(path, dir string) bool {
+	return path == dir || strings.HasPrefix(path, dir+string(filepath.Separator))
 }
 
 // TestGeneratorArgs pins the vector docs/plugin/SPEC.md specifies, including

--- a/internal/avroc/descriptor.go
+++ b/internal/avroc/descriptor.go
@@ -41,6 +41,35 @@ const descriptorFilename = "descriptor.binpb"
 // into a descriptor quietly different from the one avroc wrote.
 const descriptorFileMode os.FileMode = 0o444
 
+// newDescriptorDir creates the private directory one generator invocation's
+// descriptor is written into, and which the path at --descriptor names.
+//
+// docs/plugin/SPEC.md's "Location and lifetime" is what this implements: a
+// directory created for that one invocation and nothing else, never shared
+// between two generators or two runs, so a descriptor on disk belongs to exactly
+// one generator and one run and cannot have been overwritten by whichever
+// invocation happened to finish last.
+//
+// It is created *inside* the generator's own output tree, beside the scratch
+// directory --out names (newScratchDir), rather than under os.TempDir (#218).
+// avroc reads no ambient temporary directory at all, which is what lets the
+// published image be scratch plus the files docs/container/SPEC.md names — with
+// no /tmp in it, and no --tmpfs on the `docker run` line an adopter copies. The
+// leading dot keeps it out of a shell glob for the moment it exists, and the name
+// says what left it behind if a hard kill ever stops the removal from running,
+// exactly as the scratch directory's does.
+//
+// Nothing here is a promise about the path: docs/plugin/SPEC.md forbids a plugin
+// deriving anything from the descriptor's name or its directory, so a plugin that
+// notices this location has already broken that rule rather than found a feature.
+func newDescriptorDir(output, generatorName string) (string, error) {
+	dir, err := os.MkdirTemp(output, "."+generatorName+"-descriptor-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create descriptor directory: %w", err)
+	}
+	return dir, nil
+}
+
 // newDescriptor builds the descriptor for a single generator invocation: the IR
 // contract version, that generator's own options, and the resolved schemas it
 // was asked to generate from.

--- a/internal/avroc/descriptor.go
+++ b/internal/avroc/descriptor.go
@@ -59,6 +59,17 @@ const descriptorFileMode os.FileMode = 0o444
 // says what left it behind if a hard kill ever stops the removal from running,
 // exactly as the scratch directory's does.
 //
+// A leftover is **permanent**, and that is the one way the new location is worse
+// than the old one rather than merely different. Under os.TempDir the operating
+// system eventually reaped what a SIGKILL left; here nothing does — the directory
+// is in no merge plan, so pruneStale never sees it, and it is not in
+// avroc.gen.json, so no later run is entitled to remove it. What it costs is one
+// dot-directory per killed invocation, holding one read-only file, which `rm -rf`
+// and `git clean -fd` both take. A sweep of `.<generator>-descriptor-*` at startup
+// is deliberately not the answer: two avroc runs over one project are allowed, and
+// a sweep would remove a directory the other one is still reading its descriptor
+// from.
+//
 // Nothing here is a promise about the path: docs/plugin/SPEC.md forbids a plugin
 // deriving anything from the descriptor's name or its directory, so a plugin that
 // notices this location has already broken that rule rather than found a feature.

--- a/internal/avroc/descriptor_location_test.go
+++ b/internal/avroc/descriptor_location_test.go
@@ -291,6 +291,12 @@ func TestEitherDirectoryFailingIsReportedAsItself(t *testing.T) {
 
 	t.Run("the descriptor directory cannot be created", func(t *testing.T) {
 		if os.Geteuid() == 0 {
+			// Root ignores the missing write bit, and no portable arrangement makes
+			// MkdirTemp fail where MkdirAll has just succeeded without one. So this
+			// half of the pair — the end-to-end ordering — is unexercised for a test
+			// binary running as root, which includes the containerised check stages;
+			// TestNewDescriptorDirNamesTheParentItCouldNotUse below is the part of it
+			// that runs everywhere.
 			t.Skip("running as root, which writes into a directory with no write bit")
 		}
 
@@ -324,6 +330,37 @@ func TestEitherDirectoryFailingIsReportedAsItself(t *testing.T) {
 		assertReported(t, records, "failed to create descriptor directory")
 		assertNotReported(t, records, "failed to create output directory")
 	})
+}
+
+// TestNewDescriptorDirNamesTheParentItCouldNotUse is the root-proof half of the
+// pair above: a parent it cannot make a directory in is reported as a failure to
+// create the *descriptor* directory, whatever the test binary's privileges.
+//
+// It is a unit test of the one function rather than a run through generator.run,
+// because reaching this failure through run means getting MkdirAll to succeed and
+// MkdirTemp to fail, and the only portable way to arrange that is a write bit —
+// which root ignores. What it gives up is the ordering, and what it keeps is the
+// classification, which is the half that would silently become "failed to create
+// output directory" if the two calls were ever collapsed into one report.
+func TestNewDescriptorDirNamesTheParentItCouldNotUse(t *testing.T) {
+	notADirectory := filepath.Join(t.TempDir(), "gen")
+	if err := os.WriteFile(notADirectory, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := newDescriptorDir(notADirectory, testGeneratorName)
+	if err == nil {
+		t.Fatalf("newDescriptorDir returned %q for a parent that is a regular file", dir)
+	}
+	if !strings.Contains(err.Error(), "failed to create descriptor directory") {
+		t.Errorf("error %q does not say the descriptor directory could not be created", err)
+	}
+	// The parent is named, because the two directories are now one inside the
+	// other and "it could not be created" without saying where is a report that
+	// sends its reader to the wrong end of the problem.
+	if !strings.Contains(err.Error(), notADirectory) {
+		t.Errorf("error %q does not name the parent %q it could not use", err, notADirectory)
+	}
 }
 
 // assertReported requires message to be among what was logged.

--- a/internal/avroc/descriptor_location_test.go
+++ b/internal/avroc/descriptor_location_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/z5labs/avroc/avrocpb"
+)
+
+// Where the descriptor lives, and why it is checked from the generator's side.
+//
+// #218 moved the per-invocation descriptor directory out of os.TempDir and into
+// the generator's own output tree, beside the scratch directory --out names. What
+// docs/plugin/SPEC.md requires of it did not change and is checked where it
+// always was — TestGeneratorGenerate reads the descriptor the generator was
+// handed, its mode, and its removal. What is new is a location inside a directory
+// avroc also walks, merges from, prunes against and records, so the claim that
+// has to be made here is a negative one: nothing that reads the output tree can
+// see it.
+//
+// Every assertion below is made from inside the running generator or from the
+// tree afterwards, never from avroc's own variables. A check written against
+// descriptorDir would pass on an avroc that handed the generator some other path
+// entirely.
+
+// listOutputScript is the body of a generator that records what it can see —
+// every entry in its own --out, and every entry in the directory holding the
+// descriptor — and then writes files.
+//
+// The listings are taken before it writes anything, which is the only vantage
+// point from which "--out is empty, and the descriptor is not in it" is
+// observable at all.
+func listOutputScript(outListing, treeListing string, files ...string) string {
+	var writes strings.Builder
+	for _, f := range files {
+		fmt.Fprintf(&writes, "printf '%%s\\n' 'generated' > \"$out/%s\"\n", f)
+	}
+
+	return fmt.Sprintf(`set -e
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --descriptor) descriptor=$2; shift 2 ;;
+    --out) out=$2; shift 2 ;;
+    --opt) shift 2 ;;
+    *) echo "error: unexpected argument $1" >&2; exit 1 ;;
+  esac
+done
+
+ls -A "$out" > '%s'
+ls -A "$(dirname "$(dirname "$descriptor")")" > '%s'
+%s`, outListing, treeListing, writes.String())
+}
+
+// TestTheDescriptorDirectoryIsInvisibleToTheOutputTree is #218's claim about the
+// new location, made with two generators sharing one output tree so that the
+// descriptor directory has a neighbour to be confused with.
+//
+// The four things it must be invisible to are the four things avroc does with
+// that tree: hand it to a generator as --out, walk it into a merge plan, merge
+// those plans against each other, and record what was merged. A descriptor
+// directory that reached any one of them would be adopted as output, reported as
+// a collision, or written into avroc.gen.json for the next run to prune.
+func TestTheDescriptorDirectoryIsInvisibleToTheOutputTree(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	projectRoot, output := newProject(t)
+	listings := t.TempDir()
+
+	type generatorRun struct {
+		name        string
+		file        string
+		outListing  string
+		treeListing string
+	}
+	runs := []generatorRun{
+		{name: "first", file: "first.avsc"},
+		{name: "second", file: "second.avsc"},
+	}
+
+	tasks := make([]genTask, 0, len(runs))
+	for i := range runs {
+		runs[i].outListing = filepath.Join(listings, runs[i].name+".out")
+		runs[i].treeListing = filepath.Join(listings, runs[i].name+".tree")
+
+		body := listOutputScript(runs[i].outListing, runs[i].treeListing, runs[i].file)
+		tasks = append(tasks, genTask{
+			name:           "avroc-gen-" + runs[i].name,
+			executablePath: writeNamedShellGenerator(t, runs[i].name, body),
+			output:         output,
+			schemas:        []*avrocpb.Schema{testSchema("User")},
+		})
+	}
+
+	if err := generateAll(ctx, log, projectRoot, tasks); err != nil {
+		t.Fatalf("two generators sharing an output tree failed: %v", err)
+	}
+
+	for _, run := range runs {
+		// --out is empty when the generator starts, which docs/plugin/SPEC.md's
+		// "The output directory" promises outright: the descriptor directory is a
+		// sibling of it and never inside it, so a generator walking its own
+		// directory cannot reach the descriptor and cannot mistake it for a file
+		// it wrote.
+		if entries := listedEntries(t, run.outListing); len(entries) != 0 {
+			t.Errorf("generator %q was handed an --out holding %v", run.name, entries)
+		}
+
+		// The tree that holds the descriptor is the project's output tree — which
+		// is the whole of the move — and everything this run put in it while the
+		// generator was running is hidden. The tree started empty, so every entry
+		// here belongs to the run rather than to the project.
+		entries := listedEntries(t, run.treeListing)
+		if len(entries) == 0 {
+			t.Errorf("generator %q saw nothing in the directory holding its descriptor", run.name)
+		}
+		var ownDescriptor bool
+		for _, e := range entries {
+			if !strings.HasPrefix(e, ".") {
+				t.Errorf("generator %q saw %q beside its descriptor, which is not a hidden per-invocation directory", run.name, e)
+			}
+			if strings.HasPrefix(e, ".avroc-gen-"+run.name+"-descriptor-") {
+				ownDescriptor = true
+			}
+		}
+		if !ownDescriptor {
+			t.Errorf("generator %q did not see its own descriptor directory in %v: the descriptor is not in the output tree", run.name, entries)
+		}
+	}
+
+	// Nothing of either invocation survives the merge, so the tree a person is
+	// about to commit holds the generated files and nothing else.
+	want := []string{"first.avsc", "second.avsc"}
+	if got := treeEntries(t, output); !slices.Equal(got, want) {
+		t.Errorf("the output tree holds %v, want %v", got, want)
+	}
+
+	// And the record names exactly them. A descriptor directory that had reached
+	// a merge plan would be recorded here, and the next run would prune a path
+	// avroc never wrote.
+	recorded := recordedFiles(t, projectRoot)
+	wantRecorded := []string{"gen/first.avsc", "gen/second.avsc"}
+	if !slices.Equal(recorded, wantRecorded) {
+		t.Errorf("%s records %v, want %v", outputRecordFilename, recorded, wantRecorded)
+	}
+}
+
+// listedEntries reads a listing one of the generators above wrote.
+func listedEntries(t *testing.T, path string) []string {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the generator did not record a listing: %v", err)
+	}
+	var entries []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if line != "" {
+			entries = append(entries, line)
+		}
+	}
+	slices.Sort(entries)
+	return entries
+}
+
+// treeEntries is every path beneath dir, relative and slash-separated.
+func treeEntries(t *testing.T, dir string) []string {
+	t.Helper()
+
+	var found []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == dir {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		found = append(found, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(found)
+	return found
+}
+
+// recordedFiles is what avroc.gen.json names, read as the file rather than
+// through loadOutputRecord: the record is what a later run prunes against, and
+// what is on disk is the only form of it that matters.
+func recordedFiles(t *testing.T, projectRoot string) []string {
+	t.Helper()
+
+	b, err := os.ReadFile(filepath.Join(projectRoot, outputRecordFilename))
+	if err != nil {
+		t.Fatalf("a successful run left no %s: %v", outputRecordFilename, err)
+	}
+	var record outputRecord
+	if err := json.Unmarshal(b, &record); err != nil {
+		t.Fatalf("failed to parse %s: %v", outputRecordFilename, err)
+	}
+	return record.Files
+}
+
+// TestTheOutputDirectoryIsCreatedBeforeTheDescriptorNeedsIt is the ordering
+// #218 flipped, checked through its consequence rather than by reading the
+// source: the descriptor is written into the output tree, so a manifest naming
+// an output directory that does not exist yet — several levels of it — has to
+// have that directory created first, and the invocation that used to only need
+// it for --out now needs it for both.
+func TestTheOutputDirectoryIsCreatedBeforeTheDescriptorNeedsIt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	scratch := t.TempDir()
+	argsPath := filepath.Join(scratch, "args")
+	copyPath := filepath.Join(scratch, "descriptor.copy")
+
+	g := testGenerator(t, writeShellGenerator(t, recordArgsScript(argsPath, copyPath, "output.go")))
+
+	projectRoot := t.TempDir()
+	outputDir := filepath.Join(projectRoot, "gen", "go", "avro")
+
+	if err := generateOne(ctx, g, projectRoot, outputDir, nil, testSchema("User")); err != nil {
+		t.Fatalf("generation into an output directory that did not exist failed: %v", err)
+	}
+
+	// The generator could read the descriptor, which is the whole of the claim:
+	// a descriptor directory made before its parent existed would have failed the
+	// invocation instead.
+	if _, err := os.ReadFile(copyPath); err != nil {
+		t.Errorf("the generator could not read the descriptor it was handed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "output.go")); err != nil {
+		t.Errorf("expected the generator's file merged into the created output directory: %v", err)
+	}
+	if dirs := descriptorDirs(t, outputDir); len(dirs) != 0 {
+		t.Errorf("descriptor directories %v survived the invocation that created them", dirs)
+	}
+}
+
+// TestEitherDirectoryFailingIsReportedAsItself is the other half of the flip.
+// The two directories are now one inside the other, so the failure to create the
+// output tree and the failure to create the descriptor's own directory inside it
+// are adjacent in a way they were not before — and reporting one as the other
+// would send a reader to the wrong end of the problem.
+func TestEitherDirectoryFailingIsReportedAsItself(t *testing.T) {
+	t.Run("the output directory cannot be created", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		log, records := recordingLogger()
+		g := testGenerator(t, writeShellGenerator(t, "exit 0\n"))
+		g.log = log
+
+		// A regular file where a parent of the output directory would have to be,
+		// so MkdirAll cannot create it and nothing about the descriptor has been
+		// reached yet.
+		projectRoot := t.TempDir()
+		blocked := filepath.Join(projectRoot, "gen")
+		if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := generateOne(ctx, g, projectRoot, filepath.Join(blocked, "go"), nil, testSchema("User"))
+		if err == nil {
+			t.Fatal("generation succeeded with a file where the output directory had to be")
+		}
+		assertReported(t, records, "failed to create output directory")
+		assertNotReported(t, records, "failed to create descriptor directory")
+	})
+
+	t.Run("the descriptor directory cannot be created", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root, which writes into a directory with no write bit")
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		log, records := recordingLogger()
+		g := testGenerator(t, writeShellGenerator(t, "exit 0\n"))
+		g.log = log
+
+		// The output directory exists and is not writable, so MkdirAll is happy
+		// with it and the descriptor's directory is the first thing that cannot be
+		// made.
+		projectRoot := t.TempDir()
+		outputDir := filepath.Join(projectRoot, "gen")
+		if err := os.Mkdir(outputDir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			// Restored so that the test's own temporary directory can be removed.
+			_ = os.Chmod(outputDir, 0o755)
+		})
+
+		err := generateOne(ctx, g, projectRoot, outputDir, nil, testSchema("User"))
+		if err == nil {
+			t.Fatal("generation succeeded with an output directory it could not write into")
+		}
+		if !strings.Contains(err.Error(), "failed to create descriptor directory") {
+			t.Errorf("error %q does not say the descriptor directory could not be created", err)
+		}
+		assertReported(t, records, "failed to create descriptor directory")
+		assertNotReported(t, records, "failed to create output directory")
+	})
+}
+
+// assertReported requires message to be among what was logged.
+func assertReported(t *testing.T, records func() []recordedLine, message string) {
+	t.Helper()
+
+	for _, r := range records() {
+		if r.message == message {
+			return
+		}
+	}
+	t.Errorf("nothing in the log reports %q: %v", message, records())
+}
+
+// assertNotReported requires message not to be among what was logged, which is
+// how one of two adjacent failures is held to being reported as itself.
+func assertNotReported(t *testing.T, records func() []recordedLine, message string) {
+	t.Helper()
+
+	for _, r := range records() {
+		if r.message == message {
+			t.Errorf("the failure was also reported as %q", message)
+			return
+		}
+	}
+}

--- a/internal/avroc/merge.go
+++ b/internal/avroc/merge.go
@@ -37,6 +37,12 @@ import (
 // That is what lets mergeOutput move each file with a rename rather than a copy,
 // which is in turn what keeps the merge short enough to be hard to interrupt.
 // The leading dot keeps it out of a shell glob for the moment it exists.
+//
+// Since #218 it has a neighbour: newDescriptorDir creates this invocation's
+// descriptor directory in the same tree, on the same terms and for a different
+// reason. The two are siblings and never nested, so a generator walking its own
+// --out cannot reach the descriptor and nothing avroc merges, prunes or records
+// can reach either.
 func newScratchDir(output, generatorName string) (string, error) {
 	dir, err := os.MkdirTemp(output, "."+generatorName+"-out-")
 	if err != nil {

--- a/internal/avroc/tempdir_test.go
+++ b/internal/avroc/tempdir_test.go
@@ -41,6 +41,18 @@ import (
 // It is a source scan for the reason internal/plugin's determinism check is one:
 // no run of the tests can catch it, because every machine the tests run on has a
 // temporary directory. Only the published image does not.
+//
+// What the scan cannot see is worth writing down, because it is what keeps this
+// from being read as a proof. It matches names in one file at a time, so a parent
+// that is empty by way of a variable — `dir := ""; os.MkdirTemp(dir, …)` — reads as
+// a temporary directory with a parent, and a dependency doing any of this is
+// outside the scanned tree entirely. A dot import would hide a call from the walk
+// altogether, so a file dot-importing one of the packages the ban is keyed on is
+// itself reported rather than scanned and passed. The end-to-end check is
+// `dagger call regeneration`, whose scratch containers have no /tmp and a TMPDIR
+// naming a directory that is not there: it catches every one of those, including
+// the dependency, and it catches them as a failed generation rather than as a
+// finding. This scan is what makes the failure legible at the line that caused it.
 
 // moduleRoot is this module's root directory, relative to this package, which is
 // what the scanned directories below are resolved from.
@@ -67,9 +79,21 @@ func tempDirScanDirs() []string {
 func ambientTempFuncs() map[string]map[string]string {
 	const ambient = "answers with the machine's temporary directory, which a scratch image has none of"
 
+	// io/ioutil is deprecated and nothing here imports it, and both of its
+	// spellings are banned outright anyway: they are what somebody copying from
+	// older code reaches for, and a ban keyed on os alone would let
+	// ioutil.TempDir("", …) through while reporting that avroc reads no ambient
+	// temporary directory. Outright rather than only-without-a-parent, because
+	// ioutil.TempDir with a parent has os.MkdirTemp to be written as instead.
+	const deprecated = "is io/ioutil's temporary directory; use os.MkdirTemp with a parent"
+
 	return map[string]map[string]string{
 		"os": {
 			"TempDir": ambient,
+		},
+		"ioutil": {
+			"TempDir":  deprecated,
+			"TempFile": deprecated,
 		},
 	}
 }
@@ -135,7 +159,7 @@ func TestAvrocReadsNoAmbientTemporaryDirectory(t *testing.T) {
 // exactly the same from here.
 //
 // Each case is a way somebody would plausibly reintroduce the requirement, and
-// the last two are the ones a check aimed only at os.TempDir would miss.
+// the last three are the ones a check aimed only at os.TempDir would miss.
 func TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -172,13 +196,18 @@ func TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne(t *testing.
 			body: `func f() string { return stdos.TempDir() }`,
 			want: "TempDir",
 		},
+		{
+			name: "io/ioutil's spelling",
+			body: `func f() (string, error) { return ioutil.TempDir("", "descriptor-") }`,
+			want: "ioutil.TempDir",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			src := filepath.Join(dir, "scanned.go")
-			source := "package scanned\n\nimport (\n\t\"os\"\n\tstdos \"os\"\n)\n\nvar _ = os.Getpid\nvar _ = stdos.Getpid\n\n" + tc.body + "\n"
+			source := "package scanned\n\nimport (\n\t\"io/ioutil\"\n\t\"os\"\n\tstdos \"os\"\n)\n\nvar _ = os.Getpid\nvar _ = stdos.Getpid\nvar _ = ioutil.Discard\n\n" + tc.body + "\n"
 			if err := os.WriteFile(src, []byte(source), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -191,6 +220,33 @@ func TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne(t *testing.
 				t.Errorf("the check accepted %s; findings: %v", tc.body, findings)
 			}
 		})
+	}
+}
+
+// TestTheAmbientTemporaryDirectoryCheckReportsADotImportItCannotSeeThrough is
+// the one evasion the walk cannot be made to catch: `import . "os"` puts
+// `TempDir()` in the file as a bare identifier, with no selector to match. The
+// check reports the import itself rather than scanning the file and finding
+// nothing, which is the difference between a hole and a refusal.
+func TestTheAmbientTemporaryDirectoryCheckReportsADotImportItCannotSeeThrough(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "scanned.go")
+	source := `package scanned
+
+import . "os"
+
+func f() string { return TempDir() }
+`
+	if err := os.WriteFile(src, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := ambientTempFindings(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.ContainsFunc(findings, func(f string) bool { return strings.Contains(f, "dot-imported") }) {
+		t.Errorf("the check said nothing about a dot import of os; findings: %v", findings)
 	}
 }
 
@@ -250,12 +306,23 @@ func goSourcesUnder(dir string) ([]string, error) {
 //
 // The import is resolved to its path rather than assumed from the local name, so
 // a file importing os under another name is scanned as os and a local variable
-// called os is not mistaken for the package.
+// called os is not mistaken for the package. A **dot import** of a package the
+// ban is keyed on is reported outright instead: it puts the call in the file as a
+// bare identifier with no selector for the walk to match, so the alternative is
+// not scanning it and saying nothing.
 func ambientTempFindings(path string) ([]string, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 	if err != nil {
 		return nil, err
+	}
+
+	banned := ambientTempFuncs()
+	needParent := tempFuncsNeedingAParent()
+
+	var findings []string
+	report := func(pos token.Pos, format string, args ...any) {
+		findings = append(findings, fmt.Sprintf("%s: %s", fset.Position(pos), fmt.Sprintf(format, args...)))
 	}
 
 	// Local name to import path, for every import this file has.
@@ -269,15 +336,13 @@ func ambientTempFindings(path string) ([]string, error) {
 		if spec.Name != nil {
 			name = spec.Name.Name
 		}
+		if name == "." {
+			if _, keyed := banned[importPath[strings.LastIndex(importPath, "/")+1:]]; keyed {
+				report(spec.Pos(), "%q is dot-imported, which puts its functions in this file without a selector this check can see", importPath)
+			}
+			continue
+		}
 		imports[name] = importPath
-	}
-
-	banned := ambientTempFuncs()
-	needParent := tempFuncsNeedingAParent()
-
-	var findings []string
-	report := func(pos token.Pos, format string, args ...any) {
-		findings = append(findings, fmt.Sprintf("%s: %s", fset.Position(pos), fmt.Sprintf(format, args...)))
 	}
 
 	ast.Inspect(file, func(n ast.Node) bool {

--- a/internal/avroc/tempdir_test.go
+++ b/internal/avroc/tempdir_test.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avroc
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Why avroc reads no ambient temporary directory at all (#218).
+//
+// One line in this package used to need a writable /tmp — the descriptor
+// directory, created with os.MkdirTemp("", …) — and it is the reason
+// .dagger/image.go grafted a 1777 /tmp into an image whose whole claim is
+// "scratch plus the files docs/container/SPEC.md names". The cost of keeping it
+// was not the directory: it was that every `docker run` line in the README, in
+// docs/container/SPEC.md and in the worked example would have grown a
+// `--tmpfs /tmp:mode=1777`, and an adopter who forgot it would get a Go standard
+// library message about a directory they never asked for, from a program that had
+// not reached its own argument parsing.
+//
+// So the requirement was removed rather than carried: the descriptor now goes
+// into the generator's own output tree (newDescriptorDir), beside the scratch
+// directory --out names. This check is what keeps it removed. A single
+// os.MkdirTemp("", …) reintroduced anywhere avroc is built from would put the
+// mount flag back on all of those command lines, and it would do it silently —
+// on the developer's machine, in CI and in every container with a /tmp, it
+// simply works.
+//
+// It is a source scan for the reason internal/plugin's determinism check is one:
+// no run of the tests can catch it, because every machine the tests run on has a
+// temporary directory. Only the published image does not.
+
+// moduleRoot is this module's root directory, relative to this package, which is
+// what the scanned directories below are resolved from.
+func moduleRoot() string {
+	return filepath.Join("..", "..")
+}
+
+// tempDirScanDirs are the directories avroc and its generators are built from —
+// everything that ends up in one of the four published executables is under one
+// of them — written out so that a new top-level directory holding runtime code is
+// a deliberate addition to this list rather than a silent gap in it.
+//
+// The two Dagger modules are deliberately absent: they are separate modules that
+// build and check images rather than run inside one, and a temporary directory on
+// the engine is not a temporary directory in a scratch container.
+func tempDirScanDirs() []string {
+	return []string{"internal", "cmd", "avrocpb"}
+}
+
+// ambientTempFuncs are the functions whose answer is the machine's temporary
+// directory rather than a path avroc chose. Naming one at all is the finding,
+// not calling it: a function value is the same read one level of indirection
+// away.
+func ambientTempFuncs() map[string]map[string]string {
+	const ambient = "answers with the machine's temporary directory, which a scratch image has none of"
+
+	return map[string]map[string]string{
+		"os": {
+			"TempDir": ambient,
+		},
+	}
+}
+
+// ambientTempEnv are the environment variables that name a temporary directory.
+// avroc reads none of them, and the string appearing in this source at all is
+// what the check reports — an avroc that consulted TMPDIR by hand would put the
+// image's /tmp back without ever naming os.TempDir.
+func ambientTempEnv() []string {
+	return []string{"TMPDIR", "TMP", "TEMP", "TEMPDIR"}
+}
+
+// tempFuncsNeedingAParent are the functions that fall back to the machine's
+// temporary directory when their first argument is empty. They are perfectly
+// good with a parent — newDescriptorDir and newScratchDir are both built on one
+// — so what is banned is the empty first argument and not the function.
+func tempFuncsNeedingAParent() map[string][]string {
+	return map[string][]string{
+		"os": {"MkdirTemp", "CreateTemp"},
+	}
+}
+
+// TestAvrocReadsNoAmbientTemporaryDirectory is #218 held as a property of the
+// source: nothing in internal/, cmd/ or avrocpb/ asks the machine where to put a
+// temporary file.
+//
+// Test files are excluded, and t.TempDir is why. A test may put its fixtures
+// wherever the machine likes — it is not what runs inside the published image —
+// and every test in this repository does exactly that.
+func TestAvrocReadsNoAmbientTemporaryDirectory(t *testing.T) {
+	var scanned int
+	for _, dir := range tempDirScanDirs() {
+		sources, err := goSourcesUnder(filepath.Join(moduleRoot(), dir))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", dir, err)
+		}
+		if len(sources) == 0 {
+			t.Errorf("no non-test Go source found under %s: the check is looking in the wrong place", dir)
+		}
+		scanned += len(sources)
+
+		for _, src := range sources {
+			findings, err := ambientTempFindings(src)
+			if err != nil {
+				t.Fatalf("failed to scan %s: %v", src, err)
+			}
+			for _, finding := range findings {
+				t.Errorf("%s (#218: avroc writes each invocation's descriptor into the generator's own output tree, so the published image needs no /tmp)", finding)
+			}
+		}
+	}
+
+	// A scan that read nothing passes vacuously, and the directories above are
+	// relative paths that a package move would quietly invalidate.
+	if scanned == 0 {
+		t.Fatal("no Go source was scanned at all")
+	}
+}
+
+// TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne runs the
+// check's failure path, which is otherwise never run: the committed tree passes
+// by construction, so a check that had stopped reporting anything would look
+// exactly the same from here.
+//
+// Each case is a way somebody would plausibly reintroduce the requirement, and
+// the last two are the ones a check aimed only at os.TempDir would miss.
+func TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "os.TempDir called",
+			body: `func f() string { return os.TempDir() }`,
+			want: "os.TempDir",
+		},
+		{
+			name: "os.TempDir taken as a value",
+			body: `func f() func() string { return os.TempDir }`,
+			want: "os.TempDir",
+		},
+		{
+			name: "MkdirTemp with no parent",
+			body: `func f() (string, error) { return os.MkdirTemp("", "descriptor-*") }`,
+			want: "os.MkdirTemp",
+		},
+		{
+			name: "CreateTemp with no parent",
+			body: `func f() (*os.File, error) { return os.CreateTemp("", "descriptor-*") }`,
+			want: "os.CreateTemp",
+		},
+		{
+			name: "TMPDIR read by name",
+			body: `func f(env map[string]string) string { return env["TMPDIR"] }`,
+			want: "TMPDIR",
+		},
+		{
+			name: "os imported under another name",
+			body: `func f() string { return stdos.TempDir() }`,
+			want: "TempDir",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "scanned.go")
+			source := "package scanned\n\nimport (\n\t\"os\"\n\tstdos \"os\"\n)\n\nvar _ = os.Getpid\nvar _ = stdos.Getpid\n\n" + tc.body + "\n"
+			if err := os.WriteFile(src, []byte(source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			findings, err := ambientTempFindings(src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.ContainsFunc(findings, func(f string) bool { return strings.Contains(f, tc.want) }) {
+				t.Errorf("the check accepted %s; findings: %v", tc.body, findings)
+			}
+		})
+	}
+}
+
+// TestTheAmbientTemporaryDirectoryCheckAcceptsATemporaryDirectoryWithAParent is
+// the other side of the previous test, and it is what stops the ban being
+// widened into "avroc may not create a temporary directory". It may — it creates
+// two per invocation — as long as it says where.
+func TestTheAmbientTemporaryDirectoryCheckAcceptsATemporaryDirectoryWithAParent(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "scanned.go")
+	source := `package scanned
+
+import "os"
+
+func f(parent string) (string, error) { return os.MkdirTemp(parent, ".descriptor-") }
+`
+	if err := os.WriteFile(src, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := ambientTempFindings(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("the check reported %v for a temporary directory created inside a named parent", findings)
+	}
+}
+
+// goSourcesUnder is every non-test Go file beneath dir, sorted.
+func goSourcesUnder(dir string) ([]string, error) {
+	var sources []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		sources = append(sources, p)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(sources)
+	return sources, nil
+}
+
+// ambientTempFindings reports every way one file asks the machine for a
+// temporary directory: a reference to one of [ambientTempFuncs], one of
+// [tempFuncsNeedingAParent] called with an empty first argument, or one of
+// [ambientTempEnv] written as a string.
+//
+// The import is resolved to its path rather than assumed from the local name, so
+// a file importing os under another name is scanned as os and a local variable
+// called os is not mistaken for the package.
+func ambientTempFindings(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	// Local name to import path, for every import this file has.
+	imports := make(map[string]string)
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			return nil, err
+		}
+		name := importPath[strings.LastIndex(importPath, "/")+1:]
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		imports[name] = importPath
+	}
+
+	banned := ambientTempFuncs()
+	needParent := tempFuncsNeedingAParent()
+
+	var findings []string
+	report := func(pos token.Pos, format string, args ...any) {
+		findings = append(findings, fmt.Sprintf("%s: %s", fset.Position(pos), fmt.Sprintf(format, args...)))
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			pkg, ok := selectedPackage(node, imports)
+			if !ok {
+				return true
+			}
+			if why, banned := banned[pkg][node.Sel.Name]; banned {
+				report(node.Pos(), "%s.%s %s", pkg, node.Sel.Name, why)
+			}
+		case *ast.CallExpr:
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selectedPackage(sel, imports)
+			if !ok {
+				return true
+			}
+			if !slices.Contains(needParent[pkg], sel.Sel.Name) {
+				return true
+			}
+			if len(node.Args) == 0 || !isEmptyString(node.Args[0]) {
+				return true
+			}
+			report(node.Pos(), "%s.%s is called with no parent directory, so it falls back to the machine's temporary directory", pkg, sel.Sel.Name)
+		case *ast.BasicLit:
+			if node.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(node.Value)
+			if err != nil {
+				return true
+			}
+			if slices.Contains(ambientTempEnv(), value) {
+				report(node.Pos(), "%q names an ambient temporary directory", value)
+			}
+		}
+		return true
+	})
+	return findings, nil
+}
+
+// selectedPackage resolves the package half of a selector to its import path's
+// last element, so that a file importing os under another name is still read as
+// os. It reports false for a selector on anything that is not an imported
+// package.
+func selectedPackage(sel *ast.SelectorExpr, imports map[string]string) (string, bool) {
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	importPath, ok := imports[ident.Name]
+	if !ok {
+		return "", false
+	}
+	return importPath[strings.LastIndex(importPath, "/")+1:], true
+}
+
+// isEmptyString reports whether an argument is the literal "".
+func isEmptyString(arg ast.Expr) bool {
+	lit, ok := arg.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	return err == nil && value == ""
+}


### PR DESCRIPTION
Closes #218

`internal/avroc/avroc.go` held the only line in this repository that needed a
writable `/tmp` — `os.MkdirTemp("", g.name+"-descriptor-*")` — and it is the
reason `.dagger/image.go` grafted a 1777 `/tmp` into an image whose whole claim
is "scratch plus the files `docs/container/SPEC.md` names". The descriptor now
goes into the generator's own output tree, in a hidden per-invocation directory
beside the scratch directory `--out` names (`newDescriptorDir`), created and
removed on the same terms as its neighbour. The requirement is **removed** rather
than pushed onto the caller: every `docker run` line in the README, in
`docs/container/SPEC.md` and in the worked example stays exactly as written, with
no `--tmpfs` and no volume.

## Acceptance criteria

- [x] `internal/avroc` calls `os.MkdirTemp` with a parent, never `""`; nothing in
      `internal/`, `cmd/` or `avrocpb/` reads `os.TempDir`, `TMPDIR` or any other
      ambient temporary directory, and the descriptor directory is created inside
      the generator's output directory beside the scratch `--out`.
      `TestAvrocReadsNoAmbientTemporaryDirectory` is that as a source scan.
- [x] The output directory is created before the descriptor directory needs it —
      the ordering in `generator.run` flips — and the failure of either is still
      reported as itself
      (`TestTheOutputDirectoryIsCreatedBeforeTheDescriptorNeedsIt`,
      `TestEitherDirectoryFailingIsReportedAsItself`).
- [x] Everything `docs/plugin/SPEC.md`'s "Location and lifetime" requires is
      unchanged and still checked in `TestGeneratorGenerate` and its failure,
      signal and cancellation siblings: one directory per invocation holding one
      file, never shared, written in full and closed before the generator starts,
      mode `0444`, removed with its directory whatever the exit status, and named
      to the child as an absolute path.
- [x] The descriptor directory is invisible to everything that walks the output
      tree — `TestTheDescriptorDirectoryIsInvisibleToTheOutputTree`, two
      generators sharing one tree: neither is handed an `--out` holding anything,
      each sees its own descriptor directory hidden in the tree while it runs, the
      tree afterwards holds the two generated files and nothing else, and
      `avroc.gen.json` names exactly those two.
- [x] `docs/plugin/SPEC.md` is **not** modified.
- [x] `.dagger/image.go` stops building a `/tmp`: `tmpDir`, `tmpDirMode` and
      `tmpDirectory` are deleted and `ImageContract`'s exhaustive listing loses
      that row and gains nothing.
- [x] `dagger call regeneration` varies `regenerationRun.root`, which is now the
      prefix of both absolute paths on the vector, with the comment saying so —
      and keeps varying `TMPDIR` while the containers no longer have the
      directories it names, so a read put back anywhere fails the stage outright.
- [x] `image-contract`, `generator-image-contract`, `worked-example`,
      `companion-module`, `tls-egress` and `trace-propagation` all pass against an
      image with no `/tmp`, and none of them gained a mount, a flag or an
      environment variable to get there.
- [x] `docker run --rm -v "$PWD:/work" …` with no `--tmpfs` and no volume
      reproduces `example/` byte for byte, as 65532 and under
      `--user "$(id -u):$(id -g)"`.
- [x] `README.md` and `CONTRIBUTING.md` are untouched; `docs/container/SPEC.md`
      changes no command it prints — see the judgment call below.

## Judgment calls

**`docs/container/SPEC.md` did need a prose edit, and the issue predicted it
would not.** The issue says the document "never named it — confirm that rather
than assume it". Confirmed, and it is half true: the word `/tmp` appears zero
times, but the "No shell" section carried a paragraph stating that the image
*has* a writable temporary directory, under an explicit "not covered". That
sentence is now false, so the paragraph is replaced by one saying there is no
temporary directory and none is needed. No command in that document — or in the
README, or in `CONTRIBUTING.md` — changed, which is the constraint the issue
actually put on it.

**The `trace-propagation` launcher needed somewhere else to write.** It recorded
the `TRACEPARENT` Dagger handed the exec at `tmpDir + "/traceparent"`, borrowing
the directory this story deletes. It now writes into `/record`, a directory that
check adds to the image itself. `/work` is not an option — the record would fail
the byte-for-byte comparison against the committed example — and the plugin
directory is where a file is a generator. This is not the image gaining a
writable path to make avroc work: avroc needs none, which is the point.

**Two consequences accepted rather than discovered**, both already stated in the
issue: a `SIGKILL` now leaves a dot-directory in the project's output tree
instead of in `/tmp`, which `merge.go` already accepts for the scratch directory
and whose name says what left it; and the descriptor no longer lives in a
world-writable directory shared with every other process on the machine, which is
a small improvement and not the reason for the change.

## Verification

- Every `verify` command: `go build ./...`, `gofmt -l .` (empty), `go vet ./...`,
  `go test -race -cover ./...`, `golangci-lint run` (0 issues), and the
  `example/` round trip (`git diff --exit-code -- example` clean).
- `dagger call image-contract`, `generator-image-contract`, `regeneration`,
  `worked-example`, `companion-module`, `tls-egress` and `trace-propagation`, all
  green locally.
- The new assertions were mutation-checked: reverting `newDescriptorDir` to
  `os.MkdirTemp("", …)` fails `TestGeneratorGenerate` and
  `TestTheDescriptorDirectoryIsInvisibleToTheOutputTree`, and
  `TestTheAmbientTemporaryDirectoryCheckCatchesEachWayOfReadingOne` runs the
  source scan's failure path over each way of reading an ambient temporary
  directory.
- The bundle image exported and run through real `docker run` with no `--tmpfs`
  and no volume: byte-identical `example/` as the default 65532, under
  `--user "$(id -u):$(id -g)"`, and additionally with `--read-only` on the root
  filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
