### PR TITLE
story(container): let the caller point the working directory at the project, and stop shipping /work

### DIFF
--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -337,10 +337,14 @@ func (m *Avroc) checkGeneratorRuns(ctx context.Context, image *dagger.Container,
 		return err
 	}
 
+	// WithWorkdir as well as mounting there: since #219 the image declares no
+	// working directory, so a run that only mounted would start in / and fail to
+	// find avroc.json. See projectMount.
 	generated := image.
-		WithDirectory(workDir, project, dagger.ContainerWithDirectoryOpts{Owner: imageUser}).
+		WithDirectory(projectMount, project, dagger.ContainerWithDirectoryOpts{Owner: imageUser}).
+		WithWorkdir(projectMount).
 		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-		Directory(workDir + "/" + outDir)
+		Directory(projectMount + "/" + outDir)
 
 	entries, err := generated.Entries(ctx)
 	if err != nil {

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -379,7 +379,7 @@ func generatorProbe(schema *dagger.File, name, outDir string) (*dagger.Directory
 
 	return dag.Directory().
 		WithFile("schema.avdl", schema).
-		WithNewFile("avroc.json", string(manifest)), nil
+		WithNewFile(manifestFilename, string(manifest)), nil
 }
 
 // probeOptions is the least configuration a built-in generator needs to run at

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -71,15 +71,22 @@ import (
 //
 // pluginDir lives in main.go, because the regeneration stage's scratch container
 // is deliberately the same layout as the published image and both read it.
+// Two of the rows that used to be here are gone, and each absence is a decision
+// rather than an omission. They are recorded as comments in the block below,
+// where the constant they replace used to be, because a deleted constant leaves
+// nothing for a reader to find and both deletions are things a future change
+// would otherwise re-add in good faith.
 const (
 	// There is no working directory in this image, and its absence is a decision
-	// (#219). `WorkingDir` used to be /work and /work used to be created here,
-	// owned by the image's user, so that a caller could mount a project over it
-	// and pass no further arguments. Both are gone: the caller names the mount
-	// point on the command line — `-v "$PWD:/work" -w /work` — and the image
-	// declares nothing, which is what `docs/container/SPEC.md`'s "The working
-	// directory" now says. Nothing here stands in for it; see projectMount for
-	// what these checks do instead, and note that it is not in this block.
+	// (#219). WorkingDir was /work and /work was created here owned by the image's
+	// user, so that a caller could mount a project over it and pass no further
+	// arguments. Both are gone: the caller names the mount point on the command
+	// line — `-v "$PWD:/work" -w /work` — and the image declares nothing, which is
+	// what docs/container/SPEC.md's "The working directory" now says. Nothing here
+	// stands in for it, and in particular projectMount — which is where the checks
+	// in this module mount a project — is defined beside the check that uses it
+	// rather than in this block, because it is the caller's choice and not the
+	// image's contract.
 
 	// There is no temporary directory in this image, and its absence is a
 	// decision (#218). A 1777 /tmp used to be grafted on here, because avroc
@@ -249,6 +256,9 @@ func publishIndex(
 //     rather than to some other executable is `help` through the entrypoint and
 //     the usage avroc prints. Generation is checked where generation is
 //     possible, on the images that carry a generator (GeneratorImageContract).
+//   - The consequence of declaring no working directory (#219): a `generate` run
+//     with none set fails naming the manifest it could not find, rather than
+//     succeeding silently or failing in words a caller cannot act on.
 //
 // platform restricts the check to one of the published platforms; empty runs
 // every one of them, and every failure is reported rather than the first,
@@ -310,16 +320,23 @@ func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
 			Owner:       imageUser,
 			Permissions: 0o644,
 		}).
-		// No working directory, and no directory created to be one (#219). There
-		// is deliberately no WithWorkdir below either: a caller who mounts a
-		// project names the mount point once in -v and once in -w, and an image
-		// that declared one would be promising a path that the archetype this
-		// pipeline is being adopted onto does not set.
-		//
 		// PATH is set outright rather than appended to, because a scratch image
 		// has no PATH to append to. Only the guarantee that it contains the
 		// plugin directory is covered; the rest of the value is not.
 		WithEnvVariable("PATH", pluginDir).
+		// No working directory, and no directory created to be one (#219): there is
+		// deliberately no WithWorkdir and no WithDirectory for one anywhere in this
+		// chain, and checkImageConfig asserts the field is empty so that a value
+		// arriving from anywhere — here or a future base layer — is a failure.
+		//
+		// The reason is not that this function could not set one; it plainly could,
+		// and did until #219. It is that a working directory is not a property a
+		// consumer needs the image to hold — the caller already types the mount
+		// point in -v and can type it again in -w — and that this pipeline is being
+		// adopted onto a shared archetype which sets none and states that as a
+		// decision (#217). Spending the promise now, while the hand-rolled pipeline
+		// is still standing and every check here can be run against it, is what
+		// makes the adoption a change nothing consumer-visible rides on.
 		WithUser(imageUser).
 		WithEntrypoint([]string{pluginDir + "/" + cliExecutable}).
 		WithoutDefaultArgs()
@@ -355,6 +372,9 @@ func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) e
 	if err := m.checkImageIsTheCLI(ctx, image); err != nil {
 		errs = append(errs, err)
 	}
+	if err := m.checkAMissingWorkingDirectoryIsLegible(ctx, image); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
 }
 
@@ -382,6 +402,51 @@ func (m *Avroc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container)
 	}
 	if !strings.Contains(out, want) {
 		return fmt.Errorf("`help` through the image's entrypoint printed %q, which does not contain %q: the entrypoint is not the avroc CLI", out, want)
+	}
+	return nil
+}
+
+// checkAMissingWorkingDirectoryIsLegible runs `generate` with no working directory
+// and no project, and requires the run to fail saying it could not find the
+// manifest.
+//
+// This is the other half of the working directory guarantee (#219), and it is the
+// half that is easy to leave unchecked. Since the image declares no WorkingDir, an
+// unset one lands the process in / — so the new way to hold this image wrong is to
+// mount a project and forget the `-w`, which is now the single most likely mistake
+// a caller of this release makes. docs/container/SPEC.md promises what happens
+// then: the run "fails in avroc's own words, naming the manifest it could not
+// find, before it has done any work". Every other stage in this module passes the
+// flag, so without this the one new failure mode is the one path nothing runs.
+//
+// The base image is where it belongs even though the base ships no generator,
+// because loadManifest runs before the capability handshake: a run from / fails on
+// the missing avroc.json and never reaches the point where having no generator
+// would matter. That ordering is the thing being relied on, and it is why the
+// assertion is on the message and not merely on the exit code — a future change
+// that moved the manifest read after the handshake, or that failed with something
+// a person cannot act on, would leave the document's sentence wrong with the exit
+// code still non-zero.
+func (m *Avroc) checkAMissingWorkingDirectoryIsLegible(ctx context.Context, image *dagger.Container) error {
+	run := image.WithExec(
+		[]string{"generate"},
+		dagger.ContainerWithExecOpts{UseEntrypoint: true, Expect: dagger.ReturnTypeAny},
+	)
+
+	code, err := run.ExitCode(ctx)
+	if err != nil {
+		return fmt.Errorf("running `generate` with no working directory: %w", err)
+	}
+	if code == 0 {
+		return errors.New("`generate` with no working directory and no project exited 0: the image declares no WorkingDir, so this run started in / where there is no avroc.json, and a success there means a caller who forgets `-w` is told nothing")
+	}
+
+	stderr, err := run.Stderr(ctx)
+	if err != nil {
+		return fmt.Errorf("reading stderr from `generate` with no working directory: %w", err)
+	}
+	if !strings.Contains(stderr, manifestFilename) {
+		return fmt.Errorf("`generate` with no working directory exited %d but its stderr never mentions %s, so a caller who forgot `-w` cannot tell what went wrong; it said: %s", code, manifestFilename, stderr)
 	}
 	return nil
 }
@@ -647,73 +712,117 @@ func parseFindLine(line, prefix string) (imageEntry, string, error) {
 // committed worked example, produced through the same entrypoint, by generators
 // that reached the image the way a stranger's generator reaches theirs.
 //
-// Twice, as two different users. The first run is the documented default. The
-// second overrides the UID the way a caller writing output into a bind mount is
-// told to, and is what turns "an overridden UID is an ordinary configuration"
-// from a sentence into something that fails when it stops being true.
+// Twice, and the two runs differ along both axes a caller can vary. The first is
+// the documented invocation: the image's own UID, mounted at the path every
+// `docker run` in the documents prints. The second overrides the UID the way a
+// caller writing output into a bind mount is told to — which is what turns "an
+// overridden UID is an ordinary configuration" from a sentence into something
+// that fails when it stops being true — *and* mounts somewhere else entirely,
+// which is the same treatment for docs/container/SPEC.md's "`/work` there is the
+// caller's choice and nothing more" (#219).
+//
+// The second mount point is what stops projectMount becoming the old workDir
+// under a new name. Since the image declares no working directory, the claim is
+// that no path is privileged; a suite that only ever mounted at /work would go on
+// passing the day something in avroc, in a check helper or in a `Directory(…)`
+// read grew a dependence on that literal, and checkImageConfig's `workdir != ""`
+// would not see it — an image with an empty WorkingDir and a hard-coded /work
+// somewhere below is exactly the state this asserts against.
 func (m *Avroc) checkImageGenerates(ctx context.Context, image *dagger.Container) []error {
 	committed := m.Source.Directory("example")
 
-	var errs []error
-	for _, user := range []string{imageUser, "1234:1234"} {
-		generated := generateInImage(image, committed, user)
+	runs := []struct {
+		user  string
+		mount string
+	}{
+		{imageUser, projectMount},
+		{"1234:1234", "/srv/somewhere-else"},
+	}
 
-		if err := m.diffAgainstCommitted(ctx, committed, generated, user); err != nil {
+	var errs []error
+	for _, run := range runs {
+		generated := generateInImage(image, committed, run.user, run.mount)
+
+		if err := m.diffAgainstCommitted(ctx, committed, generated, run.user, run.mount); err != nil {
 			errs = append(errs, err)
 		}
-		if err := m.checkOutputOwnership(ctx, generated, user); err != nil {
+		if err := m.checkOutputOwnership(ctx, generated, run.user); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errs
 }
 
-// projectMount is where every check in this module mounts a project and points
-// the working directory, and it is the **caller's** choice rather than the
-// image's (#219).
+// projectMount is the path the checks in this module mount a project at when they
+// are running the *documented* invocation, and it is the **caller's** choice
+// rather than the image's (#219).
 //
 // It is deliberately not in the block of contract constants at the top of this
 // file, and that placement is the point of the story: the image declares no
 // WorkingDir and creates no directory to be one, so nothing about the image
-// depends on this value and a check that mounted at /project and said `-w
-// /project` would be just as correct. /work is chosen because it is the path
+// depends on this value. /work is chosen because it is the path
 // docs/container/SPEC.md's invocations print and the daggerverse module defaults
-// to, so these checks run the documented command rather than a private variant of
-// it.
+// to, so a check using it runs the documented command rather than a private
+// variant of it.
+//
+// That it is not privileged is asserted rather than stated: generateInImage takes
+// the mount point as an argument and checkImageGenerates gives one of its two runs
+// a different one. See the comment there.
 const projectMount = "/work"
 
+// manifestFilename is the file `avroc generate` reads out of the working
+// directory, and the string a run that could not find it has to name.
+//
+// It is written here rather than imported from internal/avroc: .dagger is a
+// separate Go module, and this is a check reading avroc's output the way a person
+// does. The duplication is the same kind internal/plugin.OutputPath keeps against
+// avroc's own path check — a value asserted from the outside, not shared with the
+// thing being asserted about.
+const manifestFilename = "avroc.json"
+
 // generateInImage runs `generate` through the image's own entrypoint over a
-// copy of the worked example, and returns the tree it left behind.
+// copy of the worked example mounted at mount, and returns the tree it left
+// behind.
 //
 // UseEntrypoint is what makes this the same invocation as
-// `docker run --rm -v "$PWD:/work" -w /work <image> generate`: the arguments are
-// avroc's arguments, and nothing here names the CLI by path. No environment is
+// `docker run --rm -v "$PWD:<mount>" -w <mount> <image> generate`: the arguments
+// are avroc's arguments, and nothing here names the CLI by path. No environment is
 // set either — the image's own PATH is what has to resolve the generators copied
 // into it, which is the one job it has.
 //
-// WithWorkdir as well as mounting there, because since #219 the image declares no
-// working directory: without it the process runs from /, where there is no
-// avroc.json, and the mount alone would leave the project somewhere avroc never
-// looks. That is the `-w` in the command line above, and daggerverse/avroc and
-// .dagger/main.go had both already written it for this reason.
-func generateInImage(image *dagger.Container, example *dagger.Directory, user string) *dagger.Directory {
+// mount is a parameter rather than projectMount read directly, because since #219
+// the image declares no working directory and the document therefore promises that
+// any mount point does. A function that could only mount at one path would make
+// that promise uncheckable.
+//
+// WithWorkdir as well as mounting there, for the same reason: without it the
+// process runs from /, where there is no avroc.json, and the mount alone would
+// leave the project somewhere avroc never looks. That is the `-w` in the command
+// line above, and daggerverse/avroc and .dagger/main.go had both already written it
+// for this reason.
+func generateInImage(image *dagger.Container, example *dagger.Directory, user, mount string) *dagger.Directory {
 	return image.
 		WithUser(user).
-		WithDirectory(projectMount, example, dagger.ContainerWithDirectoryOpts{Owner: user}).
-		WithWorkdir(projectMount).
+		WithDirectory(mount, example, dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithWorkdir(mount).
 		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-		Directory(projectMount)
+		Directory(mount)
 }
 
 // diffAgainstCommitted requires the generated tree to be byte-identical to the
 // committed worked example.
+//
+// mount is in the message because the two runs differ by it as well as by user
+// (#219): "the image did not reproduce the committed example" is a different
+// finding when it happened at a mount point other than the documented one, and a
+// report that named only the user would send the reader looking at the UID.
 func (m *Avroc) diffAgainstCommitted(
 	ctx context.Context,
 	committed, generated *dagger.Directory,
-	user string,
+	user, mount string,
 ) error {
 	if err := m.diffTrees(ctx, committed, generated, "/image-contract"); err != nil {
-		return fmt.Errorf("as user %s, the image did not reproduce the committed example: %w", user, err)
+		return fmt.Errorf("as user %s, mounted at %s, the image did not reproduce the committed example: %w", user, mount, err)
 	}
 	return nil
 }

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -72,8 +72,14 @@ import (
 // pluginDir lives in main.go, because the regeneration stage's scratch container
 // is deliberately the same layout as the published image and both read it.
 const (
-	// workDir is the working directory a caller mounts a project at.
-	workDir = "/work"
+	// There is no working directory in this image, and its absence is a decision
+	// (#219). `WorkingDir` used to be /work and /work used to be created here,
+	// owned by the image's user, so that a caller could mount a project over it
+	// and pass no further arguments. Both are gone: the caller names the mount
+	// point on the command line — `-v "$PWD:/work" -w /work` — and the image
+	// declares nothing, which is what `docs/container/SPEC.md`'s "The working
+	// directory" now says. Nothing here stands in for it; see projectMount for
+	// what these checks do instead, and note that it is not in this block.
 
 	// There is no temporary directory in this image, and its absence is a
 	// decision (#218). A 1777 /tmp used to be grafted on here, because avroc
@@ -128,8 +134,8 @@ func imagePlatforms() []dagger.Platform {
 //
 // It is the image docs/container/SPEC.md describes, and every promise that
 // document makes is made here: the CLI in /usr/local/bin with that directory on
-// PATH, the CLI as the entrypoint with an empty Cmd, /work as the working
-// directory, UID and GID 65532 owning both directories and running the process,
+// PATH, the CLI as the entrypoint with an empty Cmd, no working directory at all
+// (#219), UID and GID 65532 owning the plugin directory and running the process,
 // the IR FileDescriptorSet at its documented path, and nothing else in the
 // filesystem at all.
 //
@@ -304,17 +310,16 @@ func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
 			Owner:       imageUser,
 			Permissions: 0o644,
 		}).
-		// The working directory has to exist in the base image and be owned by
-		// the image's user: a caller who mounts over it inherits nothing
-		// surprising, and one who does not can still generate into it.
-		WithDirectory(workDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{
-			Owner: imageUser,
-		}).
+		// No working directory, and no directory created to be one (#219). There
+		// is deliberately no WithWorkdir below either: a caller who mounts a
+		// project names the mount point once in -v and once in -w, and an image
+		// that declared one would be promising a path that the archetype this
+		// pipeline is being adopted onto does not set.
+		//
 		// PATH is set outright rather than appended to, because a scratch image
 		// has no PATH to append to. Only the guarantee that it contains the
 		// plugin directory is covered; the rest of the value is not.
 		WithEnvVariable("PATH", pluginDir).
-		WithWorkdir(workDir).
 		WithUser(imageUser).
 		WithEntrypoint([]string{pluginDir + "/" + cliExecutable}).
 		WithoutDefaultArgs()
@@ -434,12 +439,18 @@ func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) [
 		errs = append(errs, fmt.Errorf("the image's User is %q, want %q", user, imageUser))
 	}
 
+	// WorkingDir is asserted *empty* rather than not asserted at all (#219). The
+	// image no longer declares one, and the temptation is to delete the check
+	// with the value — but an unasserted field is exactly how a base layer's
+	// inherited value arrives unnoticed, which is what this whole file exists to
+	// stop. So the assertion flips from a value to its absence: the day something
+	// sets a working directory again, here or upstream, this says so.
 	workdir, err := image.Workdir(ctx)
 	switch {
 	case err != nil:
 		errs = append(errs, fmt.Errorf("reading WorkingDir: %w", err))
-	case workdir != workDir:
-		errs = append(errs, fmt.Errorf("the image's WorkingDir is %q, want %q", workdir, workDir))
+	case workdir != "":
+		errs = append(errs, fmt.Errorf("the image's WorkingDir is %q, want it empty: since #219 the caller names the mount point and points the working directory at it, and the image declares none", workdir))
 	}
 
 	path, err := image.EnvVariable(ctx, "PATH")
@@ -461,10 +472,14 @@ func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) [
 // only form of that claim which stays true when somebody adds a file: a spot
 // check for /bin/sh passes on an image carrying a busybox under another name.
 //
-// The parent directories are root-owned and that is intentional — only the
-// plugin directory and the working directory are promised to the image's user,
-// and a root-owned parent with mode 0755 is what stops the running user
-// replacing the tree above them.
+// The parent directories are root-owned and that is intentional — the plugin
+// directory is the only one promised to the image's user, and a root-owned parent
+// with mode 0755 is what stops the running user replacing the tree above it.
+//
+// There is no working directory row (#219). The image declares no WorkingDir and
+// creates no directory to be one, so the listing loses /work and gains nothing:
+// where a project is mounted is the caller's, and a path the caller chooses is
+// not a path this image can be exhaustive about.
 //
 // executables is what is expected in the plugin directory, which is the one
 // thing that differs between the base image and an image built FROM it: the
@@ -484,7 +499,6 @@ func imageContents(executables []string) map[string]imageEntry {
 		"/usr/local/share/avroc": {0, 0, dirMode},
 		descriptorSetPath:        {imageUID, imageGID, dataMode},
 		pluginDir:                {imageUID, imageGID, dirMode},
-		workDir:                  {imageUID, imageGID, dirMode},
 	}
 	for _, name := range executables {
 		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
@@ -654,21 +668,41 @@ func (m *Avroc) checkImageGenerates(ctx context.Context, image *dagger.Container
 	return errs
 }
 
+// projectMount is where every check in this module mounts a project and points
+// the working directory, and it is the **caller's** choice rather than the
+// image's (#219).
+//
+// It is deliberately not in the block of contract constants at the top of this
+// file, and that placement is the point of the story: the image declares no
+// WorkingDir and creates no directory to be one, so nothing about the image
+// depends on this value and a check that mounted at /project and said `-w
+// /project` would be just as correct. /work is chosen because it is the path
+// docs/container/SPEC.md's invocations print and the daggerverse module defaults
+// to, so these checks run the documented command rather than a private variant of
+// it.
+const projectMount = "/work"
+
 // generateInImage runs `generate` through the image's own entrypoint over a
-// copy of the worked example mounted at the working directory, and returns the
-// tree it left behind.
+// copy of the worked example, and returns the tree it left behind.
 //
 // UseEntrypoint is what makes this the same invocation as
-// `docker run --rm -v "$PWD:/work" <image> generate`: the arguments are avroc's
-// arguments, and nothing here names the CLI by path. No environment is set
-// either — the image's own PATH is what has to resolve the generators copied
+// `docker run --rm -v "$PWD:/work" -w /work <image> generate`: the arguments are
+// avroc's arguments, and nothing here names the CLI by path. No environment is
+// set either — the image's own PATH is what has to resolve the generators copied
 // into it, which is the one job it has.
+//
+// WithWorkdir as well as mounting there, because since #219 the image declares no
+// working directory: without it the process runs from /, where there is no
+// avroc.json, and the mount alone would leave the project somewhere avroc never
+// looks. That is the `-w` in the command line above, and daggerverse/avroc and
+// .dagger/main.go had both already written it for this reason.
 func generateInImage(image *dagger.Container, example *dagger.Directory, user string) *dagger.Directory {
 	return image.
 		WithUser(user).
-		WithDirectory(workDir, example, dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithDirectory(projectMount, example, dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithWorkdir(projectMount).
 		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-		Directory(workDir)
+		Directory(projectMount)
 }
 
 // diffAgainstCommitted requires the generated tree to be byte-identical to the

--- a/.dagger/trace_propagation.go
+++ b/.dagger/trace_propagation.go
@@ -337,19 +337,25 @@ func (m *Avroc) tracedGeneration(platform dagger.Platform, collector *dagger.Ser
 			Permissions: executableMode,
 		}).
 		WithServiceBinding(collectorHostname, collector).
-		// WithWorkdir as well as mounting there: since #219 the image declares no
-		// working directory, and the launcher re-execs avroc in place rather than
-		// naming a project, so the exec's own working directory is the only thing
-		// that puts avroc where avroc.json is. See projectMount.
 		WithDirectory(projectMount, m.Source.Directory("example"), dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
-		WithWorkdir(projectMount).
 		// The launcher's own scratch directory, owned by the image's user so it
 		// can write the record into it. See traceparentRecord.
 		WithDirectory(traceRecordDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
+		// WithWorkdir as well as mounting there: since #219 the image declares no
+		// working directory, and the launcher re-execs avroc in place rather than
+		// naming a project, so the exec's own working directory is the only thing
+		// that puts avroc where avroc.json is. See projectMount.
+		//
+		// It is set **last**, immediately before the exec, and deliberately: every
+		// path above is absolute today, but a relative one added after a WithWorkdir
+		// would resolve inside the project mount — which is the one tree this check
+		// byte-compares against the committed example/, so a file landing there is a
+		// failure whose cause is nowhere near the line that caused it.
+		WithWorkdir(projectMount).
 		WithExec([]string{
 			traceLauncher,
 			"-launch",

--- a/.dagger/trace_propagation.go
+++ b/.dagger/trace_propagation.go
@@ -113,13 +113,14 @@ const (
 	// handed the exec.
 	//
 	// It is in a directory this check adds to the image, at a path that is part
-	// of nothing: the image carries no temporary directory since #218, and the
-	// two directories it does carry are both wrong for this — /work is the tree
-	// checkOneConnectedTrace byte-compares against the committed example/, so a
-	// record left in it would fail that comparison, and the plugin directory is
-	// where a file is a generator. A derived image adding a directory of its own
-	// is what any adopter does, and it is not the image gaining a writable path
-	// to make avroc work: avroc needs none, which is the whole of #218.
+	// of nothing: the image carries no temporary directory since #218 and no
+	// working directory since #219, and neither of the two directories this check
+	// does have will do — the project mount is the tree checkOneConnectedTrace
+	// byte-compares against the committed example/, so a record left in it would
+	// fail that comparison, and the plugin directory is where a file is a
+	// generator. A derived image adding a directory of its own is what any adopter
+	// does, and it is not the image gaining a writable path to make avroc work:
+	// avroc needs none, which is the whole of #218.
 	//
 	// The negative control gets it too, because it goes through the same
 	// tracedGeneration — which is what keeps it able to reach a *fetched trace*
@@ -223,7 +224,7 @@ func (m *Avroc) checkOneConnectedTrace(
 	// this is that sentence made about a run whose spans actually left the
 	// container — which is more than Regeneration's traced run can say, since
 	// nothing is listening at the endpoint it configures.
-	generated := run.Directory(workDir)
+	generated := run.Directory(projectMount)
 	if err := m.diffTrees(ctx, m.Source.Directory("example"), generated, "/trace-propagation"); err != nil {
 		return fmt.Errorf("a traced generation did not reproduce the committed example: %w", err)
 	}
@@ -336,9 +337,14 @@ func (m *Avroc) tracedGeneration(platform dagger.Platform, collector *dagger.Ser
 			Permissions: executableMode,
 		}).
 		WithServiceBinding(collectorHostname, collector).
-		WithDirectory(workDir, m.Source.Directory("example"), dagger.ContainerWithDirectoryOpts{
+		// WithWorkdir as well as mounting there: since #219 the image declares no
+		// working directory, and the launcher re-execs avroc in place rather than
+		// naming a project, so the exec's own working directory is the only thing
+		// that puts avroc where avroc.json is. See projectMount.
+		WithDirectory(projectMount, m.Source.Directory("example"), dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
+		WithWorkdir(projectMount).
 		// The launcher's own scratch directory, owned by the image's user so it
 		// can write the record into it. See traceparentRecord.
 		WithDirectory(traceRecordDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -171,7 +171,7 @@ func (m *Avroc) WorkedExample(ctx context.Context) error {
 	}
 	errs = append(errs, m.checkImageConfig(ctx, image)...)
 	errs = append(errs, m.checkImageContents(ctx, image, want)...)
-	errs = append(errs, m.checkWorkedExampleGenerates(ctx, image, example.generator)...)
+	errs = append(errs, m.checkWorkedExampleGenerates(ctx, image, example.generator, example.mount)...)
 	return errors.Join(errs...)
 }
 
@@ -186,7 +186,18 @@ func (m *Avroc) workedExample(ctx context.Context) (*workedExample, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newWorkedExample(dockerfile)
+	mount, err := workedExampleMount(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	example, err := newWorkedExample(dockerfile)
+	if err != nil {
+		return nil, err
+	}
+	example.mount = mount
+	example.spec = spec
+	return example, nil
 }
 
 // workedExample is the document's Dockerfile, parsed and judged.
@@ -206,6 +217,20 @@ type workedExample struct {
 	// manifest asks for it by.
 	executable string
 	generator  string
+	// mount is where the document's own `docker run` mounts the project and
+	// points the working directory, read out of the console block beside the
+	// Dockerfile rather than written here (#219).
+	//
+	// It is extracted for the reason the Dockerfile is: since the image declares
+	// no working directory, the `-w` in that command is load bearing, and a copy
+	// of it in this file would be the one that is checked while the one in the
+	// document is the one people read.
+	mount string
+	// spec is the whole document, kept so that rules can break the console block
+	// the way it breaks the Dockerfile. mount is extracted from the document
+	// rather than from the Dockerfile, so its failure path is not reachable from
+	// the dockerfile field alone.
+	spec string
 }
 
 // newWorkedExample parses text and requires it to be the shape
@@ -383,6 +408,51 @@ func (e *workedExample) rules() error {
 		}
 	}
 
+	// The mount point comes out of the document's console block rather than out of
+	// its Dockerfile (#219, workedExampleMount), so its failure path is not
+	// reachable by editing e.dockerfile and needs cases of its own. Same rule as
+	// above: the edit must change something, or the case is re-checking the
+	// committed document.
+	mounts := []struct {
+		broken string
+		edit   func(string) string
+	}{{
+		// The one this story creates. A `docker run` printed without `-w` is a
+		// command that lands in / and cannot find the manifest, and it is the first
+		// thing an adopter copies.
+		broken: "the documented `docker run` losing its -w",
+		edit:   func(s string) string { return strings.Replace(s, " -w "+e.mount, "", 1) },
+	}, {
+		// The other half of "correct as printed": a command whose -w and -v have
+		// drifted apart runs, finds no manifest, and reads as the caller's mistake.
+		broken: "the documented `docker run` pointing -w somewhere it did not mount",
+		edit:   func(s string) string { return strings.Replace(s, "-w "+e.mount, "-w /elsewhere", 1) },
+	}, {
+		broken: "the console block the invocation is printed in being removed",
+		edit: func(s string) string {
+			return strings.Replace(s, "```console\n$ docker build", "```text\n$ docker build", 1)
+		},
+	}}
+	for _, c := range mounts {
+		// The edit is applied to the worked example's section alone. This document
+		// prints the same `docker run` in several sections, so an unscoped Replace
+		// edits an *earlier* one, leaves the extracted command untouched and reports
+		// the committed value back — a case that passes while checking nothing. The
+		// negative control caught exactly that, which is what it is for.
+		edited, err := editWorkedExampleSection(e.spec, c.edit)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.broken, err))
+			continue
+		}
+		if edited == e.spec {
+			errs = append(errs, fmt.Errorf("%s: the case changed nothing, so it is checking the committed document rather than a broken one", c.broken))
+			continue
+		}
+		if got, err := workedExampleMount(edited); err == nil {
+			errs = append(errs, fmt.Errorf("%s: accepted (as %q), want rejected", c.broken, got))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -444,7 +514,12 @@ func (e *workedExample) contents() (map[string]imageEntry, error) {
 // files — what the example's generator writes is the document's business, and a
 // pipeline asserting its bytes would be a second copy of a Go program nobody
 // would think to update.
-func (m *Avroc) checkWorkedExampleGenerates(ctx context.Context, image *dagger.Container, generator string) []error {
+// mount is the path the document's own `docker run` mounts at and points `-w`
+// at, extracted from the console block rather than written here (#219,
+// workedExampleMount). That is what makes the flag in that command checked as
+// printed: a `-w` dropped from the document changes where this check mounts, and a
+// `-w` removed from it altogether fails the extraction outright.
+func (m *Avroc) checkWorkedExampleGenerates(ctx context.Context, image *dagger.Container, generator, mount string) []error {
 	const outDir = "out"
 
 	project, err := generatorProbe(m.Source.File("example/schema.avdl"), generator, outDir)
@@ -457,14 +532,13 @@ func (m *Avroc) checkWorkedExampleGenerates(ctx context.Context, image *dagger.C
 	var errs []error
 	for _, user := range []string{imageUser, "1234:1234"} {
 		// WithWorkdir as well as mounting there: since #219 the image declares no
-		// working directory, and the document's own invocations carry the `-w`
-		// this is. See projectMount.
+		// working directory, and the `-w` this is came out of the document.
 		generated := image.
 			WithUser(user).
-			WithDirectory(projectMount, project, dagger.ContainerWithDirectoryOpts{Owner: user}).
-			WithWorkdir(projectMount).
+			WithDirectory(mount, project, dagger.ContainerWithDirectoryOpts{Owner: user}).
+			WithWorkdir(mount).
 			WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-			Directory(projectMount + "/" + outDir)
+			Directory(mount + "/" + outDir)
 
 		entries, err := generated.Entries(ctx)
 		switch {
@@ -512,6 +586,133 @@ func workedExampleDockerfile(spec string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%s's %q section contains no ```dockerfile block", containerSpec, workedExampleHeading)
+}
+
+// workedExampleMount reads the mount point out of the `docker run` the worked
+// example's section prints, taking it from the `-w` flag that command carries.
+//
+// It exists because the image declares no working directory since #219, which
+// makes that flag part of the documented invocation rather than decoration: a
+// reader who copies the command without it lands in / and gets an error about a
+// manifest they can see. So the flag is *extracted* and used as this check's mount
+// point, exactly as the Dockerfile is extracted and built — a `-w` hard-coded here
+// would be the copy that is checked while the document's is the copy that is read,
+// and the two would drift the moment somebody reflowed the command.
+//
+// Both ends are located rather than assumed and every failure names what was
+// missing, for workedExampleDockerfile's reason: a section whose console block has
+// been reworded and one whose `docker run` has genuinely lost its `-w` are
+// different findings, and a check that quietly found nothing has stopped running.
+func workedExampleMount(spec string) (string, error) {
+	const fence = "```"
+
+	lines := strings.Split(spec, "\n")
+	start := slices.Index(lines, workedExampleHeading)
+	if start < 0 {
+		return "", fmt.Errorf("%s has no %q section", containerSpec, workedExampleHeading)
+	}
+
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			break
+		}
+		if strings.TrimSpace(lines[i]) != fence+"console" {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == fence {
+				break
+			}
+			if !strings.Contains(lines[j], "docker run") {
+				continue
+			}
+			// The command is wrapped across lines with a trailing backslash, so
+			// the flag and its value are not reliably on the line `docker run` is
+			// on. Join the continuations before looking.
+			command := lines[j]
+			for strings.HasSuffix(strings.TrimSpace(command), `\`) && j+1 < len(lines) {
+				j++
+				command = strings.TrimSuffix(strings.TrimSpace(command), `\`) + " " + lines[j]
+			}
+
+			return dockerRunMount(strings.TrimSpace(command))
+		}
+	}
+	return "", fmt.Errorf("%s's %q section contains no ```console block running `docker run`", containerSpec, workedExampleHeading)
+}
+
+// editWorkedExampleSection applies edit to the worked example's section of the
+// document and returns the whole document with that section replaced.
+//
+// It exists because this document prints `docker run` in several places, so an
+// edit meant to break the worked example's invocation will silently break an
+// earlier section's instead — leaving the command under test untouched and the
+// case passing on a document it did not change in the way it claimed to.
+func editWorkedExampleSection(spec string, edit func(string) string) (string, error) {
+	head, section, found := strings.Cut(spec, workedExampleHeading)
+	if !found {
+		return "", fmt.Errorf("%s has no %q section", containerSpec, workedExampleHeading)
+	}
+	return head + workedExampleHeading + edit(section), nil
+}
+
+// dockerRunMount reads the project mount point out of one `docker run` command
+// line, and requires the command to be internally consistent: the path `-w` names
+// has to be the path `-v` mounts the project at.
+//
+// Both halves matter, and the second is the one worth having. Since #219 the image
+// declares no working directory, so `-v` and `-w` are two statements of the same
+// path that a person edits separately — the shape of mistake this catches is a
+// mount point changed in one of them, which produces a command that runs, finds no
+// manifest at the working directory, and fails in a way the document says is a
+// caller's error rather than the document's.
+//
+// It returns the mount point, which is what the check then generates at, so a
+// document that renamed its mount is followed rather than contradicted.
+func dockerRunMount(command string) (string, error) {
+	fields := strings.Fields(command)
+
+	value := func(flag string) (string, bool) {
+		for k, field := range fields {
+			if field == flag && k+1 < len(fields) {
+				return fields[k+1], true
+			}
+			// The joined form, `-w=/work`, which docker also accepts.
+			if after, ok := strings.CutPrefix(field, flag+"="); ok {
+				return after, true
+			}
+		}
+		return "", false
+	}
+
+	workdir, ok := value("-w")
+	if !ok {
+		workdir, ok = value("--workdir")
+	}
+	if !ok {
+		return "", fmt.Errorf("%s's worked example runs `%s`, which carries no -w: the image declares no working directory (#219), so that command lands in / and cannot find %s. Add the flag to the document rather than to this check", containerSpec, command, manifestFilename)
+	}
+
+	volume, ok := value("-v")
+	if !ok {
+		volume, ok = value("--volume")
+	}
+	if !ok {
+		return "", fmt.Errorf("%s's worked example runs `%s`, which mounts nothing: there is no project for -w %s to point at", containerSpec, command, workdir)
+	}
+
+	// `-v <host>:<container>[:<options>]`; the container path is what -w has to
+	// agree with. The host side may itself be quoted and contain no colon here.
+	parts := strings.Split(strings.Trim(volume, `"'`), ":")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("%s's worked example runs `%s`, whose -v %s names no container path", containerSpec, command, volume)
+	}
+	target := parts[1]
+
+	if target != workdir {
+		return "", fmt.Errorf("%s's worked example runs `%s`, which mounts the project at %s and sets the working directory to %s: the two have to be the same path, or avroc starts somewhere there is no %s", containerSpec, command, target, workdir, manifestFilename)
+	}
+	return workdir, nil
 }
 
 // dockerfileInstruction is one instruction, with its keyword upper-cased and

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -456,11 +456,15 @@ func (m *Avroc) checkWorkedExampleGenerates(ctx context.Context, image *dagger.C
 
 	var errs []error
 	for _, user := range []string{imageUser, "1234:1234"} {
+		// WithWorkdir as well as mounting there: since #219 the image declares no
+		// working directory, and the document's own invocations carry the `-w`
+		// this is. See projectMount.
 		generated := image.
 			WithUser(user).
-			WithDirectory(workDir, project, dagger.ContainerWithDirectoryOpts{Owner: user}).
+			WithDirectory(projectMount, project, dagger.ContainerWithDirectoryOpts{Owner: user}).
+			WithWorkdir(projectMount).
 			WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-			Directory(workDir + "/" + outDir)
+			Directory(projectMount + "/" + outDir)
 
 		entries, err := generated.Entries(ctx)
 		switch {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,22 +545,48 @@ overturn it; and the writable half dies independently, because a contributed
 directory is mode `0555` and a `/work` that is not writable is not one a
 generation can write into. What made it affordable is that `-w /work` is a path
 the invocation already contains, where #218's `--tmpfs /tmp:mode=1777` was a fact
-an adopter had no way to possess. It is a **break**, deliberately, and it rides
-in #217's release notes beside the two already there. Three things about the way
-it landed are decisions rather than mechanics. `ImageContract` asserts
-`WorkingDir` is *empty* rather than dropping the assertion, because an unasserted
-field is how a base layer's inherited value arrives unnoticed. `projectMount` in
-`image.go` is the checks' own mount point and is deliberately **not** in the block
-of contract constants, because nothing about the image depends on it and a check
-that mounted at `/project` would be equally correct — it is `/work` only so the
-checks run the command the documents print. And every check that reached
-`avroc.json` through the image's working directory now names one explicitly
-(`image.go`, `generator_image.go`, `worked_example.go`, `trace_propagation.go`),
-which is what `.dagger/main.go` and `daggerverse/avroc` had already written for
-exactly this reason — the latter defending against this image before it existed.
-`daggerverse/avroc`'s `projectDir` stays `/work` and its behaviour is unchanged:
-the mount point is still this project's convention, and the module is what names
-it now rather than the image.
+an adopter had no way to possess. It is a **break**, deliberately, and the SPEC
+requires the next minor release's notes to name it beside #217's two rather than
+claiming they already do.
+
+Every check that reached `avroc.json` through the image's working directory now
+names one explicitly (`image.go`, `generator_image.go`, `worked_example.go`,
+`trace_propagation.go`), which is what `.dagger/main.go` and `daggerverse/avroc`
+had already written for exactly this reason — the latter defending against this
+image before it existed. `daggerverse/avroc`'s `projectDir` stays `/work` and its
+behaviour is unchanged: the mount point is still this project's convention, and
+the module is what names it now rather than the image.
+
+Four things about the way it landed are decisions rather than mechanics, and three
+of them exist because **an absence is the easiest thing to leave unchecked**.
+
+- `ImageContract` asserts `WorkingDir` is *empty* rather than dropping the
+  assertion, because an unasserted field is how a base layer's inherited value
+  arrives unnoticed.
+- `checkAMissingWorkingDirectoryIsLegible` runs `generate` with no working
+  directory and requires a non-zero exit whose stderr names `avroc.json`. The new
+  way to hold this image wrong is to mount a project and forget the `-w`, and
+  every other stage passes the flag — so without this the one failure mode the
+  release creates is the one path nothing runs. It sits on the *base* image, which
+  ships no generator, because `loadManifest` runs before the capability handshake:
+  a run from `/` fails on the missing manifest and never reaches the point where
+  having no generator would matter. That ordering is what the check depends on,
+  which is why it asserts the message and not merely the status.
+- `projectMount` in `image.go` is the checks' own mount point and is deliberately
+  **not** in the block of contract constants, because nothing about the image
+  depends on it. That it is not privileged is *asserted* rather than stated:
+  `generateInImage` takes the mount as an argument, and `checkImageGenerates`
+  gives its two runs different ones — `/work` with the image's UID (the documented
+  invocation) and `/srv/somewhere-else` with an overridden UID. A suite that only
+  ever mounted at `/work` would go on passing the day something grew a dependence
+  on that literal, and the empty-`WorkingDir` assertion would not see it.
+- The worked example's `-w` is **extracted from the document** rather than written
+  in `worked_example.go` (`workedExampleMount`), the way its Dockerfile already
+  was, and `dockerRunMount` additionally requires the `-w` path to equal the path
+  `-v` mounts at. A hard-coded flag would have been the copy that is checked while
+  the document's is the copy that is read. `workedExample.rules` breaks the console
+  block three ways and requires each to be refused, because the failure path of an
+  extractor nobody has broken is a check nobody knows the state of.
 
 `.dagger/generator_image.go` builds the three images that carry avroc's own
 generators, each of them the base plus one executable in the plugin directory
@@ -679,8 +705,8 @@ generator that has no image yet. `Image` exposes what those composed.
 
 It is a **convenience over `docs/container/SPEC.md`, not a contract**, so it gets
 no `SPEC.md` (`docs/CONVENTIONS.md`, "What belongs here"): everything it does can
-be written as `docker run --rm -v "$PWD:/work" -w /work`, and a spec for it would imply
-the contract were a property of the module. What it needs to say it says in its
+be written as `docker run --rm -v "$PWD:/work" -w /work`, and a spec for it would
+imply the contract were a property of the module. What it needs to say it says in its
 module comment and in `dagger call --help`. It is a separate module rather than
 more functions on the root one because a caller who installs it should get the
 one function they came for and not this repository's `ci`, `release` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,13 +525,42 @@ grows a timestamp uses it rather than inventing its own.
 
 `.dagger/image.go` builds the base image `docs/container/SPEC.md` describes, and
 that document is normative: `/usr/local/bin` on `PATH` holding the CLI **and no
-generator**, the CLI as `Entrypoint` with an empty `Cmd`, `/work` as
-`WorkingDir`, UID and GID 65532 owning both directories and running the process,
+generator**, the CLI as `Entrypoint` with an empty `Cmd`, **no `WorkingDir` at
+all**, UID and GID 65532 owning the plugin directory and running the process,
 the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a `scratch`
 base — no shell, no libc, no package manager, so extension is `COPY`-only. The
 filesystem is now exactly the files that document names and nothing else: a 1777
 `/tmp` used to be grafted on for the descriptor, and #218 removed the reason for
 it rather than the mount that carried it (see "Where the descriptor is written").
+
+**The image sets no working directory, and that is a decision** (#219,
+`docs/container/SPEC.md`'s "The working directory"). `WorkingDir` was `/work` and
+`/work` was created here owned by the image's user; both are gone, and the caller
+names the mount point twice instead — `-v "$PWD:/work" -w /work`. It is the third
+of the promises #217 could not express against the refactored `z5labs` archetype,
+closed the way #218 closed the second: by deleting avroc's need for the thing
+rather than asking for it upstream. The archetype states the absence as a decision
+rather than an omission and rests a rule on it, so an upstream issue would have to
+overturn it; and the writable half dies independently, because a contributed
+directory is mode `0555` and a `/work` that is not writable is not one a
+generation can write into. What made it affordable is that `-w /work` is a path
+the invocation already contains, where #218's `--tmpfs /tmp:mode=1777` was a fact
+an adopter had no way to possess. It is a **break**, deliberately, and it rides
+in #217's release notes beside the two already there. Three things about the way
+it landed are decisions rather than mechanics. `ImageContract` asserts
+`WorkingDir` is *empty* rather than dropping the assertion, because an unasserted
+field is how a base layer's inherited value arrives unnoticed. `projectMount` in
+`image.go` is the checks' own mount point and is deliberately **not** in the block
+of contract constants, because nothing about the image depends on it and a check
+that mounted at `/project` would be equally correct — it is `/work` only so the
+checks run the command the documents print. And every check that reached
+`avroc.json` through the image's working directory now names one explicitly
+(`image.go`, `generator_image.go`, `worked_example.go`, `trace_propagation.go`),
+which is what `.dagger/main.go` and `daggerverse/avroc` had already written for
+exactly this reason — the latter defending against this image before it existed.
+`daggerverse/avroc`'s `projectDir` stays `/work` and its behaviour is unchanged:
+the mount point is still this project's convention, and the module is what names
+it now rather than the image.
 
 `.dagger/generator_image.go` builds the three images that carry avroc's own
 generators, each of them the base plus one executable in the plugin directory
@@ -650,7 +679,7 @@ generator that has no image yet. `Image` exposes what those composed.
 
 It is a **convenience over `docs/container/SPEC.md`, not a contract**, so it gets
 no `SPEC.md` (`docs/CONVENTIONS.md`, "What belongs here"): everything it does can
-be written as `docker run --rm -v "$PWD:/work"`, and a spec for it would imply
+be written as `docker run --rm -v "$PWD:/work" -w /work`, and a spec for it would imply
 the contract were a property of the module. What it needs to say it says in its
 module comment and in `dagger call --help`. It is a separate module rather than
 more functions on the root one because a caller who installs it should get the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ dagger call generator-bundle-image export --path ./avroc-all.tar
 describes — the one other people's Dockerfiles say `FROM` — and
 `image-contract` is that document's compatibility guarantees table executed
 rather than read: the plugin directory and its place on `PATH`, the entrypoint,
-the empty `Cmd`, the working directory, the pinned non-root UID, the absence of
-a shell, and the `FileDescriptorSet`'s path.
+the empty `Cmd`, the *absence* of a working directory, the pinned non-root UID,
+the absence of a shell, and the `FileDescriptorSet`'s path.
 
 The base ships the CLI and **no generator**. avroc's own three are images built
 `FROM` it, one `COPY` each, exactly as a stranger's generator image is
@@ -79,13 +79,15 @@ repository this project cannot see and breaks without breaking anything here: an
 image whose `PATH` lost `/usr/local/bin` runs avroc perfectly and fails at the
 point where somebody else's generator is not found.
 
-To run an image the way a consumer does, load the tarball and mount a project
-at `/work`. Use the bundle rather than the base — `example/`'s manifest names
-three generators, and the base carries none:
+To run an image the way a consumer does, load the tarball, mount a project and
+point `-w` at where you mounted it — the image declares no working directory, so
+that flag is not optional. Use the bundle rather than the base — `example/`'s
+manifest names three generators, and the base carries none:
 
 ```sh
 docker load -i ./avroc-all.tar
-docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/example:/work" <image> generate
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/example:/work" -w /work \
+  <image> generate
 ```
 
 `dagger call publish --address …` and `dagger call publish-generator --name …

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ developer's laptop; it makes no reproducibility guarantee.
 ### The published image
 
 avroc is published as a container image, and each built-in generator as an image
-built `FROM` it. Run one over the project in the working directory. The image
-declares no working directory of its own, so mount the project wherever you like
-and point `-w` at it — `/work` below is this project's convention and nothing
-more:
+built `FROM` it. Run one over the project in the current directory. Mount that
+directory wherever you like and point `-w` at the same path — the image declares
+no working directory of its own, so both flags are needed, and `/work` below is
+this project's convention and nothing more:
 
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \

--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ developer's laptop; it makes no reproducibility guarantee.
 ### The published image
 
 avroc is published as a container image, and each built-in generator as an image
-built `FROM` it. Run one over the project in the working directory — `/work` is
-where the image expects it:
+built `FROM` it. Run one over the project in the working directory. The image
+declares no working directory of its own, so mount the project wherever you like
+and point `-w` at it — `/work` below is this project's convention and nothing
+more:
 
 ```bash
-docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \
   ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 

--- a/daggerverse/avroc/main.go
+++ b/daggerverse/avroc/main.go
@@ -20,10 +20,11 @@
 // # This is a convenience, not a contract
 //
 // The contract is the published image: docs/container/SPEC.md says what is on
-// PATH, what the entrypoint is, which directory a project is mounted at and which
-// UID the process runs as, and it is that document a third party builds against.
-// Everything here is those promises spelled as Dagger calls, and every one of
-// them can be written by hand as `docker run --rm -v "$PWD:/work"` instead.
+// PATH, what the entrypoint is, that the caller chooses where a project is mounted
+// and which UID the process runs as, and it is that document a third party builds
+// against. Everything here is those promises spelled as Dagger calls, and every
+// one of them can be written by hand as `docker run --rm -v "$PWD:/work" -w /work`
+// instead.
 //
 // So this module gets no SPEC.md, deliberately (docs/CONVENTIONS.md, "What
 // belongs here"). A specification for it would imply the contract is a property
@@ -81,10 +82,14 @@ const (
 	pluginDir = "/usr/local/bin"
 
 	// projectDir is where a project is mounted when the image does not say
-	// otherwise. docs/container/SPEC.md pins /work as the published image's
-	// working directory; this is the fallback for a container built some other
-	// way, since `avroc generate` reads avroc.json from the working directory and
-	// a project mounted anywhere else is a project avroc will not find.
+	// otherwise, and since #219 the published image says nothing: it declares no
+	// WorkingDir, so this is the path that is actually used rather than a fallback
+	// for a container built some other way. /work is unchanged, because the mount
+	// point is this project's convention either way — what moved is which side
+	// names it, and it is this module now rather than the image.
+	//
+	// A container that *does* declare a working directory still wins, which is what
+	// keeps New able to accept an image this module did not build.
 	projectDir = "/work"
 
 	// executableMode is the mode a generator lands with. It is the derived
@@ -288,14 +293,15 @@ func (m *Avroc) Generate(
 		workdir = projectDir
 	}
 
-	// WithWorkdir as well as mounting there, because the two are only the same
-	// call when the image already declared one. An image that declared none runs
-	// from / — where there is no avroc.json — and the mount alone would leave the
-	// project somewhere avroc never looks.
+	// WithWorkdir as well as mounting there, because the published image declares
+	// no working directory (#219) and therefore runs from / — where there is no
+	// avroc.json — so the mount alone would leave the project somewhere avroc
+	// never looks. This was written against a hypothetical image that declared
+	// none; it is now the image this module pulls by default.
 	//
 	// UseEntrypoint, so this is the same invocation as
-	// `docker run --rm -v "$PWD:/work" <image> generate`: the arguments are
-	// avroc's, and nothing here names the CLI by path.
+	// `docker run --rm -v "$PWD:/work" -w /work <image> generate`: the arguments
+	// are avroc's, and nothing here names the CLI by path.
 	return c.
 		WithDirectory(workdir, source, dagger.ContainerWithDirectoryOpts{Owner: owner}).
 		WithWorkdir(workdir).

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -28,7 +28,7 @@ belongs here.
 
 In scope: what the published image guarantees to an image built `FROM` it — the
 directory a generator is copied into and the `PATH` that makes it reachable, the
-entrypoint, the working directory a project is mounted at, the user and UID the
+entrypoint, the working directory and who chooses it, the user and UID the
 process runs as together with the guidance for overriding it with
 `--user $(id -u):$(id -g)`, whether a shell is present and what follows from the
 answer, whether the image trusts any certificate authority and what that means
@@ -143,7 +143,8 @@ The image's `Entrypoint` is the avroc CLI, and its `Cmd` is empty (#126). The
 arguments a caller passes to `docker run` are therefore avroc's arguments:
 
 ```console
-$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc-gen-go:v0 generate
+$ docker run --rm -v "$PWD:/work" -w /work \
+    ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 
 The image named there is a [generator image](#avrocs-own-generators), because
@@ -164,23 +165,64 @@ which is what allows the CLI to move without a major version.
 
 ## The working directory
 
-The image's `WorkingDir` is **`/work`** (#126), and a caller mounts the project
-to be generated there. avroc resolves the relative paths in a project's manifest
-against the working directory, so a mount at `/work` and no further arguments is
-the shortest complete invocation:
+**The image declares no `WorkingDir`, and the caller chooses the mount point and
+points the working directory at it** (#219). avroc resolves a project's manifest
+and every relative path in it against the process working directory, so a caller
+who mounts a project names that path twice — once to mount it and once to work
+from it:
 
 ```console
-$ docker run --rm -v "$PWD:/work" ghcr.io/z5labs/avroc-gen-go:v0 generate
+$ docker run --rm -v "$PWD:/work" -w /work \
+    ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 
-`/work` **MUST** exist in the base image and **MUST** be owned by the [image's
-user](#the-user), so that generation into an unmounted `/work` works and a
-caller who mounts over it inherits nothing surprising. It is covered by the
-[compatibility guarantees](#compatibility-guarantees).
+`/work` there is the caller's choice and nothing more. Any path does, and the
+image contains none of them: nothing is created to be a working directory, and
+there is no path in the image a project has to be mounted over.
 
-A derived image **MAY** change `WorkingDir`, and a caller **MAY** override it
-with `--workdir`. Neither is expected: `/work` is a mount point, and a project
-that wants a different one passes different paths to avroc instead.
+A caller **MUST** point the working directory at the mounted project, with `-w`
+or `--workdir` or a derived image's `WORKDIR`. Nothing in the image does it for
+them, and an unset `WorkingDir` is not neutral — the runtime specification
+requires an absolute `process.cwd`, and an empty image value resolves to `/`,
+where there is no `avroc.json`. A run that forgets the flag fails in avroc's own
+words, naming the manifest it could not find, before it has done any work.
+
+That the image declares no working directory is covered by the [compatibility
+guarantees](#compatibility-guarantees): the assertion is that the field is
+**empty**, not that it holds some other value, because a `WorkingDir` arriving
+from a base layer nobody here wrote is exactly the change an unasserted field
+lets through.
+
+A derived image **MAY** set `WorkingDir`, and one built for a fixed project
+layout reasonably does. A caller **MUST NOT** rely on the base image setting one.
+
+### Why the image sets none
+
+Because the pipeline that builds it does not, and the response to that gap is to
+delete avroc's need for the thing rather than to ask for it upstream (#217, #218).
+The shared archetype states the absence as a decision rather than an omission,
+and it is load bearing there: a relative contribution path is refused on the
+grounds that it would resolve against a working directory the pipeline never
+sets. The writable half dies with it independently — a contributed directory is
+mode `0555`, so a `/work` created in the image would not be one generation could
+write into, and "generation into an unmounted `/work` works" would stop being
+true whatever happened to the configuration field.
+
+The flag is cheap in a way the argument turned on: `-v "$PWD:/work"` already
+types the path once, so `-w /work` types a path the invocation contains rather
+than teaching the reader a fact they had no way to possess. That is the
+difference between this and the `--tmpfs /tmp:mode=1777` #218 removed, and it is
+why this promise was worth spending and that one was not.
+
+> **Breaking change.** This is one, and it is called out as one: every `docker
+> run` in this document, in [`README.md`](../../README.md) and in
+> [`CONTRIBUTING.md`](../../CONTRIBUTING.md) grew a `-w`, and a documented command
+> that stops working does not ship in a patch release. It lands in the next minor
+> release beside the other breaks #217 carries — attestation discovery becoming
+> referrers-only, and the SBOM's subject moving from the executable to the image
+> — and the release notes name all three together. See [How a covered thing would
+> change](#how-a-covered-thing-would-change) for why a removal cannot be shipped
+> as an overlap the way a move can.
 
 ## The user
 
@@ -210,8 +252,9 @@ the number other people's tooling already expects.
 
 ### What it means for ownership
 
-The [plugin directory](#the-plugin-directory) and the [working
-directory](#the-working-directory) are owned by 65532:65532 in the base image. A
+The [plugin directory](#the-plugin-directory) is owned by 65532:65532 in the base
+image, and is the only directory in it that is: there is no [working
+directory](#the-working-directory) in the image to own. A
 derived image copying a plugin in **SHOULD** use `--chown=65532:65532` and
 **MUST** ensure the result is readable and executable by that user; a
 world-readable, world-executable file satisfies this without the `--chown`,
@@ -229,7 +272,7 @@ they may not be able to edit or delete it either.
 A caller **SHOULD** therefore run as themselves:
 
 ```console
-$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \
     ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
 
@@ -284,11 +327,13 @@ hard way by somebody:
   arguments, or against an image built `FROM` this one with a busybox copied in
   for the purpose.
 
-One thing the image does **not** have is worth naming: there is no temporary
-directory in it, and none is needed. avroc writes each invocation's descriptor
+Two things the image does **not** have are worth naming, and neither is needed.
+There is no temporary directory in it: avroc writes each invocation's descriptor
 into a directory beneath the output tree the generator is writing to, so a
-`docker run` that mounts a project at `/work` needs no `--tmpfs`, no volume and
-no writable path anywhere else. Where the descriptor goes is
+`docker run` that mounts a project needs no `--tmpfs`, no volume and
+no writable path anywhere else. And there is no [working
+directory](#the-working-directory) — nothing is created to be one, so the mounted
+project is the only writable path a generation touches. Where the descriptor goes is
 [implementation detail](#compatibility-guarantees) like everything else in the
 filesystem that is not named above, and a derived image that wrote into it by
 path would be depending on something that may change in a patch release.
@@ -325,7 +370,7 @@ working.
 Export **in plaintext, to a collector on the pod or the host network**:
 
 ```console
-$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \
     -e OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
     ghcr.io/z5labs/avroc-gen-go:v0 generate
 ```
@@ -590,7 +635,7 @@ and a generator image is still avroc. Running one is running avroc with one more
 generator on its `PATH`:
 
 ```console
-$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \
     ghcr.io/z5labs/avroc-gen-json:v0 generate
 ```
 
@@ -750,7 +795,7 @@ generator. The [example project](../../example)'s schema and a manifest naming
 
 ```console
 $ docker build -t avroc-hello .
-$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" \
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work \
     avroc-hello generate
 $ cat out/hello.txt
 hello
@@ -817,7 +862,7 @@ to any of them is a breaking change:
 | --- | --- |
 | [The plugin directory](#the-plugin-directory) | `/usr/local/bin`, on `PATH` |
 | [The entrypoint](#the-entrypoint) | Is the avroc CLI, and takes its arguments |
-| [The working directory](#the-working-directory) | `/work`, existing and owned by the image's user |
+| [The working directory](#the-working-directory) | None: `WorkingDir` is empty, and the caller points it at the mount |
 | [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
 | [No shell](#no-shell) | Absent; extension is `COPY`-only |
 | [No certificate authorities](#no-certificate-authorities) | Absent; TLS egress verifies against nothing, and plaintext to a collector on the local network is the supported shape |
@@ -838,8 +883,7 @@ depending on something that may change in a patch release, with no notice:
 - Layer count, layer ordering, image size, build timestamps and every other
   label or annotation on the manifest.
 - The set of platforms beyond `linux/amd64` and `linux/arm64` (#126).
-- Which UID owns a file that is not in the plugin directory or the working
-  directory.
+- Which UID owns a file that is not in the plugin directory.
 
 ### How a covered thing would change
 
@@ -855,6 +899,16 @@ project cannot see, is built by a pipeline this project cannot warn, and fails
 at `COPY` time with an error naming a path rather than a version. Giving it a
 release in which both the old and the new form work is what turns that into a
 deprecation notice somebody reads instead of a broken build somebody bisects.
+
+**A guarantee that is withdrawn rather than moved cannot be shipped that way**, and
+[the working directory](#the-working-directory) is the case (#219). There is no
+form in which `WorkingDir` is both `/work` and unset, so there is no overlap to
+hold: a withdrawal is announced in the release notes of the release that makes it,
+with the invocation the caller has to write instead, and it **MUST NOT** ship in a
+patch release. What replaces the overlap is that the new invocation works against
+both the old image and the new one — a `docker run` carrying `-w /work` behaves
+identically on an image that already set it — so a consumer can make the change
+before taking the release rather than after.
 
 ## Out of Scope
 
@@ -924,7 +978,7 @@ found there and what happens to it.
 | _This document_ | [#107](https://github.com/z5labs/avroc/issues/107) |
 | [The plugin directory](#the-plugin-directory) | [#126](https://github.com/z5labs/avroc/issues/126) |
 | [The entrypoint](#the-entrypoint) | [#126](https://github.com/z5labs/avroc/issues/126), [#127](https://github.com/z5labs/avroc/issues/127) |
-| [The working directory](#the-working-directory) | [#126](https://github.com/z5labs/avroc/issues/126) |
+| [The working directory](#the-working-directory) | [#126](https://github.com/z5labs/avroc/issues/126), [#219](https://github.com/z5labs/avroc/issues/219) |
 | [The user](#the-user) | [#126](https://github.com/z5labs/avroc/issues/126) |
 | [No shell](#no-shell) | [#126](https://github.com/z5labs/avroc/issues/126) |
 | [No certificate authorities](#no-certificate-authorities) | [#198](https://github.com/z5labs/avroc/issues/198) |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -198,31 +198,46 @@ layout reasonably does. A caller **MUST NOT** rely on the base image setting one
 
 ### Why the image sets none
 
-Because the pipeline that builds it does not, and the response to that gap is to
-delete avroc's need for the thing rather than to ask for it upstream (#217, #218).
-The shared archetype states the absence as a decision rather than an omission,
-and it is load bearing there: a relative contribution path is refused on the
-grounds that it would resolve against a working directory the pipeline never
-sets. The writable half dies with it independently — a contributed directory is
-mode `0555`, so a `/work` created in the image would not be one generation could
-write into, and "generation into an unmounted `/work` works" would stop being
-true whatever happened to the configuration field.
+Because a working directory is not something a consumer needs the image to hold.
+It is the one part of the invocation the caller has already written down: `-v
+"$PWD:/work"` types the path once, so `-w /work` types a path the command
+contains rather than teaching the reader a fact they had no way to possess. A
+baked-in default saves one flag and, in exchange, makes a mount point a promise —
+and promises are what this document is for spending carefully.
 
-The flag is cheap in a way the argument turned on: `-v "$PWD:/work"` already
-types the path once, so `-w /work` types a path the invocation contains rather
-than teaching the reader a fact they had no way to possess. That is the
-difference between this and the `--tmpfs /tmp:mode=1777` #218 removed, and it is
-why this promise was worth spending and that one was not.
+The **writable** half of the old guarantee could not have survived in any case,
+and that is a fact about the image rather than about how it is built. Generation
+needs to write into the working directory, so `/work` had to be a directory this
+image's user owned and could write to; a `/work` that is not writable makes
+"generation into an unmounted `/work` works" false whatever the configuration
+field says. Once the writable half is gone, an empty `/work` in the filesystem is
+a path that exists to be mounted over, and [No shell](#no-shell)'s "the base is
+`scratch` plus the files this document names" is a better guarantee without it.
 
-> **Breaking change.** This is one, and it is called out as one: every `docker
-> run` in this document, in [`README.md`](../../README.md) and in
-> [`CONTRIBUTING.md`](../../CONTRIBUTING.md) grew a `-w`, and a documented command
-> that stops working does not ship in a patch release. It lands in the next minor
-> release beside the other breaks #217 carries — attestation discovery becoming
-> referrers-only, and the SBOM's subject moving from the executable to the image
-> — and the release notes name all three together. See [How a covered thing would
-> change](#how-a-covered-thing-would-change) for why a removal cannot be shipped
-> as an overlap the way a move can.
+There is a second reason, and it is deliberately *not* stated as a property of
+this image: the shared pipeline this project is moving its build onto sets no
+working directory and states that as a decision rather than an omission (#217).
+How the image is built is [out of
+scope](#how-the-image-is-built-and-published) here, so that is not a reason a
+consumer can check and it is not offered as one — it is why the promise is being
+spent now, while it can still be, rather than why it was not worth keeping.
+
+> **Breaking change.** This is one. Every `docker run` in this document, in
+> [`README.md`](../../README.md) and in [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+> grew a `-w`, and a command a previous release documented now fails without it.
+>
+> Two things follow, and they are requirements on the release rather than
+> descriptions of one already made. It **MUST NOT** ship in a patch release; it
+> ships in the next minor, beside the other breaks #217 carries — attestation
+> discovery becoming referrers-only, and the SBOM's subject moving from the
+> executable to the image. And that release's notes **MUST** name it, with the
+> invocation a caller has to write instead, which is what [How a covered thing
+> would change](#how-a-covered-thing-would-change) requires of a guarantee that is
+> withdrawn rather than moved.
+>
+> The migration is safe to make early: `-w /work` behaves identically on an image
+> that already sets `WorkingDir`, so a caller can add the flag before taking the
+> release rather than after.
 
 ## The user
 
@@ -327,13 +342,19 @@ hard way by somebody:
   arguments, or against an image built `FROM` this one with a busybox copied in
   for the purpose.
 
-Two things the image does **not** have are worth naming, and neither is needed.
-There is no temporary directory in it: avroc writes each invocation's descriptor
-into a directory beneath the output tree the generator is writing to, so a
-`docker run` that mounts a project needs no `--tmpfs`, no volume and
-no writable path anywhere else. And there is no [working
-directory](#the-working-directory) — nothing is created to be one, so the mounted
-project is the only writable path a generation touches. Where the descriptor goes is
+Two things the image does **not** have are worth naming, because the exhaustive
+listing above reads as exhaustive and neither absence is guessable from it.
+
+**No temporary directory, and none is needed.** avroc writes each invocation's
+descriptor into a directory beneath the output tree the generator is writing to,
+so a `docker run` that mounts a project needs no `--tmpfs`, no volume and no
+writable path anywhere else.
+
+**No working directory, and the caller supplies one.** Nothing in the image is
+created to be one, which is why the mounted project is the only writable path a
+generation touches — but unlike the temporary directory, this one is not simply
+absent from the invocation too: a caller **MUST** pass `-w`, as [The working
+directory](#the-working-directory) requires. Where the descriptor goes is
 [implementation detail](#compatibility-guarantees) like everything else in the
 filesystem that is not named above, and a derived image that wrote into it by
 path would be depending on something that may change in a patch release.


### PR DESCRIPTION
Closes #219

The published image no longer declares a `WorkingDir` and no longer creates
`/work`. Both were covered guarantees, neither survives #217, and this is the
last of that story's three unexpressible promises — closed the way #218 closed
the second, by deleting avroc's need for the thing rather than asking for it
upstream.

## Acceptance criteria

- [x] **`.dagger/image.go` sets no working directory and creates no `/work`.**
      `workDir`, the `WithWorkdir` call and the `WithDirectory(workDir,
      dag.Directory(), …)` are all deleted rather than moved. What is left in
      their place in the contract-constants block is a comment saying so, beside
      #218's.
- [x] **`ImageContract` requires `WorkingDir` to be empty**, and the exhaustive
      filesystem listing loses the `/work` row and gains nothing. The assertion
      flips from a value to its absence rather than being dropped — an
      unasserted field is how a base layer's inherited value arrives unnoticed.
      Verified as a live assertion, not just a passing one: putting
      `WithWorkdir("/work")` back makes `dagger call image-contract` fail on both
      platforms with `the image's WorkingDir is "/work", want it empty`.
- [x] **Every check that reached `avroc.json` through the image's working
      directory now names one explicitly** — `image.go`, `generator_image.go`,
      `worked_example.go`, `trace_propagation.go` — the way `.dagger/main.go`
      and `daggerverse/avroc` already do. All seven named stages pass locally:
      `image-contract`, `generator-image-contract`, `regeneration`,
      `worked-example`, `companion-module`, `tls-egress`, `trace-propagation`.
- [x] **`daggerverse/avroc` is unchanged in behaviour** and `projectDir` stays
      `/work`. The comment at `main.go:291` stops describing a hypothetical image
      that declares no working directory and starts describing this one; the
      constant's own comment stops calling itself a fallback, since it is now the
      path actually used. A container that *does* declare one still wins, which
      is what keeps `New` able to accept an image this module did not build.
- [x] **`docs/container/SPEC.md`'s "The working directory"** says the caller
      chooses the mount point and points the working directory at it, and drops
      the `MUST` that `/work` exist. The compatibility row becomes "None:
      `WorkingDir` is empty, and the caller points it at the mount", and the
      traceability table names #219 beside #126.
- [x] **Every `docker run` printed** in `docs/container/SPEC.md` (5),
      `README.md` (1) and `CONTRIBUTING.md` (1) carries `-w`, and is correct as
      printed. `dagger call worked-example` is what checks the SPEC's own worked
      example rather than a reading of the diff.
- [x] **A run under the documented invocation generates `example/` byte for
      byte**, as 65532 and under an overridden UID, against an image whose
      `WorkingDir` is empty — `checkImageGenerates` through
      `generator-image-contract`, plus `companion-module` and the byte comparison
      inside `trace-propagation`.
- [x] **The break is called out as one.** A `> **Breaking change.**` block in
      "The working directory" names it, names the migration, says it lands in the
      next minor release beside #217's two, and says a documented command that
      stops working does not ship in a patch.
- [x] **Nothing in `.dagger/` sets a working directory on the image** to stand
      in for the archetype's absent one.

## Judgment calls

**`projectMount` is a new constant, and where it lives is the point.** The four
checks still have to mount a project somewhere and now have to say where, so the
path had to go *somewhere*. It is deliberately **not** in `image.go`'s block of
contract constants, and its comment says why: nothing about the image depends on
it, and a check that mounted at `/project` and passed `-w /project` would be
equally correct. It is `/work` only so that the checks run the command the
documents print rather than a private variant of it. That placement is what keeps
the deletion of `workDir` a deletion rather than a rename.

**"How a covered thing would change" grew a paragraph.** That section required a
covered value to change only by holding both forms simultaneously for a full
minor release, and there is no form in which `WorkingDir` is both `/work` and
unset — so a withdrawal could not satisfy the rule as written. Rather than leave
the document self-contradicting, the section now states what replaces the overlap
for a withdrawal: the *new* invocation works against both the old image and the
new one, since `-w /work` behaves identically on an image that already set it, so
a consumer can make the change before taking the release.

**No `release notes` file exists in the repository**, so the version half of that
criterion is stated where it can live: the SPEC says the break ships in the next
minor and not in a patch, and names #217's other two. The tag itself is derived
from the refs at HEAD by `.dagger/release.go` at release time, which is outside a
pull request's reach.

## Verification

All six `verify` commands pass: `go build ./...`, `gofmt -l .` (empty),
`go vet ./...`, `go test -race -cover ./...`, `golangci-lint run` (0 issues), and
the `example/` round trip with `git diff --exit-code`. The `internal/docs` link
check passes, which is what covers the new `#how-a-covered-thing-would-change`
anchor.

Beyond that, all seven Dagger stages the acceptance criteria name were run
locally and pass, and the `WorkingDir` assertion was confirmed to fail when a
working directory is put back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
