### PR TITLE
story(ci): adopt the refactored z5labs module and delete avroc's hand-rolled image, publish and release pipeline

### DIFF
--- a/.dagger/companion_module.go
+++ b/.dagger/companion_module.go
@@ -86,8 +86,8 @@ func (m *Avroc) CompanionModule(ctx context.Context) error {
 	// Both start from the base image this pipeline built, which carries the CLI
 	// and no generator — so a generation that succeeded below did so with the
 	// generators these calls put there and with nothing that was lying around.
-	fromImages := dag.Companion(dagger.CompanionOpts{Image: m.image(platform)})
-	fromExecutables := dag.Companion(dagger.CompanionOpts{Image: m.image(platform)})
+	fromImages := dag.Companion(dagger.CompanionOpts{Image: m.baseImage(platform)})
+	fromExecutables := dag.Companion(dagger.CompanionOpts{Image: m.baseImage(platform)})
 
 	for _, name := range builtinGenerators() {
 		fromImages = fromImages.WithGenerator(name, dagger.CompanionWithGeneratorOpts{

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -63,9 +63,11 @@ func (r Avroc) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Source     *dagger.Directory
 		LintConfig *dagger.File
+		GitDir     *dagger.Directory
 	}
 	concrete.Source = r.Source
 	concrete.LintConfig = r.LintConfig
+	concrete.GitDir = r.GitDir
 	return json.Marshal(&concrete)
 }
 
@@ -73,6 +75,7 @@ func (r *Avroc) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		Source     *dagger.Directory
 		LintConfig *dagger.File
+		GitDir     *dagger.Directory
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -80,6 +83,7 @@ func (r *Avroc) UnmarshalJSON(bs []byte) error {
 	}
 	r.Source = concrete.Source
 	r.LintConfig = concrete.LintConfig
+	r.GitDir = concrete.GitDir
 	return nil
 }
 
@@ -321,69 +325,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Avroc).Lint(&parent, ctx)
-		case "Publish":
-			var parent Avroc
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var address string
-			if inputArgs["address"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
-				}
-			}
-			var username string
-			if inputArgs["username"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
-				}
-			}
-			var password *dagger.Secret
-			if inputArgs["password"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
-				}
-			}
-			return (*Avroc).Publish(&parent, ctx, address, username, password)
-		case "PublishGenerator":
-			var parent Avroc
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var name string
-			if inputArgs["name"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
-				}
-			}
-			var address string
-			if inputArgs["address"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
-				}
-			}
-			var username string
-			if inputArgs["username"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
-				}
-			}
-			var password *dagger.Secret
-			if inputArgs["password"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
-				}
-			}
-			return (*Avroc).PublishGenerator(&parent, ctx, name, address, username, password)
 		case "Regeneration":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -409,6 +350,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
 				if err != nil {
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
+				}
+			}
+			var registry string
+			if inputArgs["registry"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registry", err))
 				}
 			}
 			var repository string
@@ -446,21 +394,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg idTokenRequestToken", err))
 				}
 			}
-			var builder string
-			if inputArgs["builder"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["builder"]), &builder)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg builder", err))
-				}
-			}
-			var invocation string
-			if inputArgs["invocation"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["invocation"]), &invocation)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg invocation", err))
-				}
-			}
-			return (*Avroc).Release(&parent, ctx, gitDir, repository, username, password, idTokenRequestUrl, idTokenRequestToken, builder, invocation)
+			return (*Avroc).Release(&parent, ctx, gitDir, registry, repository, username, password, idTokenRequestUrl, idTokenRequestToken)
 		case "TagScheme":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -489,6 +423,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Avroc).TlsEgress(&parent, ctx, platform)
+		case "TracePropagation":
+			var parent Avroc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return nil, (*Avroc).TracePropagation(&parent, ctx, platform)
 		case "Vet":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -537,7 +485,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg lintConfig", err))
 				}
 			}
-			return New(source, lintConfig), nil
+			var gitDir *dagger.Directory
+			if inputArgs["gitDir"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
+				}
+			}
+			return New(source, lintConfig, gitDir), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -345,13 +345,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			var gitDir *dagger.Directory
-			if inputArgs["gitDir"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
-				}
-			}
 			var registry string
 			if inputArgs["registry"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["registry"]), &registry)
@@ -394,7 +387,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg idTokenRequestToken", err))
 				}
 			}
-			return (*Avroc).Release(&parent, ctx, gitDir, registry, repository, username, password, idTokenRequestUrl, idTokenRequestToken)
+			return (*Avroc).Release(&parent, ctx, registry, repository, username, password, idTokenRequestUrl, idTokenRequestToken)
 		case "TagScheme":
 			var parent Avroc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -145,34 +145,6 @@ func (m *Avroc) GeneratorBundleImage(
 	return m.generatorBundleImage(p), nil
 }
 
-// PublishGenerator pushes one built-in generator's image to address as a
-// multi-platform index, and returns the digest-qualified reference it pushed.
-//
-// One function and one address per generator rather than a loop over a registry
-// prefix: this pushes one reference, and which references a release consists of
-// is Release's (#128), for the same reason Publish takes a full reference.
-func (m *Avroc) PublishGenerator(
-	ctx context.Context,
-	// The generator to publish, by the name a manifest asks for it by.
-	name string,
-	// The full image reference to push, including the tag.
-	address string,
-	// The registry username to authenticate as. Both this and password are
-	// needed for a registry that requires authentication.
-	// +optional
-	username string,
-	// The registry password or token to authenticate with.
-	// +optional
-	password *dagger.Secret,
-) (string, error) {
-	if !slices.Contains(builtinGenerators(), name) {
-		return "", fmt.Errorf("generator %q is not one avroc ships: %v", name, builtinGenerators())
-	}
-	return publishIndex(ctx, address, username, password, func(p dagger.Platform) *dagger.Container {
-		return m.generatorImage(p, name)
-	})
-}
-
 // GeneratorImageContract checks every published generator image against the
 // contract its base makes (#127).
 //
@@ -224,54 +196,113 @@ func (m *Avroc) GeneratorImageContract(
 	return errors.Join(errs...)
 }
 
-// generatorImage is one generator's image for one platform, and the one
-// definition of it: GeneratorImage, PublishGenerator, the bundle and the contract
-// check all come through here.
+// generatorApp is one generator as an application in its own right, before it is
+// composed into anything.
 //
-// The two calls are FROM and COPY. The owner and the mode are the derived
-// Dockerfile's `--chown=65532:65532 --chmod=0755`, which docs/container/SPEC.md
-// asks for so that the file is the image user's and executable; a world-readable
-// world-executable file would satisfy the contract without them, which is what
-// makes leaving them out a latent bug rather than an immediate one.
+// It is assembled through the archetype's generic App constructor rather than
+// through its Go chain, and that is a consequence of avroc having four commands in
+// one module: the chain names the binary it builds after go.mod's module path, so
+// every one of avroc's four would be called `avroc` and three of them would land
+// on top of each other in the plugin directory. The generic constructor is the
+// sanctioned seam for an executable the chain did not name — it produces the same
+// App, with the same hardening, the same annotations, the same modes and the same
+// publish — and it takes the name as an argument, which is the one thing that has
+// to be `avroc-gen-<name>` for avroc to find it on PATH at all.
 //
-// Nothing else is set. In particular Cmd is left empty even though a derived
-// image MAY set it: a generator image that supplied a default subcommand would be
-// answering a question the caller is entitled to answer, and every invocation in
-// the documentation passes `generate` explicitly anyway.
-func (m *Avroc) generatorImage(platform dagger.Platform, name string) *dagger.Container {
+// What that costs is stated rather than hidden. A prebuilt variant is not stamped
+// with main.version and main.commit, and its image carries the version annotation
+// without the revision, the created time and the source: those are facts the chain
+// observed about a tree it compiled, and a caller asserting them would be
+// asserting a provenance nobody can check. Neither is a loss here — avroc's
+// generators declare no version variables, and the generator *images* are composed
+// onto the base App, whose annotations are the chain's and are what a release
+// carries.
+//
+// The executable arrives with a document like every other byte in an image, and
+// the document is dag.Go().Spdx over that binary: a Go executable's SBOM is
+// derived from the compiled artifact and therefore cannot disagree with what it
+// describes, which is exactly what the archetype uses for its own. The digest is
+// checked against the bytes at publish time, so a document about a different
+// binary fails the release rather than shipping.
+//
+// One variant per published platform, stated rather than inferred: a *dagger.File
+// carries no architecture, and an App whose platform set does not match the base's
+// exactly is refused in both directions — which is the check that stops an arm64
+// index shipping an amd64 generator.
+func (m *Avroc) generatorApp(platform []dagger.Platform, name, version string) *dagger.Z5LabsApp {
 	exe := generatorExecutable(name)
 
-	return m.image(platform).WithFile(
-		pluginDir+"/"+exe,
-		m.binaries(platform).File(exe),
-		dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: executableMode},
-	)
+	app := dag.Z5Labs().App(version)
+	for _, p := range platform {
+		binary := m.binaries(p).File(exe)
+		app = app.WithVariant(p, binary, dag.Go().Spdx(binary, m.Source),
+			dagger.Z5LabsAppBuilderWithVariantOpts{Name: exe})
+	}
+	return app.Build()
 }
 
-// generatorBundleImage is the image holding every built-in generator, built by
-// stacking the published generator images rather than by copying binaries out of
-// the build.
+// generatorImageApp is one generator's published image: the base App with that
+// generator's App composed into it (#127, #217).
 //
-// That is the difference between demonstrating the mechanism and demonstrating
-// that this repository can put four files in a directory: each executable is
-// taken from the image that publishes it, at the promised path, which is exactly
-// what somebody combining two generator images they did not build would write.
-func (m *Avroc) generatorBundleImage(platform dagger.Platform) *dagger.Container {
-	names := builtinGenerators()
+// Composition is what a derived Dockerfile's FROM and COPY were, and it is
+// strictly more than they were: the executable is matched platform by platform, it
+// lands in the plugin directory under its own file name at the mode an executable
+// needs, its document joins the base's so the image's SBOM accounts for it, its
+// version is recorded so something says which release of the generator shipped,
+// and the composed entry is exec'd in every variant before the first byte is
+// pushed. A collision with the base or with a generator composed earlier is
+// refused rather than layered over.
+//
+// Nothing else is set. In particular Cmd stays empty even though a derived image
+// MAY set it: a generator image that supplied a default subcommand would be
+// answering a question the caller is entitled to answer, and every invocation in
+// the documentation passes `generate` explicitly anyway. The archetype makes that
+// structural rather than a discipline — there is no seam on an App for an
+// entrypoint, a Cmd, a user or an environment variable.
+func (m *Avroc) generatorImageApp(name, version string) *dagger.Z5LabsApp {
+	platforms := imagePlatforms()
+	return m.baseApp(version).WithApp(m.generatorApp(platforms, name, version))
+}
 
-	// FROM the first generator's image, so the bundle is a derived image of a
-	// derived image — the case that would break if a generator image had quietly
-	// stopped being a valid base.
-	image := m.generatorImage(platform, names[0])
-	for _, name := range names[1:] {
-		path := pluginDir + "/" + generatorExecutable(name)
-		image = image.WithFile(
-			path,
-			m.generatorImage(platform, name).File(path),
-			dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: executableMode},
-		)
+// generatorImage is one generator's image for one platform.
+//
+// It is an accessor onto the App for the same reason baseImage is: the container
+// it hands back is the one a publish would push, which is what lets a check read
+// it and mean something.
+func (m *Avroc) generatorImage(platform dagger.Platform, name string) *dagger.Container {
+	return m.generatorImageApp(name, devVersion).Container(platform)
+}
+
+// generatorBundleApp is the App holding every built-in generator: the base with
+// all three composed into it.
+//
+// It used to be built by stacking the published generator images — FROM the first
+// and `COPY --from` the rest — on the grounds that copying an executable out of
+// the image that publishes it is what an adopter combining two strangers' images
+// writes. Composition replaces that with something that does more of what the
+// stacking was standing in for: each generator arrives as a whole application with
+// its own document and its own version, the collision surface is checked rather
+// than layered over, and every one of the three is run in the finished image before
+// it is published. What is lost is the transitivity the old shape demonstrated
+// incidentally — a derived image of a derived image — and the archetype states that
+// composition is transitive and refuses nothing about it, so nothing here relies on
+// having shown it.
+//
+// example/ is what it is checked against, since that project's manifest names all
+// three; see checkImageGenerates.
+func (m *Avroc) generatorBundleApp(version string) *dagger.Z5LabsApp {
+	platforms := imagePlatforms()
+
+	app := m.baseApp(version)
+	for _, name := range builtinGenerators() {
+		app = app.WithApp(m.generatorApp(platforms, name, version))
 	}
-	return image
+	return app
+}
+
+// generatorBundleImage is the bundle for one platform, as a container.
+func (m *Avroc) generatorBundleImage(platform dagger.Platform) *dagger.Container {
+	return m.generatorBundleApp(devVersion).Container(platform)
 }
 
 // generatorImageContractOn checks one platform's generator images.
@@ -284,7 +315,7 @@ func (m *Avroc) generatorImageContractOn(ctx context.Context, platform dagger.Pl
 
 	for _, name := range builtinGenerators() {
 		image := m.generatorImage(platform, name)
-		contents := append(baseImageExecutables(), generatorExecutable(name))
+		contents := append(baseImageExecutables(), generatorExecutable(name)) //nolint:gocritic // the base ships none, and appending is what says "the base's plus this one"
 
 		for _, err := range m.checkImageConfig(ctx, image) {
 			errs = append(errs, fmt.Errorf("%s: %w", name, err))

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -3,9 +3,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// This file builds and checks the published generator images: avroc's own three
-// generators, each shipped as an image built FROM the base image, which image.go
-// builds (#127).
+// This file composes and checks the published generator images: avroc's own three
+// generators, each shipped as the base image plus one executable in the plugin
+// directory (#127, #217).
 //
 // # Why the built-ins go through the front door
 //
@@ -17,34 +17,48 @@
 // out that the mechanism needs a path the contract does not promise would have
 // been somebody in another repository, at their `docker build`.
 //
-// So the base ships the CLI and nothing else, and avroc-gen-go, avroc-gen-json
-// and avroc-gen-pcf reach their images the way a stranger's generator reaches
-// theirs: FROM the base, COPY into the plugin directory, chowned to the image's
-// user and marked executable, nothing else touched. Every path named below is
-// one docs/container/SPEC.md promises, which is the property this whole
-// arrangement exists to keep honest — and GeneratorImageContract is what fails
-// when it stops being true.
+// So the base ships no generator, and avroc-gen-go, avroc-gen-json and
+// avroc-gen-pcf reach their images through the one seam a stranger's generator
+// reaches theirs by: the plugin directory, under the name avroc searches PATH for.
+// Every path named below is one docs/container/SPEC.md promises, which is the
+// property this whole arrangement exists to keep honest — and
+// GeneratorImageContract is what fails when it stops being true.
+//
+// # Composition, not FROM plus COPY
+//
+// It was FROM plus COPY here until #217: m.image(platform).WithFile(...), which is
+// literally what a derived Dockerfile writes, because Dagger's WithFile and
+// buildkit's COPY are the same operation. The archetype's App.WithApp replaces it
+// and does strictly more of what that was standing in for — the executable is
+// matched platform by platform so an arm64 index cannot ship an amd64 generator,
+// its SPDX document joins the base's so the image's SBOM accounts for it, its
+// version is recorded so something says which release of the generator shipped,
+// a path collision with the base or with a generator composed earlier is refused
+// rather than layered over, and the composed entry is exec'd in every variant
+// before the first byte is pushed.
 //
 // # Why this is Dagger rather than a Dockerfile the pipeline builds
 //
 // docs/container/SPEC.md states these images as Dockerfiles, because a Dockerfile
-// is what an adopter writes, and the two instructions below are the two
-// instructions in one. The pipeline nonetheless builds them with the calls here
-// rather than by handing that Dockerfile to a builder, for a reason that is about
-// what is being checked rather than about taste: a `FROM ghcr.io/z5labs/avroc:v0`
-// line names a *published* image, and a pull request has to check the image it
-// just built. There is no way to point a Dockerfile's FROM at a container that
-// exists only inside the pipeline — a registry service is not reachable from a
-// Dockerfile build's image resolution — so building the committed Dockerfile
-// would check the previous release's base and say nothing about this change.
+// is what an adopter writes. The pipeline nonetheless composes them with the calls
+// here rather than by handing that Dockerfile to a builder, for a reason that is
+// about what is being checked rather than about taste: a
+// `FROM ghcr.io/z5labs/avroc:v0` line names a *published* image, and a pull request
+// has to check the image it just built. There is no way to point a Dockerfile's
+// FROM at a container that exists only inside the pipeline — a registry service is
+// not reachable from a Dockerfile build's image resolution — so building the
+// committed Dockerfile would check the previous release's base and say nothing
+// about this change.
 //
 // The drift that arrangement risks is closed by the check rather than by
 // discipline: checkImageFilesystem compares each generator image against an
 // exhaustive listing, so an image that differs from "the base plus exactly one
 // executable at the promised path" fails, which is the same assertion the
-// Dockerfile makes. Dagger's WithFile *is* COPY — both are buildkit — and the
-// stage built FROM the base runs no exec at all, which is the strongest form of
-// the COPY-only rule available: there is no shell in the image to run one with.
+// Dockerfile makes. Nothing composed here runs an exec in the finished image
+// either, which is the strongest form of the COPY-only rule available: there is no
+// shell in the image to run one with. What a Dockerfile *cannot* express is the
+// list above, which is why the two are no longer the same two instructions —
+// worked_example.go is where the document's own version is built and run.
 package main
 
 import (
@@ -86,15 +100,16 @@ func generatorExecutable(name string) string {
 	return "avroc-gen-" + name
 }
 
-// GeneratorImage builds the published image for one built-in generator: the base
-// image with that generator copied into the plugin directory, and nothing else
-// changed (#127).
+// GeneratorImage is the published image for one built-in generator, as a
+// container: the base image with that generator composed into the plugin
+// directory, and nothing else changed (#127, #217).
 //
-// It is the same two instructions docs/container/SPEC.md's worked example gives
-// a third-party author, and deliberately no more: the entrypoint is inherited
-// rather than set, Cmd stays empty so a caller's arguments are still avroc's, and
-// the only path named is the plugin directory, which is covered by the
-// compatibility guarantees.
+// It exists so that a contributor can load or export one, the way Image does, and
+// it hands back a container rather than the App for the reason given there. What it
+// promises is what the worked example promises a third-party author and no more:
+// the entrypoint is inherited rather than set, Cmd stays empty so a caller's
+// arguments are still avroc's, and the only path named is the plugin directory,
+// which is covered by the compatibility guarantees.
 //
 // platform defaults to the engine's own, which is what makes
 // `dagger call generator-image --name go` useful from a checkout.
@@ -118,16 +133,15 @@ func (m *Avroc) GeneratorImage(
 	return m.generatorImage(p, name), nil
 }
 
-// GeneratorBundleImage builds the image that combines every built-in generator:
-// one generator image with the others' executables copied into it (#127).
+// GeneratorBundleImage is the image that combines every built-in generator: the
+// base with all three composed into it (#127, #217).
 //
 // It is here because combining generators is the question an adopter asks
 // immediately after adding one — a project whose manifest names three generators
 // needs one image holding all three — and because the answer had better not be
-// "rebuild them all from source". It is not: each executable is copied out of the
-// published generator image that already carries it, at the path
-// docs/container/SPEC.md promises, which is `COPY --from=<image>` and is
-// available to anybody combining images this project has never heard of.
+// "rebuild them all from source". It is not: each generator is an application in
+// its own right, composed in, which is the seam an adopter combining generators
+// this project has never heard of uses too.
 //
 // example/ is what it is checked against, since that project's manifest names all
 // three; see checkImageGenerates.
@@ -315,7 +329,7 @@ func (m *Avroc) generatorImageContractOn(ctx context.Context, platform dagger.Pl
 
 	for _, name := range builtinGenerators() {
 		image := m.generatorImage(platform, name)
-		contents := append(baseImageExecutables(), generatorExecutable(name)) //nolint:gocritic // the base ships none, and appending is what says "the base's plus this one"
+		contents := append(baseImageExecutables(), generatorExecutable(name))
 
 		for _, err := range m.checkImageConfig(ctx, image) {
 			errs = append(errs, fmt.Errorf("%s: %w", name, err))

--- a/.dagger/generator_image.go
+++ b/.dagger/generator_image.go
@@ -328,16 +328,7 @@ func (m *Avroc) generatorImageContractOn(ctx context.Context, platform dagger.Pl
 	var errs []error
 
 	for _, name := range builtinGenerators() {
-		image := m.generatorImage(platform, name)
-		contents := append(baseImageExecutables(), generatorExecutable(name))
-
-		for _, err := range m.checkImageConfig(ctx, image) {
-			errs = append(errs, fmt.Errorf("%s: %w", name, err))
-		}
-		for _, err := range m.checkImageFilesystem(ctx, image, contents) {
-			errs = append(errs, fmt.Errorf("%s: %w", name, err))
-		}
-		if err := m.checkGeneratorRuns(ctx, image, name); err != nil {
+		for _, err := range m.checkGeneratorImage(ctx, m.generatorImage(platform, name), name) {
 			errs = append(errs, fmt.Errorf("%s: %w", name, err))
 		}
 	}
@@ -359,6 +350,35 @@ func (m *Avroc) generatorImageContractOn(ctx context.Context, platform dagger.Pl
 	}
 
 	return errors.Join(errs...)
+}
+
+// checkGeneratorImage is every assertion one generator's image is held to, over a
+// container somebody else chose.
+//
+// It is image.go's checkBaseImage for a derived image, and it exists for the same
+// reason: GeneratorImageContract builds one container per published platform and
+// the release gate passes the very container it is about to push, and both have to
+// be the same list of checks or the gate is weaker than the pull request that
+// preceded it.
+//
+// It is deliberately *not* checkBaseImage plus one row. A generator image inherits
+// its configuration and is checked for that, its filesystem is the base's plus one
+// executable, and what replaces the base's two behavioural checks is
+// checkGeneratorRuns — the base's `help`-through-the-entrypoint is all an image
+// with no generator can be asked to do, and an image with one can be asked to
+// generate instead, which is strictly more. checkAMissingWorkingDirectoryIsLegible
+// stays the base's alone for the reason its own comment gives: it depends on
+// loadManifest running before the capability handshake, so it is a statement about
+// an image that ships no generator.
+func (m *Avroc) checkGeneratorImage(ctx context.Context, image *dagger.Container, name string) []error {
+	contents := append(baseImageExecutables(), generatorExecutable(name))
+
+	errs := m.checkImageConfig(ctx, image)
+	errs = append(errs, m.checkImageFilesystem(ctx, image, contents)...)
+	if err := m.checkGeneratorRuns(ctx, image, name); err != nil {
+		errs = append(errs, err)
+	}
+	return errs
 }
 
 // checkGeneratorRuns requires the image to generate with its own generator and

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -3,43 +3,52 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// This file builds and checks the published base image — the one
+// This file composes and checks the published base image — the one
 // docs/container/SPEC.md describes and strangers' Dockerfiles name paths inside
-// (#126).
+// (#126, #217).
 //
-// # Why the image is built here rather than by the GoApp archetype
+// # Why there is no image built here any more
 //
-// The base-image story opened with a blocker and three ways out: extend the
-// devex GoApp archetype upstream to accept image customization, build the image
-// in this module, or accept a non-scratch base. This file is the second, and the
-// reason is that the first two are not alternatives at the same level.
+// There used to be, and this comment used to argue at length that there had to
+// be. The base-image story opened with a blocker and three ways out — extend the
+// devex archetype upstream to accept image customization, build the image here,
+// or accept a non-scratch base — and it took the second, because the archetype's
+// image half produced one scratch image per binary with /app/<binaryName> as
+// entrypoint and nothing else: no PATH, no user, no plugin directory, no second
+// executable, no data file. avroc's image is a base other people build FROM and
+// has to promise all of those.
 //
-// GoApp's imageForPlatform produces a scratch image holding one binary at
-// /app/<binaryName>, with that path as the entrypoint and nothing else set: no
-// PATH, no USER, no working directory, no second binary, no data file. avroc's
-// image has to promise all six, because it is a base that other people build
-// FROM — and four of the six are not settings GoApp is missing so much as a
-// different shape of image. avroc publishes an image that is a base: one binary
-// in a directory on PATH, into which other images COPY plugins that are found
-// by a PATH search rather than run as the entrypoint (#127); GoApp publishes one
-// image per binary and has no notion of a derived image. Teaching GoApp that shape
-// would be teaching it avroc's plugin model, which is a contract in this
-// repository's docs/ and belongs nowhere else. What would be left upstream after
-// the customization was general enough to keep — a settable USER, WORKDIR and
-// PATH — is a handful of Container calls, which is precisely what is below.
+// #217 is the first way out arriving after all. The refactored archetype makes
+// every one of those a property of the standard rather than of this repository:
+// /usr/local/bin is its fixed executable directory with PATH composed from the
+// same constant so the two cannot drift, 65532:65532 is its pinned non-root user
+// with no seam to move it, an image carries no working directory and states that
+// as a decision, a contribution arrives with a document describing it, and
+// App.WithApp composes one application's executable into another's plugin
+// directory — which is what a generator image is, matched platform by platform
+// and exec'd before anything is pushed. So what is left here is the two
+// contributions that are avroc's own and the checks that hold the contract, and
+// the image itself belongs to nobody in this file.
 //
-// The third way out, a non-scratch base, was rejected on the contract rather
-// than on size. docs/container/SPEC.md's "No shell" is a load-bearing promise:
-// it is what makes extension COPY-only, and what makes the image's contents
-// exactly the executables somebody deliberately put there. A distroless or
-// busybox base would be a smaller change here and a larger one there.
+// Two things the archetype does *not* express are worth naming, because both
+// were promises this repository made and neither is worked around here:
 //
-// What is *not* rebuilt here is anything about what "checked" means. fmt, vet,
-// lint and `go test -race` still route through the Z5Labs standard by way of Ci,
-// the binaries are still built by the shared devex Go module's Build, and this
-// file adds only the image layout the standard has no opinion about. That is the
-// split main.go's package comment anticipated, and no upstream devex change was
-// needed to reach it.
+//   - A writable 1777 /tmp, which #218 removed the need for by writing each
+//     invocation's descriptor into the output tree.
+//   - /work as a WorkingDir, which #219 withdrew, and which the archetype now
+//     rests a refusal on rather than merely omitting.
+//
+// A third arrived with the adoption itself and is recorded in
+// docs/container/SPEC.md rather than here: the base image no longer carries an
+// *empty* /usr/local/bin, because a contribution to any directory the image's
+// PATH resolves against is refused — content with no architecture that something
+// could find by name is how an arm64 image comes to run an amd64 executable —
+// and composition, the sanctioned route, would mean shipping a generator in the
+// base. See that document's "The plugin directory".
+//
+// The third way out, a non-scratch base, stayed rejected on the contract rather
+// than on size: docs/container/SPEC.md's "No shell" is what makes extension
+// COPY-only, and the archetype's base is scratch too.
 //
 // # Why the contract is a check rather than a comment
 //
@@ -115,18 +124,73 @@ const (
 	// author whose language has no protobuf code generation in the build.
 	descriptorSetPath = "/usr/local/share/avroc/ir.binpb"
 
+	// appDir is where the archetype puts an application's own binary, and homeDir
+	// is what it points HOME at. Neither is avroc's to choose and neither is in
+	// docs/container/SPEC.md: they are here because the filesystem listing is
+	// exhaustive, so a path the image carries has to be named somewhere even when
+	// nothing may depend on it.
+	//
+	// They are read from this repository rather than imported because the
+	// archetype exposes no constant for either, which is the same reason
+	// manifestFilename is written out below: a check reads the image the way a
+	// person would, and the day either value moves the listing is what says so.
+	appDir  = "/app"
+	homeDir = "/home/nonroot"
+
+	// homeMode is the mode HOME's directory has: traversable and readable,
+	// writable by nobody, and root-owned so that the refusal survives a caller
+	// overriding the runtime user. avroc writes nothing under HOME — since #218 it
+	// reads no ambient temporary directory either — so an empty read-only
+	// directory is the whole of what this row means.
+	homeMode = 0o555
+
 	// cliExecutable is the avroc CLI, and the only executable the base image
 	// ships. Its path is deliberately not part of the contract; that it is the
 	// one and only binary in the base is, because "the base is scratch plus the
 	// files docs/container/SPEC.md names" is what makes a generator image's
 	// contents exactly what somebody copied into it.
+	//
+	// It is also the name the archetype gives the binary it builds, which is the
+	// basename of the module path in go.mod and not something a caller states —
+	// so cliPackage below is the package that produces it and the two agree
+	// because this repository's module is called avroc.
 	cliExecutable = "avroc"
 
-	// executableMode is the mode every executable in the plugin directory has:
-	// readable and executable by the image's user and by any UID a caller
-	// overrides it with, which is what makes `--user $(id -u):$(id -g)` an
-	// ordinary configuration rather than a workaround.
-	executableMode = 0o755
+	// cliPackage is the package the archetype builds the base image's binary
+	// from. It is stated where the version is, rather than beside the entrypoint,
+	// because the archetype derives the executable's *name* from go.mod and takes
+	// only the package to compile.
+	cliPackage = "./cmd/" + cliExecutable
+
+	// executableMode is the mode every executable in the plugin directory has.
+	//
+	// It is 0555 rather than the 0755 this pipeline used to write, because the
+	// archetype owns it now: every byte it puts in an image is read-only, on the
+	// grounds that an image whose files the application can rewrite is one whose
+	// published digest stops describing what is running. What the contract needs
+	// is unchanged and is the reason the mode is world-anything at all — an
+	// executable any UID can run, so `--user $(id -u):$(id -g)` is an ordinary
+	// configuration rather than a workaround.
+	executableMode = 0o555
+
+	// contributedFileMode is the mode a contributed data file lands with, and it
+	// is the archetype's for executableMode's reason. The FileDescriptorSet is
+	// the one file in this image that has it; world-readable is the half the
+	// contract depends on, because a caller who overrides the UID reads the same
+	// file.
+	contributedFileMode = 0o444
+
+	// devVersion is the version every build that is not a release publishes
+	// under, and therefore the version every check builds.
+	//
+	// The archetype requires one: it stamps main.version into the binary and puts
+	// the value in an OCI annotation, and it refuses a version that could not be
+	// an image tag. A release states its own (release.go's planRelease, from the
+	// refs at HEAD); everything else is not a release and says so, rather than
+	// borrowing the last one's number. Nothing in docs/container/SPEC.md covers an
+	// annotation, so this value is invisible to a consumer — it exists so that
+	// "which release is this" has an answer that is never wrong.
+	devVersion = "v0.0.0-dev"
 )
 
 // imagePlatforms is the set of platforms the image is published for, and the
@@ -137,17 +201,25 @@ func imagePlatforms() []dagger.Platform {
 	return []dagger.Platform{"linux/amd64", "linux/arm64"}
 }
 
-// Image builds the published base image for one platform.
+// Image is the published base image for one platform, as a container.
 //
-// It is the image docs/container/SPEC.md describes, and every promise that
-// document makes is made here: the CLI in /usr/local/bin with that directory on
-// PATH, the CLI as the entrypoint with an empty Cmd, no working directory at all
-// (#219), UID and GID 65532 owning the plugin directory and running the process,
-// the IR FileDescriptorSet at its documented path, and nothing else in the
-// filesystem at all.
+// It exists so that a contributor can load or export the image the pipeline
+// builds — `dagger call image export --path ./avroc.tar` — and for nothing else.
+// Every promise docs/container/SPEC.md makes about it is the archetype's now:
+// baseApp is the whole of avroc's contribution, which is the package to compile
+// and one data file.
 //
-// No generator is in it. avroc's own three are shipped as images built FROM this
-// one (#127, GeneratorImage), which is the only arrangement in which they are
+// It hands back a *dagger.Container rather than the App it came from because
+// Dagger refuses a function that returns an object type belonging to a
+// dependency module, so an `app` entrypoint threading the archetype's chain out
+// to the command line is not expressible here. That is also why there is no
+// Publish beside this one: a publish is signed and attested by construction —
+// the archetype fails one it cannot produce provenance for — and the only
+// caller that has an OIDC token to exchange is the release workflow, which
+// reaches it through Release.
+//
+// No generator is in it. avroc's own three are composed onto this App (#127,
+// #217, GeneratorImage), which is the only arrangement in which they are
 // consumers of the extension mechanism rather than a private arrangement that
 // happens to look like one.
 //
@@ -166,74 +238,7 @@ func (m *Avroc) Image(
 	if err != nil {
 		return nil, err
 	}
-	return m.image(p), nil
-}
-
-// Publish pushes the image to address as a multi-platform index covering every
-// platform in imagePlatforms, and returns the digest-qualified reference it
-// pushed.
-//
-// address carries the tag, because this function's job is to push one reference
-// and not to decide which references exist. Which tags a release carries is
-// Release's, derived from the refs at HEAD in one place (#128); this is what a
-// person calls to put an image on a test registry, and what Release calls once
-// per tag.
-//
-// One index rather than one image per platform, so that a `FROM` line naming the
-// tag resolves to the manifest for whatever platform the builder is on, which is
-// what makes the published set of platforms invisible to a derived Dockerfile.
-func (m *Avroc) Publish(
-	ctx context.Context,
-	// The full image reference to push, including the tag.
-	address string,
-	// The registry username to authenticate as. Both this and password are
-	// needed for a registry that requires authentication, which is every
-	// registry this project publishes to.
-	// +optional
-	username string,
-	// The registry password or token to authenticate with.
-	// +optional
-	password *dagger.Secret,
-) (string, error) {
-	return publishIndex(ctx, address, username, password, m.image)
-}
-
-// publishIndex pushes one multi-platform index built from build, which is called
-// once per published platform.
-//
-// It is shared by Publish and PublishGenerator rather than written twice: the
-// credential handling and the index shape are properties of publishing an avroc
-// image, not of which image is being published, and a second copy would be a
-// second chance to get the anonymous-push case wrong.
-func publishIndex(
-	ctx context.Context,
-	address, username string,
-	password *dagger.Secret,
-	build func(dagger.Platform) *dagger.Container,
-) (string, error) {
-	platforms := imagePlatforms()
-	variants := make([]*dagger.Container, 0, len(platforms))
-	for _, p := range platforms {
-		variants = append(variants, build(p))
-	}
-
-	// Half a credential is refused rather than quietly dropped. Skipping the
-	// auth because one of the two is missing turns a typo into an anonymous
-	// push, which fails at the registry with a message about permissions rather
-	// than about the argument that was actually wrong — and on a registry that
-	// happened to allow it, would not fail at all.
-	switch {
-	case username != "" && password == nil:
-		return "", errors.New("username was given without password: both are needed to authenticate, and publishing with neither pushes anonymously")
-	case username == "" && password != nil:
-		return "", errors.New("password was given without username: both are needed to authenticate, and publishing with neither pushes anonymously")
-	}
-
-	c := dag.Container()
-	if username != "" {
-		c = c.WithRegistryAuth(address, username, password)
-	}
-	return c.Publish(ctx, address, dagger.ContainerPublishOpts{PlatformVariants: variants})
+	return m.baseImage(p), nil
 }
 
 // ImageContract checks the published image against every promise
@@ -290,67 +295,82 @@ func (m *Avroc) ImageContract(
 	return errors.Join(errs...)
 }
 
-// image is the base image for one platform, and the one definition of it: Image,
-// Publish and every image built FROM this one all come through here, so there is
-// no arrangement in which the image a check passed is not the image that was
-// pushed, nor one in which a generator image is built on a base nobody checked.
+// baseApp is the base image as the archetype's App, and the one definition of
+// it: Image, every generator image composed onto it and every check that reads it
+// all come through here, so there is no arrangement in which the image a check
+// passed is not the image that was pushed.
 //
-// The order of the calls below is the order docs/container/SPEC.md states the
-// promises in, which is not an accident worth preserving so much as one worth
-// not breaking: WithEntrypoint clears Cmd, so it comes before the WithoutDefaultArgs
-// that asserts Cmd is empty rather than after it.
-func (m *Avroc) image(platform dagger.Platform) *dagger.Container {
-	cli := dag.Directory().WithFile(
-		cliExecutable,
-		m.binaries(platform).File(cliExecutable),
-		dagger.DirectoryWithFileOpts{Permissions: executableMode},
-	)
+// Two lines are avroc's, and everything docs/container/SPEC.md covers other than
+// the FileDescriptorSet's path falls out of the archetype: the executable
+// directory and its membership of PATH, the entrypoint, the empty Cmd, the absent
+// working directory and the 65532:65532 that owns the files and runs the process.
+//
+// The FileDescriptorSet arrives as a contribution, which means it arrives with a
+// document: every byte an image carries is described, because the SPDX and
+// CycloneDX pair a publish attaches accounts for the whole image rather than for
+// the binary the chain compiled. A protobuf FileDescriptorSet has no ecosystem
+// and therefore no module able to produce a document for it, which is the case
+// Z5Labs.FileDocument exists for — so this is a call and not a hand-rolled SPDX
+// file in this repository. The licence is stated explicitly rather than left to
+// default: MIT is this repository's, and NOASSERTION would be the honest answer to
+// a question nobody had asked rather than to one whose answer is known. No version
+// is given, because the file is a rendering of this commit's protos and inventing
+// a number would put a value in a field consumers compare.
+//
+// version is the version the App publishes and stamps under. It is a parameter
+// rather than devVersion outright so that Release passes the release's own and
+// the check stages pass devVersion, and so that the two cannot be different code
+// paths — the container a contract check reads is built exactly as the container
+// a release pushes is.
+func (m *Avroc) baseApp(version string) *dagger.Z5LabsApp {
+	set := m.IrDescriptorSet()
 
-	return dag.Container(dagger.ContainerOpts{Platform: platform}).
-		// The plugin directory, owned by the image's user so that a generator
-		// copied in by a derived image lands somewhere that user can execute
-		// from. The CLI goes here too; its path is explicitly not part of the
-		// contract, and this is simply the one directory the image has.
-		WithDirectory(pluginDir, cli, dagger.ContainerWithDirectoryOpts{
-			Owner: imageUser,
+	return m.appChain().
+		App(version, dagger.Z5LabsGoChainAppOpts{
+			Pkg:       cliPackage,
+			Platforms: imagePlatforms(),
 		}).
-		// The FileDescriptorSet, world-readable because a caller who overrides
-		// the UID reads the same file.
-		WithFile(descriptorSetPath, m.IrDescriptorSet(), dagger.ContainerWithFileOpts{
-			Owner:       imageUser,
-			Permissions: 0o644,
-		}).
-		// PATH is set outright rather than appended to, because a scratch image
-		// has no PATH to append to. Only the guarantee that it contains the
-		// plugin directory is covered; the rest of the value is not.
-		WithEnvVariable("PATH", pluginDir).
-		// No working directory, and no directory created to be one (#219): there is
-		// deliberately no WithWorkdir and no WithDirectory for one anywhere in this
-		// chain, and checkImageConfig asserts the field is empty so that a value
-		// arriving from anywhere — here or a future base layer — is a failure.
-		//
-		// The reason is not that this function could not set one; it plainly could,
-		// and did until #219. It is that a working directory is not a property a
-		// consumer needs the image to hold — the caller already types the mount
-		// point in -v and can type it again in -w — and that this pipeline is being
-		// adopted onto a shared archetype which sets none and states that as a
-		// decision (#217). Spending the promise now, while the hand-rolled pipeline
-		// is still standing and every check here can be run against it, is what
-		// makes the adoption a change nothing consumer-visible rides on.
-		WithUser(imageUser).
-		WithEntrypoint([]string{pluginDir + "/" + cliExecutable}).
-		WithoutDefaultArgs()
+		WithFile(descriptorSetPath, set, dag.Z5Labs().FileDocument(set, dagger.Z5LabsFileDocumentOpts{
+			License: "MIT",
+			Name:    "avroc-ir-descriptor-set",
+		}))
+}
+
+// baseImage is one platform's base image, for the checks and for the stages that
+// run avroc rather than publish it.
+//
+// It is an accessor onto the App and not an image build: the container it hands
+// back is the one the archetype assembled and the one a publish would push, which
+// is the whole reason the checks are allowed to read it.
+func (m *Avroc) baseImage(platform dagger.Platform) *dagger.Container {
+	return m.baseApp(devVersion).Container(platform)
+}
+
+// appChain is the Go chain an App is built from — the source with its git
+// metadata folded in, and nothing configured about the check stages.
+//
+// The lint and test configuration deliberately does not travel here. Ci runs the
+// checks and App builds; a chain configured for both would make a change to the
+// lint version a change to the image's cache key, and the archetype's own comment
+// on WithBuild says the same thing from the other side.
+func (m *Avroc) appChain() *dagger.Z5LabsGoChain {
+	return dag.Z5Labs().Go(m.appSource())
 }
 
 // binaries builds every executable this repository ships, for one platform.
 //
-// One build for the base image and the three generator images alike, so the CLI
-// a generator image inherits and the generator copied into it are the same
-// binaries the base image was checked with. They are cross-compiled by the
-// toolchain container rather than compiled under emulation, and CGO is off
-// because the image is scratch: there is no libc in it, and a dynamically linked
-// executable would find no loader and fail with `no such file or directory`
-// naming a file that is plainly there.
+// It no longer builds anything that goes into the base image — the archetype
+// compiles the CLI itself, from cliPackage — and what is left is the two callers
+// that need a loose executable rather than an image: the generator Apps, which
+// package a prebuilt binary because the archetype names a Go application after
+// its module and avroc's three generators share one module (generator_image.go),
+// and CompanionModule, which hands executables to the companion module the way an
+// adopter with no generator image would.
+//
+// They are cross-compiled by the toolchain container rather than compiled under
+// emulation, and CGO is off because the image is scratch: there is no libc in it,
+// and a dynamically linked executable would find no loader and fail with `no such
+// file or directory` naming a file that is plainly there.
 func (m *Avroc) binaries(platform dagger.Platform) *dagger.Directory {
 	return dag.Go().Build(m.Source, dagger.GoBuildOpts{
 		Pkg:        "./cmd/...",
@@ -365,7 +385,7 @@ func (m *Avroc) binaries(platform dagger.Platform) *dagger.Directory {
 // first: a change that broke the entrypoint most likely broke the user and the
 // working directory too, and one run should say so.
 func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) error {
-	image := m.image(platform)
+	image := m.baseImage(platform)
 
 	errs := m.checkImageConfig(ctx, image)
 	errs = append(errs, m.checkImageFilesystem(ctx, image, baseImageExecutables())...)
@@ -551,44 +571,84 @@ func (m *Avroc) checkImageConfig(ctx context.Context, image *dagger.Container) [
 // difference between the two listings is exactly the set of files somebody
 // COPYed in, and checking a derived image against this is how "only COPY ran in
 // the stage built FROM the base" becomes an assertion rather than a claim.
-func imageContents(executables []string) map[string]imageEntry {
-	const (
-		dirMode  = 0o755
-		dataMode = 0o644
-	)
+func imageContents(pluginExecutables []string) map[string]imageEntry {
+	const dirMode = 0o755
 
 	contents := map[string]imageEntry{
+		// The application's own directory and the CLI in it. Neither path is
+		// covered by docs/container/SPEC.md — that document says the CLI's own
+		// path is implementation detail and a derived image reaches it through
+		// the entrypoint — and both are listed here anyway, because the listing
+		// is exhaustive or it is nothing. appDir is root-owned so the running
+		// user cannot unlink the binary it is about to exec.
+		appDir:                   {0, 0, dirMode},
+		cliPath():                {imageUID, imageGID, executableMode},
+		"/home":                  {0, 0, dirMode},
+		homeDir:                  {0, 0, homeMode},
 		"/usr":                   {0, 0, dirMode},
 		"/usr/local":             {0, 0, dirMode},
 		"/usr/local/share":       {0, 0, dirMode},
 		"/usr/local/share/avroc": {0, 0, dirMode},
-		descriptorSetPath:        {imageUID, imageGID, dataMode},
-		pluginDir:                {imageUID, imageGID, dirMode},
+		descriptorSetPath:        {imageUID, imageGID, contributedFileMode},
 	}
-	for _, name := range executables {
+
+	// The plugin directory appears exactly when something is in it, and that is
+	// the row #217 changed rather than a looseness in the check (see this file's
+	// comment and docs/container/SPEC.md's "The plugin directory"). The base
+	// image carries no generator, and a contribution to a directory the image's
+	// PATH resolves against is refused by the archetype — so the base's listing
+	// has no /usr/local/bin at all, and a generator image's has it because
+	// composing a generator created it.
+	// It is root-owned, where this pipeline used to make it the image user's.
+	// Nothing depends on the ownership of the directory — a derived image's COPY
+	// runs as root in the builder, and 0755 is traversable by every UID, so the
+	// executable inside it is reachable by the running user and by an overridden
+	// one. What a consumer does depend on is the mode and ownership of the
+	// *executable*, which is the row below and is unchanged in substance.
+	// docs/container/SPEC.md's "What it means for ownership" says so now.
+	if len(pluginExecutables) > 0 {
+		contents[pluginDir] = imageEntry{0, 0, dirMode}
+	}
+	for _, name := range pluginExecutables {
 		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
 	}
 	return contents
 }
 
-// baseImageExecutables is what ships in the base image's plugin directory: the
-// CLI, and nothing else.
+// baseImageExecutables is what ships in the base image's plugin directory:
+// nothing at all.
 //
 // avroc's own generators are not here, and their absence is the substance of
 // #127. A base that carried them would make the three published generator images
 // decorative — the built-ins would be reachable by a path nobody copied them to,
 // which is precisely the private arrangement that would leave the extension
 // mechanism untested by its own author.
+//
+// The CLI is not here either, and that is #217: the archetype puts an
+// application's own binary in appDir and names it absolutely in the entrypoint,
+// so the plugin directory is for what an extension adds and for nothing else.
+// docs/container/SPEC.md already said the CLI's path was implementation detail,
+// which is what made that free to change.
 func baseImageExecutables() []string {
-	return []string{cliExecutable}
+	return nil
 }
 
-// baseImageExecutablePaths is baseImageExecutables where they land, which is what
-// an Entrypoint would have to name.
+// cliPath is where the CLI lands inside the image.
+//
+// It is derived from the archetype's layout rather than promised: appDir plus the
+// binary's name, which the archetype takes from go.mod's module path. Nothing
+// outside this module may depend on it — docs/container/SPEC.md's "The CLI's own
+// path is not part of the contract" — and the checks depend on it only to be
+// exhaustive about the filesystem and to recognise the entrypoint.
+func cliPath() string {
+	return appDir + "/" + cliExecutable
+}
+
+// baseImageExecutablePaths is every executable the base image ships, where it
+// lands, which is what an Entrypoint would have to name.
 func baseImageExecutablePaths() []string {
-	names := baseImageExecutables()
-	paths := make([]string, 0, len(names))
-	for _, name := range names {
+	paths := []string{cliPath()}
+	for _, name := range baseImageExecutables() {
 		paths = append(paths, pluginDir+"/"+name)
 	}
 	return paths

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -79,7 +79,9 @@ import (
 // without changing it there is the drift ImageContract exists to catch.
 //
 // pluginDir lives in main.go, because the regeneration stage's scratch container
-// is deliberately the same layout as the published image and both read it.
+// resolves generators on PATH out of the same directory the published image does
+// and both read the constant; that container is no longer the published layout in
+// full, and main.go's comment on the constant says which half it reproduces.
 // Two of the rows that used to be here are gone, and each absence is a decision
 // rather than an omission. They are recorded as comments in the block below,
 // where the constant they replace used to be, because a deleted constant leaves
@@ -107,6 +109,24 @@ const (
 	// lines docs/container/SPEC.md and the README print need no
 	// `--tmpfs /tmp:mode=1777`, and the image is once again exactly scratch plus
 	// the files that document names.
+	//
+	// Since #217 the archetype nonetheless sets TMPDIR=/tmp, as part of a
+	// standardized environment whose whole point is that what a process reads out of
+	// HOME and TMPDIR is a property of the image rather than of the runtime. So the
+	// published image names a temporary directory it does not contain, and that is
+	// worth writing down rather than leaving to be discovered: a program that read
+	// it would get ENOENT on a path the configuration plainly advertises. What makes
+	// it harmless is #218 — avroc reads no ambient temporary directory at all, and
+	// internal/avroc.TestAvrocReadsNoAmbientTemporaryDirectory holds that as a
+	// property of the source across internal/, cmd/ and avrocpb/, so the thing that
+	// would break is a thing the tests refuse. Both halves are checked, and by
+	// different checks: that nothing reads it is that test's, and that the image
+	// does not carry it is imageContents' — the listing below is exhaustive, so a
+	// /tmp appearing in the image is a failure, in either direction.
+	//
+	// A deployment that wants one mounts a tmpfs or an emptyDir over it, which is
+	// what the archetype documents and is the reason nothing may be contributed
+	// under that path.
 
 	// imageUID and imageGID are the pinned non-root identity the image runs as.
 	// They are numbers rather than a name because the image has no /etc/passwd
@@ -385,8 +405,25 @@ func (m *Avroc) binaries(platform dagger.Platform) *dagger.Directory {
 // first: a change that broke the entrypoint most likely broke the user and the
 // working directory too, and one run should say so.
 func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) error {
-	image := m.baseImage(platform)
+	return errors.Join(m.checkBaseImage(ctx, m.baseImage(platform))...)
+}
 
+// checkBaseImage is every assertion the base image is held to, over a container
+// somebody else chose.
+//
+// It takes the container rather than a platform so that there is exactly one
+// definition of "the base image is correct" and three call sites for it:
+// ImageContract, which builds one per published platform; the release gate, which
+// passes the very container it is about to push (release.go's releaseContract);
+// and nothing else. The reviewer of #217 caught the release gate having grown a
+// second, hand-copied list — which would have meant a check added here silently
+// stopping short of a release, the exact hole putting the gate inside Release was
+// meant to close.
+//
+// Every group is run and every failure collected rather than stopping at the
+// first: a change that broke the entrypoint most likely broke the user and the
+// working directory too, and one run should say so.
+func (m *Avroc) checkBaseImage(ctx context.Context, image *dagger.Container) []error {
 	errs := m.checkImageConfig(ctx, image)
 	errs = append(errs, m.checkImageFilesystem(ctx, image, baseImageExecutables())...)
 	if err := m.checkImageIsTheCLI(ctx, image); err != nil {
@@ -395,7 +432,7 @@ func (m *Avroc) imageContractOn(ctx context.Context, platform dagger.Platform) e
 	if err := m.checkAMissingWorkingDirectoryIsLegible(ctx, image); err != nil {
 		errs = append(errs, err)
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 // checkImageIsTheCLI runs the entrypoint and requires avroc's usage back.

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/avroc/main.go:104:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/avroc/main.go:109:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // Every function on it is either a builder returning a new Avroc or a terminal
 // that runs something, so a call chain reads as the image being assembled and
 // then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/avroc/main.go:104:6)
+type Companion struct { // companion (../../../daggerverse/avroc/main.go:109:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -52,7 +52,7 @@ type CompanionGenerateOpts struct {
 	// back is exported by the engine as whoever runs the export. Set it when the
 	// output has to arrive owned by a particular UID.
 	//
-	User string // companion (../../../daggerverse/avroc/main.go:266:2)
+	User string // companion (../../../daggerverse/avroc/main.go:271:2)
 }
 
 // Generate runs `avroc generate` over a project and returns the tree it left
@@ -70,7 +70,7 @@ type CompanionGenerateOpts struct {
 // Nothing is passed to avroc but the subcommand. The manifest is the sole source
 // of inputs, generators and their options, and a flag here that could override
 // any of it would be a second place a project's generation is configured.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/avroc/main.go:256:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/avroc/main.go:261:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -142,7 +142,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // Publishing one is a reasonable thing to do — it is the same image a Dockerfile
 // would have produced — but it is not a release of avroc and carries none of the
 // signatures or attestations one does.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/avroc/main.go:237:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/avroc/main.go:242:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -157,7 +157,7 @@ type CompanionWithGeneratorOpts struct {
 	// generator image for name. Any image carrying the generator in the plugin
 	// directory will do, including one that is not published.
 	//
-	Image *Container // companion (../../../daggerverse/avroc/main.go:184:2)
+	Image *Container // companion (../../../daggerverse/avroc/main.go:189:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -170,7 +170,7 @@ type CompanionWithGeneratorOpts struct {
 //
 // Repeated calls compose, so a project whose manifest names three generators is
 // three calls and one image.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/avroc/main.go:175:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/avroc/main.go:180:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -195,7 +195,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // example states as `CGO_ENABLED=0`, and it is the caller's to meet: nothing here
 // can check it, and a dynamically linked generator fails at exec time with the
 // kernel's message rather than avroc's.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/avroc/main.go:205:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/avroc/main.go:210:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -215,7 +215,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/avroc/main.go:104:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/avroc/main.go:109:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -228,7 +228,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/avroc/main.go:104:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/avroc/main.go:109:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -248,7 +248,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/avroc/main.go:136:2)
+	Version string // companion (../../../daggerverse/avroc/main.go:141:2)
 	//
 	// The registry repository the images are pulled from, as `<host>/<path>` with
 	// no tag. The generator images derive from it by the rule this project
@@ -262,7 +262,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/z5labs/avroc"
-	Repository string // companion (../../../daggerverse/avroc/main.go:148:2)
+	Repository string // companion (../../../daggerverse/avroc/main.go:153:2)
 	//
 	// Run in this image instead of pulling one. It has to keep the promises
 	// docs/container/SPEC.md makes — avroc as the entrypoint, the plugin directory
@@ -272,7 +272,7 @@ type CompanionOpts struct {
 	// just built rather than against the last release, and how a caller tries a
 	// change to avroc before it ships.
 	//
-	Image *Container // companion (../../../daggerverse/avroc/main.go:157:2)
+	Image *Container // companion (../../../daggerverse/avroc/main.go:162:2)
 }
 
 // New selects the avroc release to run.
@@ -283,7 +283,7 @@ type CompanionOpts struct {
 // one WithGenerator call. That is one call more than a bundle image would cost
 // and it is deliberate: which generators are in the image is the caller's
 // manifest, and an image that shipped all of them would decide it for them.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/avroc/main.go:129:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/avroc/main.go:134:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/.dagger/internal/dagger/dagger.gen.go
+++ b/.dagger/internal/dagger/dagger.gen.go
@@ -393,13 +393,13 @@ type Void string
 type WorkspaceID string
 
 // A unique identifier for an object.
-type Z5LabsBuilderID string
+type Z5LabsAppBuilderID string
 
 // A unique identifier for an object.
-type Z5LabsGoAppID string
+type Z5LabsAppID string
 
 // A unique identifier for an object.
-type Z5LabsGoLibID string
+type Z5LabsGoChainID string
 
 // A unique identifier for an object.
 type Z5LabsID string
@@ -13595,12 +13595,22 @@ func (r *Query) LoadWorkspaceFromID(id WorkspaceID) *Workspace {
 	}
 }
 
-// Load a Z5LabsBuilder from its ID.
-func (r *Query) LoadZ5LabsBuilderFromID(id Z5LabsBuilderID) *Z5LabsBuilder {
-	q := r.query.Select("loadZ5LabsBuilderFromID")
+// Load a Z5LabsAppBuilder from its ID.
+func (r *Query) LoadZ5LabsAppBuilderFromID(id Z5LabsAppBuilderID) *Z5LabsAppBuilder {
+	q := r.query.Select("loadZ5LabsAppBuilderFromID")
 	q = q.Arg("id", id)
 
-	return &Z5LabsBuilder{
+	return &Z5LabsAppBuilder{
+		query: q,
+	}
+}
+
+// Load a Z5LabsApp from its ID.
+func (r *Query) LoadZ5LabsAppFromID(id Z5LabsAppID) *Z5LabsApp {
+	q := r.query.Select("loadZ5LabsAppFromID")
+	q = q.Arg("id", id)
+
+	return &Z5LabsApp{
 		query: q,
 	}
 }
@@ -13615,22 +13625,12 @@ func (r *Query) LoadZ5LabsFromID(id Z5LabsID) *Z5Labs {
 	}
 }
 
-// Load a Z5LabsGoApp from its ID.
-func (r *Query) LoadZ5LabsGoAppFromID(id Z5LabsGoAppID) *Z5LabsGoApp {
-	q := r.query.Select("loadZ5LabsGoAppFromID")
+// Load a Z5LabsGoChain from its ID.
+func (r *Query) LoadZ5LabsGoChainFromID(id Z5LabsGoChainID) *Z5LabsGoChain {
+	q := r.query.Select("loadZ5LabsGoChainFromID")
 	q = q.Arg("id", id)
 
-	return &Z5LabsGoApp{
-		query: q,
-	}
-}
-
-// Load a Z5LabsGoLib from its ID.
-func (r *Query) LoadZ5LabsGoLibFromID(id Z5LabsGoLibID) *Z5LabsGoLib {
-	q := r.query.Select("loadZ5LabsGoLibFromID")
-	q = q.Arg("id", id)
-
-	return &Z5LabsGoLib{
+	return &Z5LabsGoChain{
 		query: q,
 	}
 }

--- a/.dagger/internal/dagger/go.gen.go
+++ b/.dagger/internal/dagger/go.gen.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Retrieve the binding value, as type Go
-func (r *Binding) AsGo() *Go { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L24)
+func (r *Binding) AsGo() *Go { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L24)
 	q := r.query.Select("asGo")
 
 	return &Go{
@@ -20,7 +20,7 @@ func (r *Binding) AsGo() *Go { // go (https://github.com/z5labs/devex/tree/47e25
 }
 
 // Retrieve the binding value, as type GoCi
-func (r *Binding) AsGoCi() *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L44)
+func (r *Binding) AsGoCi() *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L44)
 	q := r.query.Select("asGoCi")
 
 	return &GoCi{
@@ -29,7 +29,7 @@ func (r *Binding) AsGoCi() *GoCi { // go (https://github.com/z5labs/devex/tree/4
 }
 
 // Create or update a binding of type GoCi in the environment
-func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L44)
+func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L44)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoCiInput")
 	q = q.Arg("name", name)
@@ -42,7 +42,7 @@ func (r *Env) WithGoCiInput(name string, value *GoCi, description string) *Env {
 }
 
 // Declare a desired GoCi output to be assigned in the environment
-func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L44)
+func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L44)
 	q := r.query.Select("withGoCiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -53,7 +53,7 @@ func (r *Env) WithGoCiOutput(name string, description string) *Env { // go (http
 }
 
 // Create or update a binding of type Go in the environment
-func (r *Env) WithGoInput(name string, value *Go, description string) *Env { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L24)
+func (r *Env) WithGoInput(name string, value *Go, description string) *Env { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L24)
 	assertNotNil("value", value)
 	q := r.query.Select("withGoInput")
 	q = q.Arg("name", name)
@@ -66,7 +66,7 @@ func (r *Env) WithGoInput(name string, value *Go, description string) *Env { // 
 }
 
 // Declare a desired Go output to be assigned in the environment
-func (r *Env) WithGoOutput(name string, description string) *Env { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L24)
+func (r *Env) WithGoOutput(name string, description string) *Env { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L24)
 	q := r.query.Select("withGoOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -79,7 +79,7 @@ func (r *Env) WithGoOutput(name string, description string) *Env { // go (https:
 // Go wraps the Go CLI as Dagger functions. Construct via New(); call
 // Container() for the prepared base container, or use the per-CLI helpers
 // (Build, Test, Vet, ...) which reuse the same backing container.
-type Go struct { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L24)
+type Go struct { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L24)
 	query *querybuilder.Selection
 
 	env         *string
@@ -108,7 +108,7 @@ type GoBuildOpts struct {
 	//
 	//
 	// Default: "./..."
-	Pkg string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L240)
+	Pkg string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L240)
 	//
 	// Name of the artifact written under /out. Empty means `-o /out/`, which
 	// lets go build name each binary after its main package.
@@ -120,17 +120,17 @@ type GoBuildOpts struct {
 	// binaryName dodges the same collision; this one is not always a binary,
 	// because buildmode can make it an archive or a shared library.
 	//
-	ArtifactName string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L252)
+	ArtifactName string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L252)
 	//
 	// Pass -trimpath: strip the build's local file system paths out of the
 	// binary, so the output does not depend on where it was compiled.
 	//
-	Trimpath bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L257)
+	Trimpath bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L257)
 	//
 	// Pass -ldflags "-s -w": drop the symbol table and the DWARF debug
 	// info. Smaller binary, no usable stack symbolization or debugger.
 	//
-	Strip bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L262)
+	Strip bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L262)
 	//
 	// Link-time variable assignments, each `importpath.Name=value`,
 	// rendered as `-ldflags "-X importpath.Name=value"`. This is how a
@@ -140,25 +140,25 @@ type GoBuildOpts struct {
 	// ignores a stamp naming a variable that does not exist, or one that
 	// is not a package-level string.
 	//
-	Stamps []string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L272)
+	Stamps []string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L272)
 	//
 	// Build tags, passed as `-tags a,b,c`. Selects which `//go:build`
 	// files are compiled in.
 	//
-	Tags []string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L277)
+	Tags []string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L277)
 	//
 	// Target platform as `GOOS/GOARCH[/variant]`, e.g. "linux/arm64".
 	// Sets GOOS and GOARCH for a cross-compile; empty builds for the
 	// toolchain container's own platform. Any variant segment is ignored —
 	// GOARM/GOAMD64 are left unset.
 	//
-	Platform string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L284)
+	Platform string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L284)
 	//
 	// Set CGO_ENABLED=0. Produces a statically linked binary with no libc
 	// dependency, which is what a scratch image needs, at the cost of the
 	// cgo-backed net and os/user implementations.
 	//
-	DisableCgo bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L290)
+	DisableCgo bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L290)
 	//
 	// Pass -race: link Go's data-race detector into the output. The binary
 	// then reports racing accesses to stderr as it runs, at roughly 2-20x
@@ -170,7 +170,7 @@ type GoBuildOpts struct {
 	// golang image has one for its own platform, but a cross-compile via
 	// platform does not unless the toolchain image provides it.
 	//
-	Race bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L302)
+	Race bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L302)
 	//
 	// Pass -buildmode=<mode>: what the linker emits, which for most modes is
 	// not an executable. Absent leaves the flag off entirely, so `go build`
@@ -178,7 +178,7 @@ type GoBuildOpts struct {
 	// package, an archive for the rest. See BuildMode for what each member
 	// produces.
 	//
-	Buildmode GoBuildMode // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L310)
+	Buildmode GoBuildMode // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L310)
 }
 
 // Build runs `go build` against the supplied source and returns /out as a
@@ -193,7 +193,7 @@ type GoBuildOpts struct {
 // every caller re-learn the same spellings. Container() is the escape hatch
 // for anything not named here — it hands back the prepared container so a
 // caller can run whatever `go build` invocation it likes.
-func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L234)
+func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L234)
 	assertNotNil("source", source)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -246,7 +246,7 @@ func (r *Go) Build(source *Directory, opts ...GoBuildOpts) *Directory { // go (h
 }
 
 // Ci returns a new pipeline builder bound to the supplied source.
-func (r *Go) Ci(source *Directory) *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L72)
+func (r *Go) Ci(source *Directory) *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L72)
 	assertNotNil("source", source)
 	q := r.query.Select("ci")
 	q = q.Arg("source", source)
@@ -265,7 +265,7 @@ func (r *Go) Ci(source *Directory) *GoCi { // go (https://github.com/z5labs/deve
 // when New("") was used, from source/go.mod's `go` directive (fallback
 // "latest"). The signature takes ctx + returns error because go.mod
 // inspection requires async I/O.
-func (r *Go) Container(source *Directory) *Container { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L53)
+func (r *Go) Container(source *Directory) *Container { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L53)
 	assertNotNil("source", source)
 	q := r.query.Select("container")
 	q = q.Arg("source", source)
@@ -288,7 +288,7 @@ func (r *Go) Container(source *Directory) *Container { // go (https://github.com
 // graph, so the two documents cannot disagree about what shipped. See
 // Spdx for how the graph is resolved and how licence confidence is
 // handled.
-func (r *Go) CycloneDx(binary *File, source *Directory) *File { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/sbom.go#L80)
+func (r *Go) CycloneDx(binary *File, source *Directory) *File { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/sbom.go#L80)
 	assertNotNil("binary", binary)
 	assertNotNil("source", source)
 	q := r.query.Select("cycloneDx")
@@ -301,7 +301,7 @@ func (r *Go) CycloneDx(binary *File, source *Directory) *File { // go (https://g
 }
 
 // Env runs `go env` in a source-less base container and returns its stdout.
-func (r *Go) Env(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L488)
+func (r *Go) Env(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L488)
 	if r.env != nil {
 		return *r.env, nil
 	}
@@ -316,7 +316,7 @@ func (r *Go) Env(ctx context.Context) (string, error) { // go (https://github.co
 // Fmt runs `gofmt -l -d .` against the supplied source. Returns the diff
 // of any unformatted files; non-empty output is also returned as an error so
 // CI fails fast on formatting violations.
-func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L452)
+func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L452)
 	assertNotNil("source", source)
 	if r.fmt != nil {
 		return *r.fmt, nil
@@ -334,12 +334,12 @@ func (r *Go) Fmt(ctx context.Context, source *Directory) (string, error) { // go
 type GoGenerateOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L191)
+	Pkg string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L191)
 }
 
 // Generate runs `go generate pkg` against the supplied source and returns
 // /src after generation. pkg defaults to `./...`.
-func (r *Go) Generate(source *Directory, opts ...GoGenerateOpts) *Directory { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L187)
+func (r *Go) Generate(source *Directory, opts ...GoGenerateOpts) *Directory { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L187)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -414,7 +414,7 @@ func (r *Go) UnmarshalJSON(bs []byte) error {
 // The pin is what makes the result safe to cache across calls within a
 // session — without it, the proxy could resolve different versions on
 // successive invocations.
-func (r *Go) Install(pkg string) *File { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L84)
+func (r *Go) Install(pkg string) *File { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L84)
 	q := r.query.Select("install")
 	q = q.Arg("pkg", pkg)
 
@@ -424,7 +424,7 @@ func (r *Go) Install(pkg string) *File { // go (https://github.com/z5labs/devex/
 }
 
 // ModDownload runs `go mod download` against the supplied source.
-func (r *Go) ModDownload(ctx context.Context, source *Directory) error { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L162)
+func (r *Go) ModDownload(ctx context.Context, source *Directory) error { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L162)
 	assertNotNil("source", source)
 	if r.modDownload != nil {
 		return nil
@@ -437,7 +437,7 @@ func (r *Go) ModDownload(ctx context.Context, source *Directory) error { // go (
 
 // ModTidy runs `go mod tidy` against the supplied source and returns the
 // updated /src directory.
-func (r *Go) ModTidy(source *Directory) *Directory { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L148)
+func (r *Go) ModTidy(source *Directory) *Directory { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L148)
 	assertNotNil("source", source)
 	q := r.query.Select("modTidy")
 	q = q.Arg("source", source)
@@ -448,7 +448,7 @@ func (r *Go) ModTidy(source *Directory) *Directory { // go (https://github.com/z
 }
 
 // ModVerify runs `go mod verify` against the supplied source.
-func (r *Go) ModVerify(ctx context.Context, source *Directory) error { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L174)
+func (r *Go) ModVerify(ctx context.Context, source *Directory) error { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L174)
 	assertNotNil("source", source)
 	if r.modVerify != nil {
 		return nil
@@ -461,12 +461,12 @@ func (r *Go) ModVerify(ctx context.Context, source *Directory) error { // go (ht
 
 // GoRunOpts contains options for Go.Run
 type GoRunOpts struct {
-	Args []string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L209)
+	Args []string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L209)
 }
 
 // Run runs `go run pkg [args...]` against the supplied source and returns
 // the program's stdout. pkg is required (a single runnable main package).
-func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoRunOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L204)
+func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoRunOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L204)
 	assertNotNil("source", source)
 	if r.run != nil {
 		return *r.run, nil
@@ -512,7 +512,7 @@ func (r *Go) Run(ctx context.Context, source *Directory, pkg string, opts ...GoR
 // when the match covers essentially the whole file. Anything less
 // concludes NOASSERTION, so a low-confidence match cannot be mistaken
 // downstream for an established one.
-func (r *Go) Spdx(binary *File, source *Directory) *File { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/sbom.go#L46)
+func (r *Go) Spdx(binary *File, source *Directory) *File { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/sbom.go#L46)
 	assertNotNil("binary", binary)
 	assertNotNil("source", source)
 	q := r.query.Select("spdx")
@@ -528,17 +528,17 @@ func (r *Go) Spdx(binary *File, source *Directory) *File { // go (https://github
 type GoTestOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L428)
+	Pkg string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L428)
 
-	Race bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L430)
+	Race bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L430)
 
-	Flags []string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L432)
+	Flags []string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L432)
 }
 
 // Test runs `go test -count=1 [-race] [flags] pkg` against the supplied
 // source and returns the combined stdout. -count=1 is always passed to
 // bypass Go's internal test cache.
-func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L424)
+func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L424)
 	assertNotNil("source", source)
 	if r.test != nil {
 		return *r.test, nil
@@ -568,7 +568,7 @@ func (r *Go) Test(ctx context.Context, source *Directory, opts ...GoTestOpts) (s
 
 // ToolVersion runs `go version` in a source-less base container and returns
 // the trimmed output (e.g. "go version go1.23.0 linux/amd64").
-func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L496)
+func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L496)
 	if r.toolVersion != nil {
 		return *r.toolVersion, nil
 	}
@@ -583,7 +583,7 @@ func (r *Go) ToolVersion(ctx context.Context) (string, error) { // go (https://g
 // Version is the pinned Go toolchain version (e.g. "1.23"). Empty
 // means infer from the supplied source's go.mod `go` directive;
 // falls back to "latest" when no go directive is found.
-func (r *Go) Version(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L28)
+func (r *Go) Version(ctx context.Context) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L28)
 	if r.version != nil {
 		return *r.version, nil
 	}
@@ -599,12 +599,12 @@ func (r *Go) Version(ctx context.Context) (string, error) { // go (https://githu
 type GoVetOpts struct {
 
 	// Default: "./..."
-	Pkg string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L475)
+	Pkg string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L475)
 }
 
 // Vet runs `go vet pkg` against the supplied source. pkg defaults to
 // `./...`. Returns a non-nil error when vet reports any issue.
-func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L471)
+func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) error { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L471)
 	assertNotNil("source", source)
 	if r.vet != nil {
 		return nil
@@ -623,13 +623,13 @@ func (r *Go) Vet(ctx context.Context, source *Directory, opts ...GoVetOpts) erro
 
 // GoWorkOpts contains options for Go.Work
 type GoWorkOpts struct {
-	Args []string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L133)
+	Args []string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L133)
 }
 
 // Work runs `go work <subcommand> [args...]` against the supplied source
 // and returns stdout. subcommand is required (e.g. "init", "use", "sync",
 // "version").
-func (r *Go) Work(ctx context.Context, source *Directory, subcommand string, opts ...GoWorkOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L128)
+func (r *Go) Work(ctx context.Context, source *Directory, subcommand string, opts ...GoWorkOpts) (string, error) { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L128)
 	assertNotNil("source", source)
 	if r.work != nil {
 		return *r.work, nil
@@ -666,7 +666,7 @@ func (r *Go) AsNode() Node {
 // errors are aggregated. Stage 2 builds the source and Run returns the
 // produced binary as a *dagger.File. Downstream consumers compose that file
 // into their own pipelines (package, sign, publish, ...).
-type GoCi struct { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L44)
+type GoCi struct { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L44)
 	query *querybuilder.Selection
 
 	check *Void
@@ -692,7 +692,7 @@ func (r *GoCi) WithGraphQLQuery(q *querybuilder.Selection) *GoCi {
 // aggregated error. Use when callers want to run the checks
 // independently of the build (for example multi-platform pipelines
 // that share one check run across N platform builds).
-func (r *GoCi) Check(ctx context.Context) error { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L148)
+func (r *GoCi) Check(ctx context.Context) error { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L148)
 	if r.check != nil {
 		return nil
 	}
@@ -753,7 +753,7 @@ func (r *GoCi) UnmarshalJSON(bs []byte) error {
 // Run executes the pipeline: stage 1 (Check) → stage 2 (build). Returns
 // the built binary as a *dagger.File. On stage-1 failure, returns the
 // aggregated error from Check and a nil file (stage 2 is skipped).
-func (r *GoCi) Run() *File { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L173)
+func (r *GoCi) Run() *File { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L173)
 	q := r.query.Select("run")
 
 	return &File{
@@ -763,9 +763,9 @@ func (r *GoCi) Run() *File { // go (https://github.com/z5labs/devex/tree/47e25f0
 
 // GoCiWithBuildOpts contains options for GoCi.WithBuild
 type GoCiWithBuildOpts struct {
-	Pkg string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L131)
+	Pkg string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L131)
 
-	BinaryName string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L133)
+	BinaryName string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L133)
 }
 
 // WithBuild configures the build stage parameters. pkg defaults to "."
@@ -775,7 +775,7 @@ type GoCiWithBuildOpts struct {
 //
 // Note: the binary-name flag is called binaryName (CLI: --binary-name) to
 // avoid colliding with Dagger CLI's top-level --output/-o flag.
-func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L129)
+func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L129)
 	q := r.query.Select("withBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `pkg` optional argument
@@ -794,7 +794,7 @@ func (r *GoCi) WithBuild(opts ...GoCiWithBuildOpts) *GoCi { // go (https://githu
 }
 
 // WithFmt enables the gofmt check stage.
-func (r *GoCi) WithFmt() *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L77)
+func (r *GoCi) WithFmt() *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L77)
 	q := r.query.Select("withFmt")
 
 	return &GoCi{
@@ -804,9 +804,9 @@ func (r *GoCi) WithFmt() *GoCi { // go (https://github.com/z5labs/devex/tree/47e
 
 // GoCiWithLintOpts contains options for GoCi.WithLint
 type GoCiWithLintOpts struct {
-	Version string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L101)
+	Version string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L101)
 
-	Config *File // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L103)
+	Config *File // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L103)
 }
 
 // WithLint enables the golangci-lint check stage. version pins the
@@ -820,7 +820,7 @@ type GoCiWithLintOpts struct {
 // linter runs. Pass a `v1.x` version to roll the whole stage back, config
 // dialect included; the module path installed follows the version's major,
 // so both majors are reachable without forking this pipeline.
-func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L99)
+func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L99)
 	q := r.query.Select("withLint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -840,12 +840,12 @@ func (r *GoCi) WithLint(opts ...GoCiWithLintOpts) *GoCi { // go (https://github.
 
 // GoCiWithTestOpts contains options for GoCi.WithTest
 type GoCiWithTestOpts struct {
-	Race bool // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L115)
+	Race bool // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L115)
 }
 
 // WithTest enables the `go test ./...` check stage. Pass race=true to
 // enable the data-race detector.
-func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L113)
+func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L113)
 	q := r.query.Select("withTest")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `race` optional argument
@@ -860,7 +860,7 @@ func (r *GoCi) WithTest(opts ...GoCiWithTestOpts) *GoCi { // go (https://github.
 }
 
 // WithVet enables the `go vet ./...` check stage.
-func (r *GoCi) WithVet() *GoCi { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/ci.go#L83)
+func (r *GoCi) WithVet() *GoCi { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/ci.go#L83)
 	q := r.query.Select("withVet")
 
 	return &GoCi{
@@ -878,14 +878,14 @@ func (r *GoCi) AsNode() Node {
 
 // GoOpts contains options for Query.Go
 type GoOpts struct {
-	Version string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L37)
+	Version string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L37)
 }
 
 // New returns a Go module configured for the given toolchain version.
 // version is optional: empty means the version is inferred from the source's
 // go.mod for source-bearing CLI funcs, and "latest" is used for source-less
 // funcs (Env, ToolVersion, Install).
-func (r *Query) Go(opts ...GoOpts) *Go { // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/main.go#L35)
+func (r *Query) Go(opts ...GoOpts) *Go { // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/main.go#L35)
 	q := r.query.Select("go")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -916,7 +916,7 @@ func (r *Query) Go(opts ...GoOpts) *Go { // go (https://github.com/z5labs/devex/
 // the `go build` spelling (`c-archive`) lives in buildModeFlags below rather
 // than in the identifier: a hyphen cannot appear in a Go identifier, so the
 // mapping has to be explicit.
-type GoBuildMode string // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L31)
+type GoBuildMode string // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L31)
 
 func (GoBuildMode) IsEnum() {}
 
@@ -984,7 +984,7 @@ const (
 	// BuildModeArchive builds the listed non-main packages into `.a` files
 	// (`archive`). Main packages are ignored, so pointing this at one
 	// produces nothing.
-	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L37)
+	GoBuildModeArchive GoBuildMode = "ARCHIVE" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L37)
 
 	// BuildModeCArchive builds the listed main package into a C archive
 	// (`c-archive`). Only the functions carrying a cgo `//export` comment are
@@ -995,27 +995,27 @@ const (
 	// still produces an archive, but one exporting nothing and carrying no
 	// generated header. The archive/header pair is a consequence of having
 	// cgo exports, not of asking for this mode.
-	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L47)
+	GoBuildModeCArchive GoBuildMode = "C_ARCHIVE" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L47)
 
 	// BuildModeCShared builds the listed main package into a C shared
 	// library (`c-shared`) — the same exported surface as C_ARCHIVE, linked
 	// dynamically instead, and with the same relationship to cgo.
-	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L51)
+	GoBuildModeCShared GoBuildMode = "C_SHARED" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L51)
 
 	// BuildModeExe builds the listed main packages into executables
 	// (`exe`), forcing a position-dependent executable on a toolchain whose
 	// default for the target is PIE.
-	GoBuildModeExe GoBuildMode = "EXE" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L55)
+	GoBuildModeExe GoBuildMode = "EXE" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L55)
 
 	// BuildModePie builds the listed main packages into position
 	// independent executables (`pie`), which is what a hardened runtime
 	// wanting ASLR requires.
-	GoBuildModePie GoBuildMode = "PIE" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L59)
+	GoBuildModePie GoBuildMode = "PIE" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L59)
 
 	// BuildModePlugin builds the listed main packages into a shared library
 	// loadable at run time with `plugin.Open` (`plugin`). The plugin and
 	// its host have to be built by the same toolchain from the same
 	// dependency versions or the load fails.
-	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/go/buildmode.go#L64)
+	GoBuildModePlugin GoBuildMode = "PLUGIN" // go (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/go/buildmode.go#L64)
 
 )

--- a/.dagger/internal/dagger/grafana-stack.gen.go
+++ b/.dagger/internal/dagger/grafana-stack.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type GrafanaStack
-func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L34)
+func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L34)
 	q := r.query.Select("asGrafanaStack")
 
 	return &GrafanaStack{
@@ -19,7 +19,7 @@ func (r *Binding) AsGrafanaStack() *GrafanaStack { // grafana-stack (https://git
 }
 
 // Retrieve the binding value, as type GrafanaStackGrafana
-func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L543)
+func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L543)
 	q := r.query.Select("asGrafanaStackGrafana")
 
 	return &GrafanaStackGrafana{
@@ -28,7 +28,7 @@ func (r *Binding) AsGrafanaStackGrafana() *GrafanaStackGrafana { // grafana-stac
 }
 
 // Retrieve the binding value, as type GrafanaStackLoki
-func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L96)
+func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L96)
 	q := r.query.Select("asGrafanaStackLoki")
 
 	return &GrafanaStackLoki{
@@ -37,7 +37,7 @@ func (r *Binding) AsGrafanaStackLoki() *GrafanaStackLoki { // grafana-stack (htt
 }
 
 // Retrieve the binding value, as type GrafanaStackMimir
-func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L400)
+func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L400)
 	q := r.query.Select("asGrafanaStackMimir")
 
 	return &GrafanaStackMimir{
@@ -46,7 +46,7 @@ func (r *Binding) AsGrafanaStackMimir() *GrafanaStackMimir { // grafana-stack (h
 }
 
 // Retrieve the binding value, as type GrafanaStackTempo
-func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L241)
+func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L241)
 	q := r.query.Select("asGrafanaStackTempo")
 
 	return &GrafanaStackTempo{
@@ -55,7 +55,7 @@ func (r *Binding) AsGrafanaStackTempo() *GrafanaStackTempo { // grafana-stack (h
 }
 
 // Create or update a binding of type GrafanaStackGrafana in the environment
-func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafana, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L543)
+func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafana, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L543)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackGrafanaInput")
 	q = q.Arg("name", name)
@@ -68,7 +68,7 @@ func (r *Env) WithGrafanaStackGrafanaInput(name string, value *GrafanaStackGrafa
 }
 
 // Declare a desired GrafanaStackGrafana output to be assigned in the environment
-func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L543)
+func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L543)
 	q := r.query.Select("withGrafanaStackGrafanaOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -79,7 +79,7 @@ func (r *Env) WithGrafanaStackGrafanaOutput(name string, description string) *En
 }
 
 // Create or update a binding of type GrafanaStack in the environment
-func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L34)
+func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L34)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackInput")
 	q = q.Arg("name", name)
@@ -92,7 +92,7 @@ func (r *Env) WithGrafanaStackInput(name string, value *GrafanaStack, descriptio
 }
 
 // Create or update a binding of type GrafanaStackLoki in the environment
-func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L96)
+func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L96)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackLokiInput")
 	q = q.Arg("name", name)
@@ -105,7 +105,7 @@ func (r *Env) WithGrafanaStackLokiInput(name string, value *GrafanaStackLoki, de
 }
 
 // Declare a desired GrafanaStackLoki output to be assigned in the environment
-func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L96)
+func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L96)
 	q := r.query.Select("withGrafanaStackLokiOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -116,7 +116,7 @@ func (r *Env) WithGrafanaStackLokiOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type GrafanaStackMimir in the environment
-func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L400)
+func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L400)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackMimirInput")
 	q = q.Arg("name", name)
@@ -129,7 +129,7 @@ func (r *Env) WithGrafanaStackMimirInput(name string, value *GrafanaStackMimir, 
 }
 
 // Declare a desired GrafanaStackMimir output to be assigned in the environment
-func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L400)
+func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L400)
 	q := r.query.Select("withGrafanaStackMimirOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -140,7 +140,7 @@ func (r *Env) WithGrafanaStackMimirOutput(name string, description string) *Env 
 }
 
 // Declare a desired GrafanaStack output to be assigned in the environment
-func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L34)
+func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L34)
 	q := r.query.Select("withGrafanaStackOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -151,7 +151,7 @@ func (r *Env) WithGrafanaStackOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type GrafanaStackTempo in the environment
-func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L241)
+func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L241)
 	assertNotNil("value", value)
 	q := r.query.Select("withGrafanaStackTempoInput")
 	q = q.Arg("name", name)
@@ -164,7 +164,7 @@ func (r *Env) WithGrafanaStackTempoInput(name string, value *GrafanaStackTempo, 
 }
 
 // Declare a desired GrafanaStackTempo output to be assigned in the environment
-func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L241)
+func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L241)
 	q := r.query.Select("withGrafanaStackTempoOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -176,7 +176,7 @@ func (r *Env) WithGrafanaStackTempoOutput(name string, description string) *Env 
 
 // GrafanaStack is the module entry point. Use the per-backend constructor
 // functions (Loki, Tempo, Mimir) to obtain a service handle.
-type GrafanaStack struct { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L34)
+type GrafanaStack struct { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L34)
 	query *querybuilder.Selection
 
 	id *ID
@@ -195,22 +195,22 @@ type GrafanaStackGrafanaOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L643)
+	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L643)
 	//
 	// Image tag for grafana/grafana.
 	//
 	//
 	// Default: "12.0.0"
-	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L646)
+	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L646)
 	//
 	// grafana.ini config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L649)
+	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L649)
 	//
 	// Persistence volume mounted at /var/lib/grafana. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L655)
+	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L655)
 }
 
 // Grafana configures a grafana/grafana service with file-based datasource
@@ -223,7 +223,7 @@ type GrafanaStackGrafanaOpts struct {
 // plaintext never enters generated bindings. storage, when non-nil, is
 // mounted at /var/lib/grafana for persistence; when nil, an ephemeral
 // empty Directory is mounted instead.
-func (r *GrafanaStack) Grafana(adminPassword *Secret, opts ...GrafanaStackGrafanaOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L640)
+func (r *GrafanaStack) Grafana(adminPassword *Secret, opts ...GrafanaStackGrafanaOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L640)
 	assertNotNil("adminPassword", adminPassword)
 	q := r.query.Select("grafana")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -307,22 +307,22 @@ type GrafanaStackLokiOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L132)
+	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L132)
 	//
 	// Image tag for grafana/loki.
 	//
 	//
 	// Default: "3.4.1"
-	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L135)
+	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L135)
 	//
 	// Loki YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L138)
+	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L138)
 	//
 	// Persistence volume mounted at /var/lib/loki. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L142)
+	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L142)
 }
 
 // Loki configures a grafana/loki service running in monolithic mode with
@@ -333,7 +333,7 @@ type GrafanaStackLokiOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/loki for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Loki(opts ...GrafanaStackLokiOpts) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L129)
+func (r *GrafanaStack) Loki(opts ...GrafanaStackLokiOpts) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L129)
 	q := r.query.Select("loki")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -366,22 +366,22 @@ type GrafanaStackMimirOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L435)
+	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L435)
 	//
 	// Image tag for grafana/mimir.
 	//
 	//
 	// Default: "2.15.1"
-	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L438)
+	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L438)
 	//
 	// Mimir YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L441)
+	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L441)
 	//
 	// Persistence volume mounted at /var/lib/mimir. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L445)
+	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L445)
 }
 
 // Mimir configures a grafana/mimir service in monolithic mode (the binary
@@ -394,7 +394,7 @@ type GrafanaStackMimirOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/mimir for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Mimir(opts ...GrafanaStackMimirOpts) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L432)
+func (r *GrafanaStack) Mimir(opts ...GrafanaStackMimirOpts) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L432)
 	q := r.query.Select("mimir")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -427,22 +427,22 @@ type GrafanaStackTempoOpts struct {
 	//
 	//
 	// Default: "docker.io"
-	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L274)
+	Registry string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L274)
 	//
 	// Image tag for grafana/tempo.
 	//
 	//
 	// Default: "2.7.1"
-	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L277)
+	Tag string // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L277)
 	//
 	// Tempo YAML config; replaces the embedded default when supplied.
 	//
-	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L280)
+	ConfigFile *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L280)
 	//
 	// Persistence volume mounted at /var/lib/tempo. When nil the data
 	// dir is ephemeral.
 	//
-	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L284)
+	Storage *CacheVolume // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L284)
 }
 
 // Tempo configures a grafana/tempo service running in monolithic mode
@@ -453,7 +453,7 @@ type GrafanaStackTempoOpts struct {
 // version. configFile fully replaces the embedded default when supplied.
 // storage, when non-nil, is mounted at /var/lib/tempo for persistence;
 // when nil, an ephemeral empty Directory is mounted instead.
-func (r *GrafanaStack) Tempo(opts ...GrafanaStackTempoOpts) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L271)
+func (r *GrafanaStack) Tempo(opts ...GrafanaStackTempoOpts) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L271)
 	q := r.query.Select("tempo")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -491,7 +491,7 @@ func (r *GrafanaStack) AsNode() Node {
 // datasource and dashboard provisioning. Datasources and dashboards are
 // accumulated via the WithX builder methods and rendered into the
 // container's /etc/grafana/provisioning tree at Service() time.
-type GrafanaStackGrafana struct { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L543)
+type GrafanaStackGrafana struct { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L543)
 	query *querybuilder.Selection
 
 	endpoint *string
@@ -516,7 +516,7 @@ func (r *GrafanaStackGrafana) WithGraphQLQuery(q *querybuilder.Selection) *Grafa
 // AdminPassword is mounted into the container as a file and pointed
 // at via GF_SECURITY_ADMIN_PASSWORD__FILE so plaintext never enters
 // generated bindings.
-func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L552)
+func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L552)
 	q := r.query.Select("adminPassword")
 
 	return &Secret{
@@ -526,7 +526,7 @@ func (r *GrafanaStackGrafana) AdminPassword() *Secret { // grafana-stack (https:
 
 // ConfigFile is the grafana.ini config: caller-supplied override or
 // the embedded default.
-func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L548)
+func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L548)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -537,7 +537,7 @@ func (r *GrafanaStackGrafana) ConfigFile() *File { // grafana-stack (https://git
 // Dashboards is the accumulated set of dashboard JSON files, mounted
 // at /var/lib/grafana/dashboards on the Grafana container at
 // Service() time. Starts empty.
-func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L582)
+func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L582)
 	q := r.query.Select("dashboards")
 
 	return &Directory{
@@ -547,7 +547,7 @@ func (r *GrafanaStackGrafana) Dashboards() *Directory { // grafana-stack (https:
 
 // Endpoint returns the Grafana HTTP base URL, e.g. http://<host>:3000, or
 // https://<host>:3000 once WithTls has been called.
-func (r *GrafanaStackGrafana) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L887)
+func (r *GrafanaStackGrafana) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L887)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -609,7 +609,7 @@ func (r *GrafanaStackGrafana) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/grafana:<tag> reference.
-func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L545)
+func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L545)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -626,7 +626,7 @@ func (r *GrafanaStackGrafana) Image(ctx context.Context) (string, error) { // gr
 // and dashboard state is rendered into the container's provisioning
 // tree at this point — subsequent WithX calls on the same *Grafana
 // receiver are not visible to the returned service.
-func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L804)
+func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L804)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -635,7 +635,7 @@ func (r *GrafanaStackGrafana) Service() *Service { // grafana-stack (https://git
 }
 
 // Storage is the optional persistence volume for /var/lib/grafana.
-func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L554)
+func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L554)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
@@ -646,7 +646,7 @@ func (r *GrafanaStackGrafana) Storage() *CacheVolume { // grafana-stack (https:/
 // WithDashboard adds a single dashboard JSON file to the provisioned
 // dashboards directory under the supplied name. `.json` is appended if
 // the supplied name does not already end with it.
-func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L780)
+func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L780)
 	assertNotNil("file", file)
 	q := r.query.Select("withDashboard")
 	q = q.Arg("name", name)
@@ -659,7 +659,7 @@ func (r *GrafanaStackGrafana) WithDashboard(name string, file *File) *GrafanaSta
 
 // WithDashboards adds every *.json entry in dir to the provisioned
 // dashboards directory, preserving filenames.
-func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L791)
+func (r *GrafanaStackGrafana) WithDashboards(dir *Directory) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L791)
 	assertNotNil("dir", dir)
 	q := r.query.Select("withDashboards")
 	q = q.Arg("dir", dir)
@@ -674,15 +674,15 @@ type GrafanaStackGrafanaWithLokiDatasourceOpts struct {
 	//
 	// PEM CA that signed the backend's server certificate.
 	//
-	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L709)
+	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L709)
 	//
 	// PEM client certificate Grafana presents to an mTLS backend.
 	//
-	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L712)
+	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L712)
 	//
 	// PEM client private key paired with clientCert.
 	//
-	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L715)
+	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L715)
 }
 
 // WithLokiDatasource binds loki into Grafana's network at hostname `name`
@@ -701,7 +701,7 @@ type GrafanaStackGrafanaWithLokiDatasourceOpts struct {
 // (correct only for a self-signed server cert). When loki has WithMtls, also
 // supply clientCert / clientKey (the PEM certificate + key Grafana presents to
 // the backend); Service returns an error if they are missing.
-func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStackLoki, opts ...GrafanaStackGrafanaWithLokiDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L704)
+func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStackLoki, opts ...GrafanaStackGrafanaWithLokiDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L704)
 	assertNotNil("loki", loki)
 	q := r.query.Select("withLokiDatasource")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -728,18 +728,18 @@ func (r *GrafanaStackGrafana) WithLokiDatasource(name string, loki *GrafanaStack
 
 // GrafanaStackGrafanaWithMimirDatasourceOpts contains options for GrafanaStackGrafana.WithMimirDatasource
 type GrafanaStackGrafanaWithMimirDatasourceOpts struct {
-	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L760)
+	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L760)
 
-	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L762)
+	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L762)
 
-	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L764)
+	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L764)
 }
 
 // WithMimirDatasource binds mimir into Grafana's network at hostname `name`
 // and accumulates a Prometheus-type datasource entry pointing at
 // Mimir's Prometheus-compatible API endpoint. See WithLokiDatasource
 // for the constraints on `name` and the TLS args.
-func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaStackMimir, opts ...GrafanaStackGrafanaWithMimirDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L756)
+func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaStackMimir, opts ...GrafanaStackGrafanaWithMimirDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L756)
 	assertNotNil("mimir", mimir)
 	q := r.query.Select("withMimirDatasource")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -766,17 +766,17 @@ func (r *GrafanaStackGrafana) WithMimirDatasource(name string, mimir *GrafanaSta
 
 // GrafanaStackGrafanaWithTempoDatasourceOpts contains options for GrafanaStackGrafana.WithTempoDatasource
 type GrafanaStackGrafanaWithTempoDatasourceOpts struct {
-	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L735)
+	CaCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L735)
 
-	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L737)
+	ClientCert *File // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L737)
 
-	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L739)
+	ClientKey *Secret // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L739)
 }
 
 // WithTempoDatasource binds tempo into Grafana's network at hostname
 // `name` and accumulates a Tempo datasource entry under the same name.
 // See WithLokiDatasource for the constraints on `name` and the TLS args.
-func (r *GrafanaStackGrafana) WithTempoDatasource(name string, tempo *GrafanaStackTempo, opts ...GrafanaStackGrafanaWithTempoDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L731)
+func (r *GrafanaStackGrafana) WithTempoDatasource(name string, tempo *GrafanaStackTempo, opts ...GrafanaStackGrafanaWithTempoDatasourceOpts) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L731)
 	assertNotNil("tempo", tempo)
 	q := r.query.Select("withTempoDatasource")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -811,7 +811,7 @@ func (r *GrafanaStackGrafana) WithTempoDatasource(name string, tempo *GrafanaSta
 // backend, supply the client certificate to the datasource instead (see
 // WithLokiDatasource). Ignored when a custom config file was supplied to
 // Grafana().
-func (r *GrafanaStackGrafana) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L681)
+func (r *GrafanaStackGrafana) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackGrafana { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L681)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -834,7 +834,7 @@ func (r *GrafanaStackGrafana) AsNode() Node {
 // Loki wraps a configured grafana/loki container. Use Service() to obtain
 // the *dagger.Service for binding into other containers, and Endpoint() /
 // OtlpHttpEndpoint() to derive client URLs.
-type GrafanaStackLoki struct { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L96)
+type GrafanaStackLoki struct { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L96)
 	query *querybuilder.Selection
 
 	endpoint         *string
@@ -859,7 +859,7 @@ func (r *GrafanaStackLoki) WithGraphQLQuery(q *querybuilder.Selection) *GrafanaS
 
 // ConfigFile is the Loki YAML config: either the caller-supplied
 // override or the embedded default staged into the module workdir.
-func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L101)
+func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L101)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -869,7 +869,7 @@ func (r *GrafanaStackLoki) ConfigFile() *File { // grafana-stack (https://github
 
 // Endpoint returns the Loki HTTP base URL, e.g. http://<host>:3100, or
 // https://<host>:3100 once WithTls has been called.
-func (r *GrafanaStackLoki) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L214)
+func (r *GrafanaStackLoki) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L214)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -931,7 +931,7 @@ func (r *GrafanaStackLoki) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/loki:<tag> reference.
-func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L98)
+func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L98)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -946,7 +946,7 @@ func (r *GrafanaStackLoki) Image(ctx context.Context) (string, error) { // grafa
 // OtlpHttpEndpoint returns the Loki OTLP/HTTP logs receiver URL, suitable
 // as the `endpoint` for an OpenTelemetry exporter posting log data. The
 // scheme is https once WithTls has been called.
-func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L230)
+func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L230)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -965,7 +965,7 @@ func (r *GrafanaStackLoki) OtlpHTTPEndpoint(ctx context.Context) (string, error)
 // without us having to second-guess the upstream image's USER. This is
 // safe for ephemeral dev/test services and avoids per-image UID drift
 // across Loki / Tempo / Mimir.
-func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L186)
+func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L186)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -975,7 +975,7 @@ func (r *GrafanaStackLoki) Service() *Service { // grafana-stack (https://github
 
 // Storage is the optional persistence volume for /var/lib/loki.
 // When nil the data dir is mounted as an empty Directory (ephemeral).
-func (r *GrafanaStackLoki) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L104)
+func (r *GrafanaStackLoki) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L104)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
@@ -986,7 +986,7 @@ func (r *GrafanaStackLoki) Storage() *CacheVolume { // grafana-stack (https://gi
 // WithMtls additionally requires every client to present a certificate signed
 // by clientCa (PEM). Must be combined with WithTls; Service returns an error
 // otherwise.
-func (r *GrafanaStackLoki) WithMtls(clientCa *File) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L173)
+func (r *GrafanaStackLoki) WithMtls(clientCa *File) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L173)
 	assertNotNil("clientCa", clientCa)
 	q := r.query.Select("withMtls")
 	q = q.Arg("clientCa", clientCa)
@@ -1003,7 +1003,7 @@ func (r *GrafanaStackLoki) WithMtls(clientCa *File) *GrafanaStackLoki { // grafa
 // PEM private key. After this call Endpoint / OtlpHttpEndpoint return https://
 // URLs. Ignored when a custom config file was supplied to Loki(); that config
 // owns its own TLS.
-func (r *GrafanaStackLoki) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L163)
+func (r *GrafanaStackLoki) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackLoki { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L163)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -1026,7 +1026,7 @@ func (r *GrafanaStackLoki) AsNode() Node {
 // Mimir wraps a configured grafana/mimir container running in monolithic
 // (single-binary, target=all) mode with the OTLP HTTP ingester enabled,
 // anonymous tenant, and filesystem block storage.
-type GrafanaStackMimir struct { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L400)
+type GrafanaStackMimir struct { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L400)
 	query *querybuilder.Selection
 
 	endpoint         *string
@@ -1051,7 +1051,7 @@ func (r *GrafanaStackMimir) WithGraphQLQuery(q *querybuilder.Selection) *Grafana
 
 // ConfigFile is the Mimir YAML config: either the caller-supplied
 // override or the embedded default.
-func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L405)
+func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L405)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -1063,7 +1063,7 @@ func (r *GrafanaStackMimir) ConfigFile() *File { // grafana-stack (https://githu
 // https://<host>:9009 once WithTls has been called. This endpoint serves
 // both the Prometheus-compatible query API and the OTLP HTTP metrics
 // ingester.
-func (r *GrafanaStackMimir) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L515)
+func (r *GrafanaStackMimir) Endpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L515)
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
@@ -1125,7 +1125,7 @@ func (r *GrafanaStackMimir) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/mimir:<tag> reference.
-func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L402)
+func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L402)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -1140,7 +1140,7 @@ func (r *GrafanaStackMimir) Image(ctx context.Context) (string, error) { // graf
 // OtlpHttpEndpoint returns the Mimir OTLP/HTTP metrics receiver URL,
 // suitable as the `endpoint` for an OpenTelemetry exporter posting
 // metric data. The scheme is https once WithTls has been called.
-func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L531)
+func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L531)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -1156,7 +1156,7 @@ func (r *GrafanaStackMimir) OtlpHTTPEndpoint(ctx context.Context) (string, error
 // `-target=all` so the binary runs in monolithic mode regardless of the
 // upstream image's default CMD. See Loki.Service for notes on the
 // WithUser("0:0") choice.
-func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L485)
+func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L485)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1165,7 +1165,7 @@ func (r *GrafanaStackMimir) Service() *Service { // grafana-stack (https://githu
 }
 
 // Storage is the optional persistence volume for /var/lib/mimir.
-func (r *GrafanaStackMimir) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L407)
+func (r *GrafanaStackMimir) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L407)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
@@ -1176,7 +1176,7 @@ func (r *GrafanaStackMimir) Storage() *CacheVolume { // grafana-stack (https://g
 // WithMtls additionally requires every client to present a certificate signed
 // by clientCa (PEM). Must be combined with WithTls; Service returns an error
 // otherwise.
-func (r *GrafanaStackMimir) WithMtls(clientCa *File) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L475)
+func (r *GrafanaStackMimir) WithMtls(clientCa *File) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L475)
 	assertNotNil("clientCa", clientCa)
 	q := r.query.Select("withMtls")
 	q = q.Arg("clientCa", clientCa)
@@ -1192,7 +1192,7 @@ func (r *GrafanaStackMimir) WithMtls(clientCa *File) *GrafanaStackMimir { // gra
 // certificate and serverKey its PEM private key. After this call Endpoint /
 // OtlpHttpEndpoint return https:// URLs. Ignored when a custom config file was
 // supplied to Mimir().
-func (r *GrafanaStackMimir) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L465)
+func (r *GrafanaStackMimir) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackMimir { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L465)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -1215,7 +1215,7 @@ func (r *GrafanaStackMimir) AsNode() Node {
 // Tempo wraps a configured grafana/tempo container running in monolithic
 // mode with the OTLP gRPC and HTTP receivers enabled and local filesystem
 // trace storage.
-type GrafanaStackTempo struct { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L241)
+type GrafanaStackTempo struct { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L241)
 	query *querybuilder.Selection
 
 	httpEndpoint     *string
@@ -1241,7 +1241,7 @@ func (r *GrafanaStackTempo) WithGraphQLQuery(q *querybuilder.Selection) *Grafana
 
 // ConfigFile is the Tempo YAML config: either the caller-supplied
 // override or the embedded default.
-func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L246)
+func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L246)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -1252,7 +1252,7 @@ func (r *GrafanaStackTempo) ConfigFile() *File { // grafana-stack (https://githu
 // HttpEndpoint returns the Tempo HTTP query/push base URL,
 // e.g. http://<host>:3200, or https://<host>:3200 once WithTls has been
 // called.
-func (r *GrafanaStackTempo) HTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L354)
+func (r *GrafanaStackTempo) HTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L354)
 	if r.httpEndpoint != nil {
 		return *r.httpEndpoint, nil
 	}
@@ -1314,7 +1314,7 @@ func (r *GrafanaStackTempo) UnmarshalJSON(bs []byte) error {
 }
 
 // Image is the resolved <registry>/grafana/tempo:<tag> reference.
-func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L243)
+func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L243)
 	if r.image != nil {
 		return *r.image, nil
 	}
@@ -1329,7 +1329,7 @@ func (r *GrafanaStackTempo) Image(ctx context.Context) (string, error) { // graf
 // OtlpGrpcEndpoint returns the Tempo OTLP/gRPC receiver address,
 // e.g. <host>:4317. No URL scheme — gRPC clients want host:port and must
 // configure TLS themselves (the receiver enforces it once WithTls is set).
-func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L370)
+func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L370)
 	if r.otlpGrpcEndpoint != nil {
 		return *r.otlpGrpcEndpoint, nil
 	}
@@ -1345,7 +1345,7 @@ func (r *GrafanaStackTempo) OtlpGrpcEndpoint(ctx context.Context) (string, error
 // e.g. http://<host>:4318, or https://<host>:4318 once WithTls has been
 // called. The OpenTelemetry HTTP exporter appends the per-signal path
 // itself (e.g. /v1/traces).
-func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L386)
+func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L386)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -1359,7 +1359,7 @@ func (r *GrafanaStackTempo) OtlpHTTPEndpoint(ctx context.Context) (string, error
 
 // Service returns the Tempo Dagger service. See Loki.Service for notes
 // on the WithUser("0:0") choice.
-func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L323)
+func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L323)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1368,7 +1368,7 @@ func (r *GrafanaStackTempo) Service() *Service { // grafana-stack (https://githu
 }
 
 // Storage is the optional persistence volume for /var/lib/tempo.
-func (r *GrafanaStackTempo) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L248)
+func (r *GrafanaStackTempo) Storage() *CacheVolume { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L248)
 	q := r.query.Select("storage")
 
 	return &CacheVolume{
@@ -1379,7 +1379,7 @@ func (r *GrafanaStackTempo) Storage() *CacheVolume { // grafana-stack (https://g
 // WithMtls additionally requires every client to present a certificate signed
 // by clientCa (PEM) on every listener. Must be combined with WithTls; Service
 // returns an error otherwise.
-func (r *GrafanaStackTempo) WithMtls(clientCa *File) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L315)
+func (r *GrafanaStackTempo) WithMtls(clientCa *File) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L315)
 	assertNotNil("clientCa", clientCa)
 	q := r.query.Select("withMtls")
 	q = q.Arg("clientCa", clientCa)
@@ -1396,7 +1396,7 @@ func (r *GrafanaStackTempo) WithMtls(clientCa *File) *GrafanaStackTempo { // gra
 // After this call HttpEndpoint / OtlpHttpEndpoint return https:// URLs;
 // OtlpGrpcEndpoint stays scheme-less (gRPC callers configure TLS themselves).
 // Ignored when a custom config file was supplied to Tempo().
-func (r *GrafanaStackTempo) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L305)
+func (r *GrafanaStackTempo) WithTLS(serverCert *File, serverKey *Secret) *GrafanaStackTempo { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L305)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -1418,7 +1418,7 @@ func (r *GrafanaStackTempo) AsNode() Node {
 
 // GrafanaStack is the module entry point. Use the per-backend constructor
 // functions (Loki, Tempo, Mimir) to obtain a service handle.
-func (r *Query) GrafanaStack() *GrafanaStack { // grafana-stack (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/grafana-stack/main.go#L34)
+func (r *Query) GrafanaStack() *GrafanaStack { // grafana-stack (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/grafana-stack/main.go#L34)
 	q := r.query.Select("grafanaStack")
 
 	return &GrafanaStack{

--- a/.dagger/internal/dagger/otel.gen.go
+++ b/.dagger/internal/dagger/otel.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Otel
-func (r *Binding) AsOtel() *Otel { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L151)
+func (r *Binding) AsOtel() *Otel { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L151)
 	q := r.query.Select("asOtel")
 
 	return &Otel{
@@ -19,7 +19,7 @@ func (r *Binding) AsOtel() *Otel { // otel (https://github.com/z5labs/devex/tree
 }
 
 // Retrieve the binding value, as type OtelContribCollector
-func (r *Binding) AsOtelContribCollector() *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L819)
+func (r *Binding) AsOtelContribCollector() *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L819)
 	q := r.query.Select("asOtelContribCollector")
 
 	return &OtelContribCollector{
@@ -28,7 +28,7 @@ func (r *Binding) AsOtelContribCollector() *OtelContribCollector { // otel (http
 }
 
 // Retrieve the binding value, as type OtelCoreCollector
-func (r *Binding) AsOtelCoreCollector() *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L491)
+func (r *Binding) AsOtelCoreCollector() *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L491)
 	q := r.query.Select("asOtelCoreCollector")
 
 	return &OtelCoreCollector{
@@ -37,7 +37,7 @@ func (r *Binding) AsOtelCoreCollector() *OtelCoreCollector { // otel (https://gi
 }
 
 // Retrieve the binding value, as type OtelExporter
-func (r *Binding) AsOtelExporter() *OtelExporter { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L173)
+func (r *Binding) AsOtelExporter() *OtelExporter { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L173)
 	q := r.query.Select("asOtelExporter")
 
 	return &OtelExporter{
@@ -46,7 +46,7 @@ func (r *Binding) AsOtelExporter() *OtelExporter { // otel (https://github.com/z
 }
 
 // Retrieve the binding value, as type OtelPipeline
-func (r *Binding) AsOtelPipeline() *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L407)
+func (r *Binding) AsOtelPipeline() *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L407)
 	q := r.query.Select("asOtelPipeline")
 
 	return &OtelPipeline{
@@ -55,7 +55,7 @@ func (r *Binding) AsOtelPipeline() *OtelPipeline { // otel (https://github.com/z
 }
 
 // Retrieve the binding value, as type OtelProcessor
-func (r *Binding) AsOtelProcessor() *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L163)
+func (r *Binding) AsOtelProcessor() *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L163)
 	q := r.query.Select("asOtelProcessor")
 
 	return &OtelProcessor{
@@ -64,7 +64,7 @@ func (r *Binding) AsOtelProcessor() *OtelProcessor { // otel (https://github.com
 }
 
 // Retrieve the binding value, as type OtelReceiver
-func (r *Binding) AsOtelReceiver() *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L156)
+func (r *Binding) AsOtelReceiver() *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L156)
 	q := r.query.Select("asOtelReceiver")
 
 	return &OtelReceiver{
@@ -73,7 +73,7 @@ func (r *Binding) AsOtelReceiver() *OtelReceiver { // otel (https://github.com/z
 }
 
 // Create or update a binding of type OtelContribCollector in the environment
-func (r *Env) WithOtelContribCollectorInput(name string, value *OtelContribCollector, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L819)
+func (r *Env) WithOtelContribCollectorInput(name string, value *OtelContribCollector, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L819)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelContribCollectorInput")
 	q = q.Arg("name", name)
@@ -86,7 +86,7 @@ func (r *Env) WithOtelContribCollectorInput(name string, value *OtelContribColle
 }
 
 // Declare a desired OtelContribCollector output to be assigned in the environment
-func (r *Env) WithOtelContribCollectorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L819)
+func (r *Env) WithOtelContribCollectorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L819)
 	q := r.query.Select("withOtelContribCollectorOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -97,7 +97,7 @@ func (r *Env) WithOtelContribCollectorOutput(name string, description string) *E
 }
 
 // Create or update a binding of type OtelCoreCollector in the environment
-func (r *Env) WithOtelCoreCollectorInput(name string, value *OtelCoreCollector, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L491)
+func (r *Env) WithOtelCoreCollectorInput(name string, value *OtelCoreCollector, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L491)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelCoreCollectorInput")
 	q = q.Arg("name", name)
@@ -110,7 +110,7 @@ func (r *Env) WithOtelCoreCollectorInput(name string, value *OtelCoreCollector, 
 }
 
 // Declare a desired OtelCoreCollector output to be assigned in the environment
-func (r *Env) WithOtelCoreCollectorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L491)
+func (r *Env) WithOtelCoreCollectorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L491)
 	q := r.query.Select("withOtelCoreCollectorOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -121,7 +121,7 @@ func (r *Env) WithOtelCoreCollectorOutput(name string, description string) *Env 
 }
 
 // Create or update a binding of type OtelExporter in the environment
-func (r *Env) WithOtelExporterInput(name string, value *OtelExporter, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L173)
+func (r *Env) WithOtelExporterInput(name string, value *OtelExporter, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L173)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelExporterInput")
 	q = q.Arg("name", name)
@@ -134,7 +134,7 @@ func (r *Env) WithOtelExporterInput(name string, value *OtelExporter, descriptio
 }
 
 // Declare a desired OtelExporter output to be assigned in the environment
-func (r *Env) WithOtelExporterOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L173)
+func (r *Env) WithOtelExporterOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L173)
 	q := r.query.Select("withOtelExporterOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -145,7 +145,7 @@ func (r *Env) WithOtelExporterOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type Otel in the environment
-func (r *Env) WithOtelInput(name string, value *Otel, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L151)
+func (r *Env) WithOtelInput(name string, value *Otel, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L151)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelInput")
 	q = q.Arg("name", name)
@@ -158,7 +158,7 @@ func (r *Env) WithOtelInput(name string, value *Otel, description string) *Env {
 }
 
 // Declare a desired Otel output to be assigned in the environment
-func (r *Env) WithOtelOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L151)
+func (r *Env) WithOtelOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L151)
 	q := r.query.Select("withOtelOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -169,7 +169,7 @@ func (r *Env) WithOtelOutput(name string, description string) *Env { // otel (ht
 }
 
 // Create or update a binding of type OtelPipeline in the environment
-func (r *Env) WithOtelPipelineInput(name string, value *OtelPipeline, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L407)
+func (r *Env) WithOtelPipelineInput(name string, value *OtelPipeline, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L407)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelPipelineInput")
 	q = q.Arg("name", name)
@@ -182,7 +182,7 @@ func (r *Env) WithOtelPipelineInput(name string, value *OtelPipeline, descriptio
 }
 
 // Declare a desired OtelPipeline output to be assigned in the environment
-func (r *Env) WithOtelPipelineOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L407)
+func (r *Env) WithOtelPipelineOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L407)
 	q := r.query.Select("withOtelPipelineOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -193,7 +193,7 @@ func (r *Env) WithOtelPipelineOutput(name string, description string) *Env { // 
 }
 
 // Create or update a binding of type OtelProcessor in the environment
-func (r *Env) WithOtelProcessorInput(name string, value *OtelProcessor, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L163)
+func (r *Env) WithOtelProcessorInput(name string, value *OtelProcessor, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L163)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelProcessorInput")
 	q = q.Arg("name", name)
@@ -206,7 +206,7 @@ func (r *Env) WithOtelProcessorInput(name string, value *OtelProcessor, descript
 }
 
 // Declare a desired OtelProcessor output to be assigned in the environment
-func (r *Env) WithOtelProcessorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L163)
+func (r *Env) WithOtelProcessorOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L163)
 	q := r.query.Select("withOtelProcessorOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -217,7 +217,7 @@ func (r *Env) WithOtelProcessorOutput(name string, description string) *Env { //
 }
 
 // Create or update a binding of type OtelReceiver in the environment
-func (r *Env) WithOtelReceiverInput(name string, value *OtelReceiver, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L156)
+func (r *Env) WithOtelReceiverInput(name string, value *OtelReceiver, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L156)
 	assertNotNil("value", value)
 	q := r.query.Select("withOtelReceiverInput")
 	q = q.Arg("name", name)
@@ -230,7 +230,7 @@ func (r *Env) WithOtelReceiverInput(name string, value *OtelReceiver, descriptio
 }
 
 // Declare a desired OtelReceiver output to be assigned in the environment
-func (r *Env) WithOtelReceiverOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L156)
+func (r *Env) WithOtelReceiverOutput(name string, description string) *Env { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L156)
 	q := r.query.Select("withOtelReceiverOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -240,7 +240,7 @@ func (r *Env) WithOtelReceiverOutput(name string, description string) *Env { // 
 	}
 }
 
-type Otel struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L151)
+type Otel struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L151)
 	query *querybuilder.Selection
 
 	id *ID
@@ -253,7 +253,7 @@ func (r *Otel) WithGraphQLQuery(q *querybuilder.Selection) *Otel {
 }
 
 // BatchProcessor builds a batch processor with collector defaults.
-func (r *Otel) BatchProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L323)
+func (r *Otel) BatchProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L323)
 	q := r.query.Select("batchProcessor")
 	q = q.Arg("name", name)
 
@@ -266,17 +266,17 @@ func (r *Otel) BatchProcessor(name string) *OtelProcessor { // otel (https://git
 type OtelContribOpts struct {
 
 	// Default: "docker.io"
-	Registry string // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L838)
+	Registry string // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L838)
 
 	// Default: "0.130.1"
-	Tag string // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L840)
+	Tag string // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L840)
 
-	ConfigFile *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L842)
+	ConfigFile *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L842)
 }
 
 // Contrib returns a ContribCollector backed by the
 // otel/opentelemetry-collector-contrib image. See Core.
-func (r *Otel) Contrib(opts ...OtelContribOpts) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L836)
+func (r *Otel) Contrib(opts ...OtelContribOpts) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L836)
 	q := r.query.Select("contrib")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -302,19 +302,19 @@ func (r *Otel) Contrib(opts ...OtelContribOpts) *OtelContribCollector { // otel 
 type OtelCoreOpts struct {
 
 	// Default: "docker.io"
-	Registry string // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L512)
+	Registry string // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L512)
 
 	// Default: "0.130.1"
-	Tag string // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L514)
+	Tag string // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L514)
 
-	ConfigFile *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L516)
+	ConfigFile *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L516)
 }
 
 // Core returns a CoreCollector backed by the
 // otel/opentelemetry-collector image at <registry>/<image>:<tag>.
 // configFile, when supplied, fully replaces the rendered pipeline
 // YAML; the image path is fixed.
-func (r *Otel) Core(opts ...OtelCoreOpts) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L510)
+func (r *Otel) Core(opts ...OtelCoreOpts) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L510)
 	q := r.query.Select("core")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `registry` optional argument
@@ -337,7 +337,7 @@ func (r *Otel) Core(opts ...OtelCoreOpts) *OtelCoreCollector { // otel (https://
 }
 
 // CustomExporter — see CustomReceiver.
-func (r *Otel) CustomExporter(kind string, name string, yamlBody string) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L395)
+func (r *Otel) CustomExporter(kind string, name string, yamlBody string) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L395)
 	q := r.query.Select("customExporter")
 	q = q.Arg("kind", kind)
 	q = q.Arg("name", name)
@@ -349,7 +349,7 @@ func (r *Otel) CustomExporter(kind string, name string, yamlBody string) *OtelEx
 }
 
 // CustomProcessor — see CustomReceiver.
-func (r *Otel) CustomProcessor(kind string, name string, yamlBody string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L387)
+func (r *Otel) CustomProcessor(kind string, name string, yamlBody string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L387)
 	q := r.query.Select("customProcessor")
 	q = q.Arg("kind", kind)
 	q = q.Arg("name", name)
@@ -362,7 +362,7 @@ func (r *Otel) CustomProcessor(kind string, name string, yamlBody string) *OtelP
 
 // CustomReceiver builds a receiver of arbitrary kind whose body is the
 // caller-supplied YAML, spliced verbatim under `receivers.<kind>/<name>`.
-func (r *Otel) CustomReceiver(kind string, name string, yamlBody string) *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L379)
+func (r *Otel) CustomReceiver(kind string, name string, yamlBody string) *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L379)
 	q := r.query.Select("customReceiver")
 	q = q.Arg("kind", kind)
 	q = q.Arg("name", name)
@@ -374,7 +374,7 @@ func (r *Otel) CustomReceiver(kind string, name string, yamlBody string) *OtelRe
 }
 
 // DebugExporter builds the stdout `debug` exporter at verbosity=detailed.
-func (r *Otel) DebugExporter(name string) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L311)
+func (r *Otel) DebugExporter(name string) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L311)
 	q := r.query.Select("debugExporter")
 	q = q.Arg("name", name)
 
@@ -387,7 +387,7 @@ func (r *Otel) DebugExporter(name string) *OtelExporter { // otel (https://githu
 // otlp receiver → batch processor → debug exporter for signal.
 // Component names are fixed (`otlp/debug`, `batch/debug`,
 // `debug/debug`); the pipeline name is `debug`.
-func (r *Otel) DebugPipeline(signal string) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L439)
+func (r *Otel) DebugPipeline(signal string) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L439)
 	q := r.query.Select("debugPipeline")
 	q = q.Arg("signal", signal)
 
@@ -448,7 +448,7 @@ func (r *Otel) UnmarshalJSON(bs []byte) error {
 // MemoryLimiterProcessor builds a memory_limiter processor with
 // conservative defaults (check_interval: 1s, limit_mib: 512). Callers
 // needing different thresholds should reach for CustomProcessor.
-func (r *Otel) MemoryLimiterProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L333)
+func (r *Otel) MemoryLimiterProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L333)
 	q := r.query.Select("memoryLimiterProcessor")
 	q = q.Arg("name", name)
 
@@ -463,17 +463,17 @@ type OtelOtlpExporterOpts struct {
 	// PEM-encoded CA certificate to verify the receiver against. When set
 	// the exporter speaks TLS instead of plaintext.
 	//
-	CaCert *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L232)
+	CaCert *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L232)
 	//
 	// PEM-encoded client certificate presented for mTLS. Must be paired
 	// with clientKey.
 	//
-	ClientCert *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L236)
+	ClientCert *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L236)
 	//
 	// PEM-encoded PKCS#8 client private key for mTLS. Must be paired with
 	// clientCert.
 	//
-	ClientKey *Secret // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L240)
+	ClientKey *Secret // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L240)
 }
 
 // OtlpExporter builds an OTLP gRPC exporter pointing at endpoint
@@ -481,7 +481,7 @@ type OtelOtlpExporterOpts struct {
 // (tls.insecure=true). Supplying caCert pins the server CA; supplying
 // clientCert + clientKey (which must be given together) presents an mTLS
 // identity.
-func (r *Otel) OtlpExporter(name string, endpoint string, opts ...OtelOtlpExporterOpts) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L227)
+func (r *Otel) OtlpExporter(name string, endpoint string, opts ...OtelOtlpExporterOpts) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L227)
 	q := r.query.Select("otlpExporter")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `caCert` optional argument
@@ -507,17 +507,17 @@ func (r *Otel) OtlpExporter(name string, endpoint string, opts ...OtelOtlpExport
 
 // OtelOtlpHTTPExporterOpts contains options for Otel.OtlpHTTPExporter
 type OtelOtlpHTTPExporterOpts struct {
-	CaCert *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L251)
+	CaCert *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L251)
 
-	ClientCert *File // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L253)
+	ClientCert *File // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L253)
 
-	ClientKey *Secret // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L255)
+	ClientKey *Secret // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L255)
 }
 
 // OtlpHttpExporter builds an OTLP/HTTP exporter pointing at endpoint
 // (URL with scheme, e.g. http://loki:3100/otlp). TLS options behave as
 // on OtlpExporter; point endpoint at an https:// URL when supplying them.
-func (r *Otel) OtlpHTTPExporter(name string, endpoint string, opts ...OtelOtlpHTTPExporterOpts) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L248)
+func (r *Otel) OtlpHTTPExporter(name string, endpoint string, opts ...OtelOtlpHTTPExporterOpts) *OtelExporter { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L248)
 	q := r.query.Select("otlpHttpExporter")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `caCert` optional argument
@@ -543,7 +543,7 @@ func (r *Otel) OtlpHTTPExporter(name string, endpoint string, opts ...OtelOtlpHT
 
 // OtlpReceiver builds the standard OTLP receiver listening on gRPC :4317
 // and HTTP :4318.
-func (r *Otel) OtlpReceiver(name string) *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L206)
+func (r *Otel) OtlpReceiver(name string) *OtelReceiver { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L206)
 	q := r.query.Select("otlpReceiver")
 	q = q.Arg("name", name)
 
@@ -554,7 +554,7 @@ func (r *Otel) OtlpReceiver(name string) *OtelReceiver { // otel (https://github
 
 // Pipeline builds an empty pipeline for signal (logs|traces|metrics)
 // keyed at <signal>/<name> in the rendered config.
-func (r *Otel) Pipeline(signal string, name string) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L425)
+func (r *Otel) Pipeline(signal string, name string) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L425)
 	q := r.query.Select("pipeline")
 	q = q.Arg("signal", signal)
 	q = q.Arg("name", name)
@@ -567,7 +567,7 @@ func (r *Otel) Pipeline(signal string, name string) *OtelPipeline { // otel (htt
 // ResourceProcessor builds a no-op resource processor (empty
 // attributes list). Callers needing actual attribute upserts should
 // reach for CustomProcessor.
-func (r *Otel) ResourceProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L350)
+func (r *Otel) ResourceProcessor(name string) *OtelProcessor { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L350)
 	q := r.query.Select("resourceProcessor")
 	q = q.Arg("name", name)
 
@@ -587,7 +587,7 @@ func (r *Otel) AsNode() Node {
 // ContribCollector wraps the otel/opentelemetry-collector-contrib
 // image. Method set is identical to CoreCollector; only the image
 // path differs, so the rendering and service helpers are shared.
-type OtelContribCollector struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L819)
+type OtelContribCollector struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L819)
 	query *querybuilder.Selection
 
 	id               *ID
@@ -611,7 +611,7 @@ func (r *OtelContribCollector) WithGraphQLQuery(q *querybuilder.Selection) *Otel
 	}
 }
 
-func (r *OtelContribCollector) BindingHosts(ctx context.Context) ([]string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L824)
+func (r *OtelContribCollector) BindingHosts(ctx context.Context) ([]string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L824)
 	q := r.query.Select("bindingHosts")
 
 	var response []string
@@ -620,7 +620,7 @@ func (r *OtelContribCollector) BindingHosts(ctx context.Context) ([]string, erro
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelContribCollector) BindingSvcs(ctx context.Context) ([]Service, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L825)
+func (r *OtelContribCollector) BindingSvcs(ctx context.Context) ([]Service, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L825)
 	q := r.query.Select("bindingSvcs")
 
 	q = q.Select("id")
@@ -653,7 +653,7 @@ func (r *OtelContribCollector) BindingSvcs(ctx context.Context) ([]Service, erro
 }
 
 // ConfigFile — see CoreCollector.ConfigFile.
-func (r *OtelContribCollector) ConfigFile() *File { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L885)
+func (r *OtelContribCollector) ConfigFile() *File { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L885)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -711,7 +711,7 @@ func (r *OtelContribCollector) UnmarshalJSON(bs []byte) error {
 }
 
 // OtlpGrpcEndpoint — see CoreCollector.OtlpGrpcEndpoint.
-func (r *OtelContribCollector) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L897)
+func (r *OtelContribCollector) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L897)
 	if r.otlpGrpcEndpoint != nil {
 		return *r.otlpGrpcEndpoint, nil
 	}
@@ -724,7 +724,7 @@ func (r *OtelContribCollector) OtlpGrpcEndpoint(ctx context.Context) (string, er
 }
 
 // OtlpHttpEndpoint — see CoreCollector.OtlpHttpEndpoint.
-func (r *OtelContribCollector) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L912)
+func (r *OtelContribCollector) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L912)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -736,7 +736,7 @@ func (r *OtelContribCollector) OtlpHTTPEndpoint(ctx context.Context) (string, er
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelContribCollector) Override() *File { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L822)
+func (r *OtelContribCollector) Override() *File { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L822)
 	q := r.query.Select("override")
 
 	return &File{
@@ -744,7 +744,7 @@ func (r *OtelContribCollector) Override() *File { // otel (https://github.com/z5
 	}
 }
 
-func (r *OtelContribCollector) Pipelines(ctx context.Context) ([]OtelPipeline, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L823)
+func (r *OtelContribCollector) Pipelines(ctx context.Context) ([]OtelPipeline, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L823)
 	q := r.query.Select("pipelines")
 
 	q = q.Select("id")
@@ -776,7 +776,7 @@ func (r *OtelContribCollector) Pipelines(ctx context.Context) ([]OtelPipeline, e
 	return convert(response), nil
 }
 
-func (r *OtelContribCollector) Registry(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L820)
+func (r *OtelContribCollector) Registry(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L820)
 	if r.registry != nil {
 		return *r.registry, nil
 	}
@@ -789,7 +789,7 @@ func (r *OtelContribCollector) Registry(ctx context.Context) (string, error) { /
 }
 
 // Service — see CoreCollector.Service.
-func (r *OtelContribCollector) Service() *Service { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L890)
+func (r *OtelContribCollector) Service() *Service { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L890)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -797,7 +797,7 @@ func (r *OtelContribCollector) Service() *Service { // otel (https://github.com/
 	}
 }
 
-func (r *OtelContribCollector) Tag(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L821)
+func (r *OtelContribCollector) Tag(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L821)
 	if r.tag != nil {
 		return *r.tag, nil
 	}
@@ -810,7 +810,7 @@ func (r *OtelContribCollector) Tag(ctx context.Context) (string, error) { // ote
 }
 
 // WithConfigFile — see CoreCollector.WithConfigFile.
-func (r *OtelContribCollector) WithConfigFile(f *File) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L863)
+func (r *OtelContribCollector) WithConfigFile(f *File) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L863)
 	assertNotNil("f", f)
 	q := r.query.Select("withConfigFile")
 	q = q.Arg("f", f)
@@ -821,7 +821,7 @@ func (r *OtelContribCollector) WithConfigFile(f *File) *OtelContribCollector { /
 }
 
 // WithMtls — see CoreCollector.WithMtls.
-func (r *OtelContribCollector) WithMtls(clientCa *File) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L878)
+func (r *OtelContribCollector) WithMtls(clientCa *File) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L878)
 	assertNotNil("clientCa", clientCa)
 	q := r.query.Select("withMtls")
 	q = q.Arg("clientCa", clientCa)
@@ -832,7 +832,7 @@ func (r *OtelContribCollector) WithMtls(clientCa *File) *OtelContribCollector { 
 }
 
 // WithPipeline — see CoreCollector.WithPipeline.
-func (r *OtelContribCollector) WithPipeline(p *OtelPipeline) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L856)
+func (r *OtelContribCollector) WithPipeline(p *OtelPipeline) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L856)
 	assertNotNil("p", p)
 	q := r.query.Select("withPipeline")
 	q = q.Arg("p", p)
@@ -843,7 +843,7 @@ func (r *OtelContribCollector) WithPipeline(p *OtelPipeline) *OtelContribCollect
 }
 
 // WithServiceBinding — see CoreCollector.WithServiceBinding.
-func (r *OtelContribCollector) WithServiceBinding(host string, svc *Service) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L848)
+func (r *OtelContribCollector) WithServiceBinding(host string, svc *Service) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L848)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withServiceBinding")
 	q = q.Arg("host", host)
@@ -855,7 +855,7 @@ func (r *OtelContribCollector) WithServiceBinding(host string, svc *Service) *Ot
 }
 
 // WithTls — see CoreCollector.WithTls.
-func (r *OtelContribCollector) WithTLS(serverCert *File, serverKey *Secret) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L870)
+func (r *OtelContribCollector) WithTLS(serverCert *File, serverKey *Secret) *OtelContribCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L870)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -879,7 +879,7 @@ func (r *OtelContribCollector) AsNode() Node {
 // public surface is identical to ContribCollector — both share the
 // rendering and service-construction helpers below; only the image
 // path differs.
-type OtelCoreCollector struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L491)
+type OtelCoreCollector struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L491)
 	query *querybuilder.Selection
 
 	id               *ID
@@ -903,7 +903,7 @@ func (r *OtelCoreCollector) WithGraphQLQuery(q *querybuilder.Selection) *OtelCor
 	}
 }
 
-func (r *OtelCoreCollector) BindingHosts(ctx context.Context) ([]string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L496)
+func (r *OtelCoreCollector) BindingHosts(ctx context.Context) ([]string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L496)
 	q := r.query.Select("bindingHosts")
 
 	var response []string
@@ -912,7 +912,7 @@ func (r *OtelCoreCollector) BindingHosts(ctx context.Context) ([]string, error) 
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelCoreCollector) BindingSvcs(ctx context.Context) ([]Service, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L497)
+func (r *OtelCoreCollector) BindingSvcs(ctx context.Context) ([]Service, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L497)
 	q := r.query.Select("bindingSvcs")
 
 	q = q.Select("id")
@@ -947,7 +947,7 @@ func (r *OtelCoreCollector) BindingSvcs(ctx context.Context) ([]Service, error) 
 // ConfigFile returns the file that will be mounted as the collector's
 // --config: either the caller-supplied override or the
 // pipeline-rendered YAML. Inspecting it does not launch the service.
-func (r *OtelCoreCollector) ConfigFile() *File { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L573)
+func (r *OtelCoreCollector) ConfigFile() *File { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L573)
 	q := r.query.Select("configFile")
 
 	return &File{
@@ -1006,7 +1006,7 @@ func (r *OtelCoreCollector) UnmarshalJSON(bs []byte) error {
 
 // OtlpGrpcEndpoint returns the host:port of the running collector's
 // OTLP/gRPC listener (no scheme).
-func (r *OtelCoreCollector) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L589)
+func (r *OtelCoreCollector) OtlpGrpcEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L589)
 	if r.otlpGrpcEndpoint != nil {
 		return *r.otlpGrpcEndpoint, nil
 	}
@@ -1021,7 +1021,7 @@ func (r *OtelCoreCollector) OtlpGrpcEndpoint(ctx context.Context) (string, error
 // OtlpHttpEndpoint returns <scheme>://<host>:4318 for the running
 // collector's OTLP/HTTP listener. The scheme is https once WithTls has
 // been called, http otherwise.
-func (r *OtelCoreCollector) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L606)
+func (r *OtelCoreCollector) OtlpHTTPEndpoint(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L606)
 	if r.otlpHttpEndpoint != nil {
 		return *r.otlpHttpEndpoint, nil
 	}
@@ -1033,7 +1033,7 @@ func (r *OtelCoreCollector) OtlpHTTPEndpoint(ctx context.Context) (string, error
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelCoreCollector) Override() *File { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L494)
+func (r *OtelCoreCollector) Override() *File { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L494)
 	q := r.query.Select("override")
 
 	return &File{
@@ -1041,7 +1041,7 @@ func (r *OtelCoreCollector) Override() *File { // otel (https://github.com/z5lab
 	}
 }
 
-func (r *OtelCoreCollector) Pipelines(ctx context.Context) ([]OtelPipeline, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L495)
+func (r *OtelCoreCollector) Pipelines(ctx context.Context) ([]OtelPipeline, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L495)
 	q := r.query.Select("pipelines")
 
 	q = q.Select("id")
@@ -1073,7 +1073,7 @@ func (r *OtelCoreCollector) Pipelines(ctx context.Context) ([]OtelPipeline, erro
 	return convert(response), nil
 }
 
-func (r *OtelCoreCollector) Registry(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L492)
+func (r *OtelCoreCollector) Registry(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L492)
 	if r.registry != nil {
 		return *r.registry, nil
 	}
@@ -1089,7 +1089,7 @@ func (r *OtelCoreCollector) Registry(ctx context.Context) (string, error) { // o
 // and :4318 (OTLP HTTP). Mounts the resolved config (override or
 // rendered) when one exists; otherwise launches with no --config flag,
 // matching the collector binary's behavior of refusing to start.
-func (r *OtelCoreCollector) Service() *Service { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L581)
+func (r *OtelCoreCollector) Service() *Service { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L581)
 	q := r.query.Select("service")
 
 	return &Service{
@@ -1097,7 +1097,7 @@ func (r *OtelCoreCollector) Service() *Service { // otel (https://github.com/z5l
 	}
 }
 
-func (r *OtelCoreCollector) Tag(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L493)
+func (r *OtelCoreCollector) Tag(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L493)
 	if r.tag != nil {
 		return *r.tag, nil
 	}
@@ -1112,7 +1112,7 @@ func (r *OtelCoreCollector) Tag(ctx context.Context) (string, error) { // otel (
 // WithConfigFile fully replaces the rendered pipeline YAML with the
 // supplied file. Pipelines added via WithPipeline are ignored when an
 // override is set.
-func (r *OtelCoreCollector) WithConfigFile(f *File) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L543)
+func (r *OtelCoreCollector) WithConfigFile(f *File) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L543)
 	assertNotNil("f", f)
 	q := r.query.Select("withConfigFile")
 	q = q.Arg("f", f)
@@ -1125,7 +1125,7 @@ func (r *OtelCoreCollector) WithConfigFile(f *File) *OtelCoreCollector { // otel
 // WithMtls requires client certificates signed by clientCa (PEM-encoded)
 // on every incoming OTLP connection. Must be combined with WithTls;
 // Service returns an error otherwise.
-func (r *OtelCoreCollector) WithMtls(clientCa *File) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L564)
+func (r *OtelCoreCollector) WithMtls(clientCa *File) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L564)
 	assertNotNil("clientCa", clientCa)
 	q := r.query.Select("withMtls")
 	q = q.Arg("clientCa", clientCa)
@@ -1138,7 +1138,7 @@ func (r *OtelCoreCollector) WithMtls(clientCa *File) *OtelCoreCollector { // ote
 // WithPipeline appends a pipeline to the collector. The collector
 // dedupes shared components into one top-level entry per kind/name
 // at YAML-render time.
-func (r *OtelCoreCollector) WithPipeline(p *OtelPipeline) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L534)
+func (r *OtelCoreCollector) WithPipeline(p *OtelPipeline) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L534)
 	assertNotNil("p", p)
 	q := r.query.Select("withPipeline")
 	q = q.Arg("p", p)
@@ -1151,7 +1151,7 @@ func (r *OtelCoreCollector) WithPipeline(p *OtelPipeline) *OtelCoreCollector { /
 // WithServiceBinding binds a backend service into the collector's
 // network so exporter endpoints can reach it by hostname. Repeated
 // calls accumulate.
-func (r *OtelCoreCollector) WithServiceBinding(host string, svc *Service) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L524)
+func (r *OtelCoreCollector) WithServiceBinding(host string, svc *Service) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L524)
 	assertNotNil("svc", svc)
 	q := r.query.Select("withServiceBinding")
 	q = q.Arg("host", host)
@@ -1167,7 +1167,7 @@ func (r *OtelCoreCollector) WithServiceBinding(host string, svc *Service) *OtelC
 // PEM-encoded PKCS#8 private key; both are mounted into the collector and
 // wired into every otlp receiver at render time. After this call
 // OtlpHttpEndpoint returns an https:// URL.
-func (r *OtelCoreCollector) WithTLS(serverCert *File, serverKey *Secret) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L554)
+func (r *OtelCoreCollector) WithTLS(serverCert *File, serverKey *Secret) *OtelCoreCollector { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L554)
 	assertNotNil("serverCert", serverCert)
 	assertNotNil("serverKey", serverKey)
 	q := r.query.Select("withTls")
@@ -1191,7 +1191,7 @@ func (r *OtelCoreCollector) AsNode() Node {
 // TLS options are supplied to the factory, the cert/key material is
 // carried here so the collector can mount it at the paths already baked
 // into Body (see exporterCertDir).
-type OtelExporter struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L173)
+type OtelExporter struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L173)
 	query *querybuilder.Selection
 
 	body *string
@@ -1206,7 +1206,7 @@ func (r *OtelExporter) WithGraphQLQuery(q *querybuilder.Selection) *OtelExporter
 	}
 }
 
-func (r *OtelExporter) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L176)
+func (r *OtelExporter) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L176)
 	if r.body != nil {
 		return *r.body, nil
 	}
@@ -1267,7 +1267,7 @@ func (r *OtelExporter) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *OtelExporter) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L174)
+func (r *OtelExporter) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L174)
 	if r.kind != nil {
 		return *r.kind, nil
 	}
@@ -1279,7 +1279,7 @@ func (r *OtelExporter) Kind(ctx context.Context) (string, error) { // otel (http
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelExporter) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L175)
+func (r *OtelExporter) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L175)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1304,7 +1304,7 @@ func (r *OtelExporter) AsNode() Node {
 // exporters. Components are held by reference; the collector
 // deduplicates shared components into one top-level entry per
 // kind/name when the YAML is rendered.
-type OtelPipeline struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L407)
+type OtelPipeline struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L407)
 	query *querybuilder.Selection
 
 	id     *ID
@@ -1326,7 +1326,7 @@ func (r *OtelPipeline) WithGraphQLQuery(q *querybuilder.Selection) *OtelPipeline
 	}
 }
 
-func (r *OtelPipeline) Exporters(ctx context.Context) ([]OtelExporter, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L412)
+func (r *OtelPipeline) Exporters(ctx context.Context) ([]OtelExporter, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L412)
 	q := r.query.Select("exporters")
 
 	q = q.Select("id")
@@ -1407,7 +1407,7 @@ func (r *OtelPipeline) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *OtelPipeline) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L409)
+func (r *OtelPipeline) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L409)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1419,7 +1419,7 @@ func (r *OtelPipeline) Name(ctx context.Context) (string, error) { // otel (http
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelPipeline) Processors(ctx context.Context) ([]OtelProcessor, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L411)
+func (r *OtelPipeline) Processors(ctx context.Context) ([]OtelProcessor, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L411)
 	q := r.query.Select("processors")
 
 	q = q.Select("id")
@@ -1451,7 +1451,7 @@ func (r *OtelPipeline) Processors(ctx context.Context) ([]OtelProcessor, error) 
 	return convert(response), nil
 }
 
-func (r *OtelPipeline) Receivers(ctx context.Context) ([]OtelReceiver, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L410)
+func (r *OtelPipeline) Receivers(ctx context.Context) ([]OtelReceiver, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L410)
 	q := r.query.Select("receivers")
 
 	q = q.Select("id")
@@ -1483,7 +1483,7 @@ func (r *OtelPipeline) Receivers(ctx context.Context) ([]OtelReceiver, error) { 
 	return convert(response), nil
 }
 
-func (r *OtelPipeline) Signal(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L408)
+func (r *OtelPipeline) Signal(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L408)
 	if r.signal != nil {
 		return *r.signal, nil
 	}
@@ -1496,7 +1496,7 @@ func (r *OtelPipeline) Signal(ctx context.Context) (string, error) { // otel (ht
 }
 
 // WithExporter — see WithReceiver.
-func (r *OtelPipeline) WithExporter(exp *OtelExporter) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L481)
+func (r *OtelPipeline) WithExporter(exp *OtelExporter) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L481)
 	assertNotNil("exp", exp)
 	q := r.query.Select("withExporter")
 	q = q.Arg("exp", exp)
@@ -1507,7 +1507,7 @@ func (r *OtelPipeline) WithExporter(exp *OtelExporter) *OtelPipeline { // otel (
 }
 
 // WithProcessor — see WithReceiver.
-func (r *OtelPipeline) WithProcessor(proc *OtelProcessor) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L474)
+func (r *OtelPipeline) WithProcessor(proc *OtelProcessor) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L474)
 	assertNotNil("proc", proc)
 	q := r.query.Select("withProcessor")
 	q = q.Arg("proc", proc)
@@ -1520,7 +1520,7 @@ func (r *OtelPipeline) WithProcessor(proc *OtelProcessor) *OtelPipeline { // ote
 // WithReceiver appends a receiver to the pipeline and returns a new
 // pipeline; the receiver is held by reference so it can be deduped
 // across pipelines at render time.
-func (r *OtelPipeline) WithReceiver(recv *OtelReceiver) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L467)
+func (r *OtelPipeline) WithReceiver(recv *OtelReceiver) *OtelPipeline { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L467)
 	assertNotNil("recv", recv)
 	q := r.query.Select("withReceiver")
 	q = q.Arg("recv", recv)
@@ -1539,7 +1539,7 @@ func (r *OtelPipeline) AsNode() Node {
 }
 
 // Processor is a single OpenTelemetry Collector processor component.
-type OtelProcessor struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L163)
+type OtelProcessor struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L163)
 	query *querybuilder.Selection
 
 	body *string
@@ -1554,7 +1554,7 @@ func (r *OtelProcessor) WithGraphQLQuery(q *querybuilder.Selection) *OtelProcess
 	}
 }
 
-func (r *OtelProcessor) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L166)
+func (r *OtelProcessor) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L166)
 	if r.body != nil {
 		return *r.body, nil
 	}
@@ -1615,7 +1615,7 @@ func (r *OtelProcessor) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *OtelProcessor) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L164)
+func (r *OtelProcessor) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L164)
 	if r.kind != nil {
 		return *r.kind, nil
 	}
@@ -1627,7 +1627,7 @@ func (r *OtelProcessor) Kind(ctx context.Context) (string, error) { // otel (htt
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelProcessor) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L165)
+func (r *OtelProcessor) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L165)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1650,7 +1650,7 @@ func (r *OtelProcessor) AsNode() Node {
 // Receiver is a single OpenTelemetry Collector receiver component.
 // Body is the YAML body for this component, spliced under
 // `receivers.<kind>/<name>` at render time.
-type OtelReceiver struct { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L156)
+type OtelReceiver struct { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L156)
 	query *querybuilder.Selection
 
 	body *string
@@ -1665,7 +1665,7 @@ func (r *OtelReceiver) WithGraphQLQuery(q *querybuilder.Selection) *OtelReceiver
 	}
 }
 
-func (r *OtelReceiver) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L159)
+func (r *OtelReceiver) Body(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L159)
 	if r.body != nil {
 		return *r.body, nil
 	}
@@ -1726,7 +1726,7 @@ func (r *OtelReceiver) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *OtelReceiver) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L157)
+func (r *OtelReceiver) Kind(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L157)
 	if r.kind != nil {
 		return *r.kind, nil
 	}
@@ -1738,7 +1738,7 @@ func (r *OtelReceiver) Kind(ctx context.Context) (string, error) { // otel (http
 	return response, q.Execute(ctx)
 }
 
-func (r *OtelReceiver) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L158)
+func (r *OtelReceiver) Name(ctx context.Context) (string, error) { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L158)
 	if r.name != nil {
 		return *r.name, nil
 	}
@@ -1762,7 +1762,7 @@ func (r *OtelReceiver) AsNode() Node {
 // Collector as a service for local development and testing, with a
 // component/pipeline builder API for composing receivers, processors,
 // and exporters without writing YAML by hand.
-func (r *Query) Otel() *Otel { // otel (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/otel/main.go#L151)
+func (r *Query) Otel() *Otel { // otel (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/otel/main.go#L151)
 	q := r.query.Select("otel")
 
 	return &Otel{

--- a/.dagger/internal/dagger/z-5-labs.gen.go
+++ b/.dagger/internal/dagger/z-5-labs.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Z5Labs
-func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L24)
+func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L639)
 	q := r.query.Select("asZ5Labs")
 
 	return &Z5Labs{
@@ -18,37 +18,37 @@ func (r *Binding) AsZ5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/deve
 	}
 }
 
-// Retrieve the binding value, as type Z5LabsBuilder
-func (r *Binding) AsZ5LabsBuilder() *Z5LabsBuilder { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L15)
-	q := r.query.Select("asZ5LabsBuilder")
+// Retrieve the binding value, as type Z5LabsApp
+func (r *Binding) AsZ5LabsApp() *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L45)
+	q := r.query.Select("asZ5LabsApp")
 
-	return &Z5LabsBuilder{
+	return &Z5LabsApp{
 		query: q,
 	}
 }
 
-// Retrieve the binding value, as type Z5LabsGoApp
-func (r *Binding) AsZ5LabsGoApp() *Z5LabsGoApp { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L14)
-	q := r.query.Select("asZ5LabsGoApp")
+// Retrieve the binding value, as type Z5LabsAppBuilder
+func (r *Binding) AsZ5LabsAppBuilder() *Z5LabsAppBuilder { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L73)
+	q := r.query.Select("asZ5LabsAppBuilder")
 
-	return &Z5LabsGoApp{
+	return &Z5LabsAppBuilder{
 		query: q,
 	}
 }
 
-// Retrieve the binding value, as type Z5LabsGoLib
-func (r *Binding) AsZ5LabsGoLib() *Z5LabsGoLib { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/golib.go#L10)
-	q := r.query.Select("asZ5LabsGoLib")
+// Retrieve the binding value, as type Z5LabsGoChain
+func (r *Binding) AsZ5LabsGoChain() *Z5LabsGoChain { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L36)
+	q := r.query.Select("asZ5LabsGoChain")
 
-	return &Z5LabsGoLib{
+	return &Z5LabsGoChain{
 		query: q,
 	}
 }
 
-// Create or update a binding of type Z5LabsBuilder in the environment
-func (r *Env) WithZ5LabsBuilderInput(name string, value *Z5LabsBuilder, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L15)
+// Create or update a binding of type Z5LabsAppBuilder in the environment
+func (r *Env) WithZ5LabsAppBuilderInput(name string, value *Z5LabsAppBuilder, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L73)
 	assertNotNil("value", value)
-	q := r.query.Select("withZ5LabsBuilderInput")
+	q := r.query.Select("withZ5LabsAppBuilderInput")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
 	q = q.Arg("description", description)
@@ -58,9 +58,9 @@ func (r *Env) WithZ5LabsBuilderInput(name string, value *Z5LabsBuilder, descript
 	}
 }
 
-// Declare a desired Z5LabsBuilder output to be assigned in the environment
-func (r *Env) WithZ5LabsBuilderOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L15)
-	q := r.query.Select("withZ5LabsBuilderOutput")
+// Declare a desired Z5LabsAppBuilder output to be assigned in the environment
+func (r *Env) WithZ5LabsAppBuilderOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L73)
+	q := r.query.Select("withZ5LabsAppBuilderOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -69,10 +69,10 @@ func (r *Env) WithZ5LabsBuilderOutput(name string, description string) *Env { //
 	}
 }
 
-// Create or update a binding of type Z5LabsGoApp in the environment
-func (r *Env) WithZ5LabsGoAppInput(name string, value *Z5LabsGoApp, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L14)
+// Create or update a binding of type Z5LabsApp in the environment
+func (r *Env) WithZ5LabsAppInput(name string, value *Z5LabsApp, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L45)
 	assertNotNil("value", value)
-	q := r.query.Select("withZ5LabsGoAppInput")
+	q := r.query.Select("withZ5LabsAppInput")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
 	q = q.Arg("description", description)
@@ -82,9 +82,9 @@ func (r *Env) WithZ5LabsGoAppInput(name string, value *Z5LabsGoApp, description 
 	}
 }
 
-// Declare a desired Z5LabsGoApp output to be assigned in the environment
-func (r *Env) WithZ5LabsGoAppOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L14)
-	q := r.query.Select("withZ5LabsGoAppOutput")
+// Declare a desired Z5LabsApp output to be assigned in the environment
+func (r *Env) WithZ5LabsAppOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L45)
+	q := r.query.Select("withZ5LabsAppOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -93,10 +93,10 @@ func (r *Env) WithZ5LabsGoAppOutput(name string, description string) *Env { // z
 	}
 }
 
-// Create or update a binding of type Z5LabsGoLib in the environment
-func (r *Env) WithZ5LabsGoLibInput(name string, value *Z5LabsGoLib, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/golib.go#L10)
+// Create or update a binding of type Z5LabsGoChain in the environment
+func (r *Env) WithZ5LabsGoChainInput(name string, value *Z5LabsGoChain, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L36)
 	assertNotNil("value", value)
-	q := r.query.Select("withZ5LabsGoLibInput")
+	q := r.query.Select("withZ5LabsGoChainInput")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
 	q = q.Arg("description", description)
@@ -106,9 +106,9 @@ func (r *Env) WithZ5LabsGoLibInput(name string, value *Z5LabsGoLib, description 
 	}
 }
 
-// Declare a desired Z5LabsGoLib output to be assigned in the environment
-func (r *Env) WithZ5LabsGoLibOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/golib.go#L10)
-	q := r.query.Select("withZ5LabsGoLibOutput")
+// Declare a desired Z5LabsGoChain output to be assigned in the environment
+func (r *Env) WithZ5LabsGoChainOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L36)
+	q := r.query.Select("withZ5LabsGoChainOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
 
@@ -118,7 +118,7 @@ func (r *Env) WithZ5LabsGoLibOutput(name string, description string) *Env { // z
 }
 
 // Create or update a binding of type Z5Labs in the environment
-func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L24)
+func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L639)
 	assertNotNil("value", value)
 	q := r.query.Select("withZ5LabsInput")
 	q = q.Arg("name", name)
@@ -131,7 +131,7 @@ func (r *Env) WithZ5LabsInput(name string, value *Z5Labs, description string) *E
 }
 
 // Declare a desired Z5Labs output to be assigned in the environment
-func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L24)
+func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L639)
 	q := r.query.Select("withZ5LabsOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -141,9 +141,9 @@ func (r *Env) WithZ5LabsOutput(name string, description string) *Env { // z5labs
 	}
 }
 
-// Z5labs is the root module type. Construct project archetypes via
-// GoApp / GoLib.
-func (r *Query) Z5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L24)
+// Z5labs is the root module type. Construct the Go language chain via Go;
+// everything this module does is reached from there.
+func (r *Query) Z5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L639)
 	q := r.query.Select("z5Labs")
 
 	return &Z5Labs{
@@ -151,12 +151,20 @@ func (r *Query) Z5Labs() *Z5Labs { // z5labs (https://github.com/z5labs/devex/tr
 	}
 }
 
-// Z5labs is the root module type. Construct project archetypes via
-// GoApp / GoLib.
-type Z5Labs struct { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L24)
+// Z5labs is the root module type. Construct the Go language chain via Go;
+// everything this module does is reached from there.
+type Z5Labs struct { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L639)
 	query *querybuilder.Selection
 
-	id *ID
+	composeSelfTest          *Void
+	contributedTreeSelfTest  *Void
+	contributionPathSelfTest *Void
+	id                       *ID
+	imageConfigSelfTest      *Void
+	imageSbomSelfTest        *Void
+	sourceRedactionSelfTest  *Void
+	variantSetSelfTest       *Void
+	versionTagsSelfTest      *Void
 }
 
 func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
@@ -165,238 +173,280 @@ func (r *Z5Labs) WithGraphQLQuery(q *querybuilder.Selection) *Z5Labs {
 	}
 }
 
-// Z5LabsGoAppOpts contains options for Z5Labs.GoApp
-type Z5LabsGoAppOpts struct {
-
-	// Default: "."
-	Pkg string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L72)
-
-	BinaryName string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L74)
-
-	// Default: "^refs/heads/main$"
-	PublishOn string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L77)
-
-	Registry string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L79)
-
-	// Default: "ci"
-	AuthUsername string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L82)
-
-	Auth *Secret // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L84)
-	//
-	// A `.golangci.yml` replacing the bundled default policy.
-	//
-	// The lint stage runs golangci-lint v2, so this file must be written
-	// in the v2 dialect — it has to open with `version: "2"`. The majors
-	// are not interchangeable: a v2 binary refuses a v1 file outright,
-	// before running any linter. Pass lintVersion to move the whole stage,
-	// dialect included, to another release.
-	//
-	LintConfig *File // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L94)
-	//
-	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
-	// Empty takes the version pinned by the `go` module, which is a v2
-	// release; pinning a "v1.x" release here rolls the stage — and the
-	// config dialect it requires — back to v1.
-	//
-	LintVersion string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L101)
-
-	Platforms []string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L103)
-
-	RegistryService *Service // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L105)
-
-	Insecure bool // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L107)
-	//
-	// The CI provider's OIDC token request endpoint —
-	// `ACTIONS_ID_TOKEN_REQUEST_URL` on GitHub Actions, and whatever the
-	// equivalent is elsewhere. Required for any run that publishes.
-	//
-	IDTokenRequestURL string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L113)
-	//
-	// The bearer token for that endpoint —
-	// `ACTIONS_ID_TOKEN_REQUEST_TOKEN` on GitHub Actions. A secret,
-	// because it is a credential for minting identity tokens. Required
-	// for any run that publishes.
-	//
-	IDTokenRequestToken *Secret // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L120)
-	//
-	// A Dagger-hosted OIDC token endpoint, reached over the session
-	// network instead of the public one. When set, its engine-assigned
-	// endpoint replaces the host in idTokenRequestUrl; the path and query
-	// stay the caller's, because those are part of the provider's
-	// protocol.
-	//
-	// This exists for the same reason registryService does: a service's
-	// address is not known until the engine assigns one, so it cannot be
-	// written into a URL ahead of time. It is used by the test suite,
-	// which runs a real token endpoint, and by anyone whose issuer is
-	// itself a Dagger service.
-	//
-	IDTokenService *Service // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L134)
-	//
-	// A PEM-encoded EC private key to sign the provenance with, instead
-	// of an ephemeral key certified by the public sigstore CA.
-	//
-	// This selects the signing mode and nothing else: the workload
-	// identity token is still exchanged, and the predicate still says
-	// only what that token's claims say. Use it for a build that cannot
-	// reach a public CA. Leaving it unset is keyless signing and is what
-	// a normal CI publish should do.
-	//
-	SigningKey *Secret // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L145)
-}
-
-// GoApp wires up an opinionated CI/release pipeline for a `package main`
-// Go application. Call Ci to run checks + multi-arch buildpublish, or Builder to produce the same image single-arch locally.
+// App begins an application assembled from executables this module did not
+// build: a prebuilt binary, a vendor's CLI, or the output of a language whose
+// chain nobody has written yet.
 //
-// Every binary GoApp builds is stamped at link time with the version and
-// the commit it was built from, so an application can answer "which build
-// am I running" without a second build definition beside this one. Declare
-// these two package-level vars in your main package and they are filled in:
+// What comes back is a builder. Add one variant per platform with WithVariant
+// and finish with Build, which is what refuses an empty set. The App that
+// comes out is the same App a language chain produces — the same publish, the
+// same hardening, the same annotations, the same SBOMs and the same signed
+// provenance — because GoChain.App is built on this constructor rather than
+// beside it.
 //
-//	var (
-//		version = "dev"
-//		commit  = "none"
-//	)
+// version is the version every image is published under, and the same rules
+// apply as to GoChain.App's: it has to be usable as an OCI tag, and SemVer
+// build metadata is refused rather than mangled. It is validated by Build.
 //
-// The names are fixed by the module — `main.version` and `main.commit` —
-// and the values are taken from HEAD, never from a parameter. A tag
-// pointing at HEAD gives version the stripped tag name; anything else
-// gives "<shortSha>-<isoCommitTime>", the same rule the published image
-// tag follows, so the two agree by construction. commit is the short HEAD
-// SHA. Because both are functions of the commit alone, two builds of one
-// commit are byte-identical; there is no caller-supplied value that could
-// break that. Source without git metadata at HEAD is an error.
+// # What this seam is for, and what it is not
 //
-// publishOn is a regex evaluated against source repo's HEAD refs (after
-// normalizing `refs/remotes/origin/X` → `refs/heads/X`); matches trigger
-// publish. When registry is set, auth is required.
+// It is for packaging bytes somebody else produced with the hardening, the
+// multi-platform publish, the annotations and the attestations this pipeline
+// gives everything else. It is not a way to hand this module an image: the
+// module still builds the image around the executable, applies the modes and
+// the ownership and pins the layout, so what a caller supplies is bounded and
+// every part of it is reachable by an exec of the entry. A caller-supplied
+// *container* is a different and unbounded thing, and is refused — see
+// contribute.go, which turned down the same offer for the same reason.
 //
-// platforms defaults to ["linux/amd64","linux/arm64"].
+// # Its documents are asserted rather than derived
 //
-// registryService, when non-nil, is a Dagger-hosted registry reached over
-// the session network instead of over the public network — used by tests
-// against a local registry service and by callers whose private registry
-// is itself a Dagger service. Its endpoint is assigned by the engine, so
-// it replaces registry as the address published to; registry is still
-// what decides that a publish happens at all.
-//
-// insecure means plain HTTP and no TLS verification, and it is off unless
-// the caller asks for it. It is deliberately not inferred from
-// registryService being set: that inference made a caller who supplied a
-// service for their own reasons silently publish over an unverified
-// connection. It is spelled insecure rather than tlsVerify because a bool
-// defaulting to true cannot be turned off from the CLI.
-func (r *Z5Labs) GoApp(source *Directory, opts ...Z5LabsGoAppOpts) *Z5LabsGoApp { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L68)
-	assertNotNil("source", source)
-	q := r.query.Select("goApp")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `pkg` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Pkg) {
-			q = q.Arg("pkg", opts[i].Pkg)
-		}
-		// `binaryName` optional argument
-		if !querybuilder.IsZeroValue(opts[i].BinaryName) {
-			q = q.Arg("binaryName", opts[i].BinaryName)
-		}
-		// `publishOn` optional argument
-		if !querybuilder.IsZeroValue(opts[i].PublishOn) {
-			q = q.Arg("publishOn", opts[i].PublishOn)
-		}
-		// `registry` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Registry) {
-			q = q.Arg("registry", opts[i].Registry)
-		}
-		// `authUsername` optional argument
-		if !querybuilder.IsZeroValue(opts[i].AuthUsername) {
-			q = q.Arg("authUsername", opts[i].AuthUsername)
-		}
-		// `auth` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Auth) {
-			q = q.Arg("auth", opts[i].Auth)
-		}
-		// `lintConfig` optional argument
-		if !querybuilder.IsZeroValue(opts[i].LintConfig) {
-			q = q.Arg("lintConfig", opts[i].LintConfig)
-		}
-		// `lintVersion` optional argument
-		if !querybuilder.IsZeroValue(opts[i].LintVersion) {
-			q = q.Arg("lintVersion", opts[i].LintVersion)
-		}
-		// `platforms` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Platforms) {
-			q = q.Arg("platforms", opts[i].Platforms)
-		}
-		// `registryService` optional argument
-		if !querybuilder.IsZeroValue(opts[i].RegistryService) {
-			q = q.Arg("registryService", opts[i].RegistryService)
-		}
-		// `insecure` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Insecure) {
-			q = q.Arg("insecure", opts[i].Insecure)
-		}
-		// `idTokenRequestUrl` optional argument
-		if !querybuilder.IsZeroValue(opts[i].IDTokenRequestURL) {
-			q = q.Arg("idTokenRequestUrl", opts[i].IDTokenRequestURL)
-		}
-		// `idTokenRequestToken` optional argument
-		if !querybuilder.IsZeroValue(opts[i].IDTokenRequestToken) {
-			q = q.Arg("idTokenRequestToken", opts[i].IDTokenRequestToken)
-		}
-		// `idTokenService` optional argument
-		if !querybuilder.IsZeroValue(opts[i].IDTokenService) {
-			q = q.Arg("idTokenService", opts[i].IDTokenService)
-		}
-		// `signingKey` optional argument
-		if !querybuilder.IsZeroValue(opts[i].SigningKey) {
-			q = q.Arg("signingKey", opts[i].SigningKey)
-		}
-	}
-	q = q.Arg("source", source)
+// Say this out loud rather than leaving it to be found. A Go binary's SBOM is
+// derived from the compiled artifact, so it cannot disagree with what it
+// describes. A document handed to WithVariant is a claim its supplier made.
+// What keeps the claim honest is that it has to name the SHA-256 of the
+// executable it accompanies and a publish checks it, so a document about other
+// bytes fails the publish instead of shipping. What it cannot check is whether
+// the components listed inside that document are the ones really linked into
+// the executable; that is the supplier's assertion, in a signed artifact,
+// checkable by anyone who pulls the image.
+func (r *Z5Labs) App(version string) *Z5LabsAppBuilder { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L164)
+	q := r.query.Select("app")
+	q = q.Arg("version", version)
 
-	return &Z5LabsGoApp{
+	return &Z5LabsAppBuilder{
 		query: q,
 	}
 }
 
-// Z5LabsGoLibOpts contains options for Z5Labs.GoLib
-type Z5LabsGoLibOpts struct {
-	//
-	// A `.golangci.yml` replacing the bundled default policy.
-	//
-	// The lint stage runs golangci-lint v2, so this file must be written
-	// in the v2 dialect — it has to open with `version: "2"`. The majors
-	// are not interchangeable: a v2 binary refuses a v1 file outright,
-	// before running any linter. Pass lintVersion to move the whole stage,
-	// dialect included, to another release.
-	//
-	LintConfig *File // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L184)
-	//
-	// The golangci-lint release the lint stage installs, e.g. "v2.12.2".
-	// Empty takes the version pinned by the `go` module, which is a v2
-	// release; pinning a "v1.x" release here rolls the stage — and the
-	// config dialect it requires — back to v1.
-	//
-	LintVersion string // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L191)
+// ComposeSelfTest checks the rules that decide whether one application's
+// payload may be composed into another's image.
+//
+// It sits on the module rather than in tests/ for the reason
+// ImageConfigSelfTest and ContributionPathSelfTest record, and here the
+// reason is stronger than economy. Two of these rules cannot be driven through
+// the public API at all: no constructor in this module can declare a payload
+// of more than one file, and no caller-facing seam can put an environment
+// variable on an image — so a multi-file payload and a conflicting variable
+// are branches that would be unexecutable end to end, and therefore deletable
+// tomorrow with every test still green. Split out as free functions over
+// declarations and maps, every branch runs in process.
+//
+// The end-to-end half — that the refusals really are wired into WithApp, that
+// a composed payload lands where the plugin directory promises, and that the
+// derived image is published, annotated and attested like any other — is in
+// tests/, where it costs a pair of applications instead of a table.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ComposeSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/composeselftest.go#L34)
+	if r.composeSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("composeSelfTest")
+
+	return q.Execute(ctx)
 }
 
-// GoLib wires up the checks-only pipeline for a Go library. v1 has no
-// publish equivalent for libraries.
-func (r *Z5Labs) GoLib(source *Directory, opts ...Z5LabsGoLibOpts) *Z5LabsGoLib { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/main.go#L173)
-	assertNotNil("source", source)
-	q := r.query.Select("goLib")
+// ContributedTreeSelfTest checks what a contributed tree may hold: directories
+// and regular files, and nothing else.
+//
+// It sits on the module for the reason ContributionPathSelfTest does — walkTree
+// is an unexported function over a real filesystem, and every row below would
+// otherwise cost a Dagger call to build a tree that differs from its neighbour
+// by one entry. What cannot be checked in process is that the rule is wired
+// into both readers of a contributed tree, that Dagger's own export and copy
+// preserve a link at all, and that a publish carrying one is refused before
+// anything is pushed; those are in tests/.
+//
+// The rule is a refusal rather than a skip because a skipped link is in no
+// document and no digest while still being in the image — see the "A symbolic
+// link is not content" section in contribute.go, which carries the decision and
+// the measurements behind it.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ContributedTreeSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/documentselftest.go#L35)
+	if r.contributedTreeSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("contributedTreeSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// ContributionPathSelfTest checks the rules that decide where a caller may
+// contribute content, and where they may not.
+//
+// It sits on the module rather than in tests/ for the reason
+// ImageConfigSelfTest records: the rules are unexported pure functions,
+// and driving every branch of them through the public API would mean building
+// a real multi-platform app per row of the table below. The end-to-end half —
+// that the refusal really is wired into WithFile and WithDirectory, and that
+// the entrypoint is one of the paths it protects — is in tests/, where it
+// costs one app instead of twenty.
+//
+// The rules exist because of one failure wearing several shapes: content that
+// lands on top of other content leaves the image holding one thing while its
+// documents describe two. That is the same undetectable incompleteness the
+// contribution mechanism exists to prevent, arriving through the mechanism
+// itself.
+//
+// The PATH's rows are the exception, and they answer a different question: what
+// may reach a directory the image searches by name. Nothing contributed may,
+// because only composition names the architecture of what it brings — see
+// contribute.go. They are table rows rather than a mode bit because a rule
+// enforced by a mode was bypassed by wrapping a binary in a directory, which is
+// what devex#427 closed, and they cover every directory appPath names rather
+// than the plugin directory alone: discovery by bare name is what the rule is
+// about, and /usr/local/bin is one of six directories it can happen in.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ContributionPathSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/contributeselftest.go#L40)
+	if r.contributionPathSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("contributionPathSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// Z5LabsDirectoryDocumentOpts contains options for Z5Labs.DirectoryDocument
+type Z5LabsDirectoryDocumentOpts struct {
+	//
+	// An SPDX licence expression for the content, e.g. MIT or Apache-2.0.
+	//
+	License string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L188)
+	//
+	// The version of the contributed content, if it has one.
+	//
+	Version string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L192)
+}
+
+// DirectoryDocument produces the SPDX document required to contribute dir to
+// an image, for content whose ecosystem has no module able to produce one.
+//
+// Unlike FileDocument this one enumerates: the package it describes carries
+// one SPDX file element per file in the tree, each with its SHA-256 and the
+// SHA-1 the format's verification code is computed from. A directory summed
+// as a single opaque blob would satisfy "the contribution is described" and
+// leave "every file in the image is accounted for" false one level down,
+// which is the same failure this whole mechanism exists to close.
+//
+// The package's own checksum is a digest over the sorted list of the tree's
+// paths and their digests, so two directories with the same name and version
+// and different contents are different packages rather than one.
+//
+// A tree carrying a symbolic link is **refused**, and so is one carrying a
+// device, a pipe or a socket. A link is not bytes and cannot be enumerated,
+// digested or given the mode the module sets, so a document that skipped it
+// would describe a tree the image does not have — see the "A symbolic link is
+// not content" section in contribute.go. The refusal names the link and what
+// it points at, so it can be found and replaced with the thing itself.
+//
+// name is required, because a directory has no name of its own to fall back
+// to. See FileDocument for license and version.
+func (r *Z5Labs) DirectoryDocument(dir *Directory, name string, opts ...Z5LabsDirectoryDocumentOpts) *File { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L179)
+	assertNotNil("dir", dir)
+	q := r.query.Select("directoryDocument")
 	for i := len(opts) - 1; i >= 0; i-- {
-		// `lintConfig` optional argument
-		if !querybuilder.IsZeroValue(opts[i].LintConfig) {
-			q = q.Arg("lintConfig", opts[i].LintConfig)
+		// `license` optional argument
+		if !querybuilder.IsZeroValue(opts[i].License) {
+			q = q.Arg("license", opts[i].License)
 		}
-		// `lintVersion` optional argument
-		if !querybuilder.IsZeroValue(opts[i].LintVersion) {
-			q = q.Arg("lintVersion", opts[i].LintVersion)
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
 		}
 	}
+	q = q.Arg("dir", dir)
+	q = q.Arg("name", name)
+
+	return &File{
+		query: q,
+	}
+}
+
+// Z5LabsFileDocumentOpts contains options for Z5Labs.FileDocument
+type Z5LabsFileDocumentOpts struct {
+	//
+	// An SPDX licence expression for the content, e.g. MIT or Apache-2.0.
+	//
+	License string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L102)
+	//
+	// How the contribution is named in the image's document. Defaults to
+	// the file's own name.
+	//
+	Name string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L107)
+	//
+	// The version of the contributed content, if it has one.
+	//
+	Version string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L111)
+}
+
+// FileDocument produces the SPDX document required to contribute file to an
+// image, for content whose ecosystem has no module able to produce one.
+//
+// The document describes exactly one package — the file — with the SHA-256
+// of its bytes. Files are not enumerated inside it, because the package is
+// one file and a file list would restate the checksum that is already there;
+// what the image-level document then contains is the file, named and hashed.
+//
+// license is an SPDX licence expression such as MIT, Apache-2.0 or
+// "Apache-2.0 WITH LLVM-exception". Leaving it out publishes NOASSERTION,
+// which is the honest answer and is not the same answer as a licence that was
+// looked for and not found.
+//
+// name overrides how the contribution is identified in the image's document.
+// It defaults to the file's own name, which is usually right; supply one when
+// the file's name is a build artifact rather than a description of it.
+//
+// version is what the contributed content is a version of. There is no
+// default: content with no ecosystem usually has no version, and inventing
+// one would put a value in a field consumers compare.
+func (r *Z5Labs) FileDocument(file *File, opts ...Z5LabsFileDocumentOpts) *File { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/document.go#L95)
+	assertNotNil("file", file)
+	q := r.query.Select("fileDocument")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `license` optional argument
+		if !querybuilder.IsZeroValue(opts[i].License) {
+			q = q.Arg("license", opts[i].License)
+		}
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
+		}
+	}
+	q = q.Arg("file", file)
+
+	return &File{
+		query: q,
+	}
+}
+
+// Go returns the Go language chain bound to source: the standardized
+// checks — gofmt, go vet, golangci-lint and `go test -race` — over a Go
+// source tree, configured by the chain's With* methods and run by its
+// terminal Ci, plus the build terminal App.
+//
+// This is what a Go library needs and all it needs, which is why there is
+// no library archetype: a library is a source tree you never call App on.
+// An application starts here too; the build and the publish sit downstream
+// of this chain rather than beside it.
+//
+// The returned object is GoChain rather than Go because the `go` module
+// this one depends on already owns that name — see GoChain's doc comment.
+func (r *Z5Labs) Go(source *Directory) *Z5LabsGoChain { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/main.go#L655)
+	assertNotNil("source", source)
+	q := r.query.Select("go")
 	q = q.Arg("source", source)
 
-	return &Z5LabsGoLib{
+	return &Z5LabsGoChain{
 		query: q,
 	}
 }
@@ -450,6 +500,164 @@ func (r *Z5Labs) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// ImageConfigSelfTest checks the rule every published image is held to: its
+// OCI configuration is exactly what expectedImageConfig describes — the
+// standardized environment, the declared entrypoint, and nothing else — and
+// any difference from it is refused.
+//
+// It sits on the module rather than in tests/ because the rule it checks is
+// unexported and, more to the point, because its most important cases cannot
+// be reached from tests/ at all. Nothing caller-facing can put a variable, a
+// label, a port, a working directory or a default argument on an image, which
+// is by design; the consequence is that every branch refusing one is
+// unexecutable through the public API, so a suite built out of real images can
+// only ever exercise the passing case. Splitting the comparison out and
+// driving it here is what makes those refusals guarantees rather than comments
+// — delete one and this check goes red.
+//
+// The empty expectations are the half worth insisting on. An image that
+// promises no working directory, no default arguments, no exposed ports and no
+// labels promises those things exactly as much as it promises its PATH, and
+// every one of them would be inherited from a base layer the moment this
+// module builds on one (devex#426).
+//
+// It also pins the shape of the standardized set: that it is PATH, HOME and
+// TMPDIR and nothing else, that each is the constant that names it, and that
+// the plugin directory is on the PATH.
+//
+// It does **not** pin the values, and the distinction is worth stating because
+// the check below reads like it does. The comparison is against the same
+// constants expectedImageEnv returns, so it catches a fourth variable, a
+// missing one, or a literal written into expectedImageEnv beside the constant
+// — drift between the map and the constants — and not a constant that moved.
+// Moving one is what breaks published Dockerfiles and deployed manifests, and
+// the pin that catches it is the deliberately literal one in tests/, beside
+// wantImagePath. Two literal copies here would be a third place to update and
+// a second place to get it wrong.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) ImageConfigSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/selftest.go#L245)
+	if r.imageConfigSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("imageConfigSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// ImageSbomSelfTest checks the rule the image-level documents exist to keep:
+// everything that entered the image is in them, once, and the two formats
+// say the same thing about it.
+//
+// It sits on the module rather than in tests/ for the reason
+// ImageConfigSelfTest records, and for one more that is specific to
+// this rule. The interesting case is an image assembled from *several*
+// sources. App.WithFile and App.WithDirectory do now put a second contribution
+// into an image — AppCustomizedImageStaysAttested publishes one and reads the
+// documents back — but a real publish per case is not a way to drive a
+// de-duplication table: the case that matters here is two contributions
+// sharing a component, which needs two ecosystem documents and a synthesized
+// overlap rather than a certificate bundle. Driving the assembly directly is
+// what makes the de-duplication and the cross-format agreement guarantees
+// rather than comments.
+//
+// It runs in process over synthesized documents and needs no container, so it
+// is cheap enough to be a check of its own.
+func (r *Z5Labs) ImageSbomSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/sbomselftest.go#L36)
+	if r.imageSbomSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("imageSbomSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// SourceRedactionSelfTest checks redactURLCredentials against the rule rather
+// than against a publish: no remote reaches
+// org.opencontainers.image.source carrying userinfo, and an SSH remote —
+// whose username is part of the address — survives untouched.
+//
+// It is a check of its own because the failure it guards cannot be seen from
+// a publish. A remote whose credential leaks produces an image that builds,
+// pushes and runs exactly like one whose credential was stripped; the
+// difference is a field on a manifest that anyone who can pull the image can
+// read, discovered by whoever reads it rather than by this pipeline. And the
+// inputs that leak are the ones a working tree cannot easily be made to have:
+// driving them through GoChain.gitFacts would mean a container, a repository
+// and a remote URL that git itself would have to accept, per row.
+//
+// It sits on the module rather than in tests/ for the same reason
+// VersionTagsSelfTest does — the function is unexported — and because a table
+// of a dozen remotes costs one in-process call here.
+//
+// The rows are the shapes that distinguish the rule, including the accepting
+// ones. A redactor that returned the empty string for everything would pass a
+// table of leaking inputs alone while deleting the annotation from every
+// image this module publishes.
+//
+// Nothing here quotes an input. url.Parse's own error is the reason the habit
+// is worth keeping: it renders as `parse "<the whole URL>": invalid URL
+// escape "%zz"`, credential included, so a redactor that reported why it
+// could not parse would leak by exactly the path this check closes. The
+// assertions below print a row's name and its expectation, and print what
+// came back only after establishing that it does not carry the credential.
+func (r *Z5Labs) SourceRedactionSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/annotationsselftest.go#L54)
+	if r.sourceRedactionSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("sourceRedactionSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// VariantSetSelfTest checks the rules that decide which sets of prebuilt
+// executables can become an application, and which cannot.
+//
+// It sits on the module for the reason ContributionPathSelfTest and
+// ImageConfigSelfTest do: the rules are unexported pure functions, and
+// driving every branch of them through the public API would mean compiling a
+// real executable per row of the tables below. The end-to-end half — that the
+// refusals really are wired into WithVariant and Build, and that an accepted
+// set produces an image that runs — is in tests/, where it costs one
+// application instead of a dozen.
+//
+// It runs in process and needs no container, so it is cheap enough to be a
+// check of its own.
+func (r *Z5Labs) VariantSetSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuiltselftest.go#L27)
+	if r.variantSetSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("variantSetSelfTest")
+
+	return q.Execute(ctx)
+}
+
+// VersionTagsSelfTest checks the tag family a release is published under,
+// case by case, against the rule rather than against a release.
+//
+// It is a check of its own because the failure it guards is not one a
+// publish can show you. A derivation that moves a tag it should not have —
+// a prerelease that walks `v1`, a date-shaped version that invents a
+// `2026.08` — succeeds at the registry and is discovered by a consumer whose
+// `FROM` line resolved to something they never asked for, by which time it
+// is published and someone has pulled it. So every shape that distinguishes
+// the rule is stated here, including the accepting ones: a derivation that
+// published one tag for everything would pass a table of prereleases alone.
+//
+// It sits on the module rather than in tests/ for the same reason
+// ImageEnvironmentSelfTest does — the function is unexported — and because a
+// table of thirty versions costs one in-process call here and thirty
+// publishes there.
+func (r *Z5Labs) VersionTagsSelfTest(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/selftest.go#L29)
+	if r.versionTagsSelfTest != nil {
+		return nil
+	}
+	q := r.query.Select("versionTagsSelfTest")
+
+	return q.Execute(ctx)
+}
+
 // AsNode returns this Z5Labs as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Z5Labs) AsNode() Node {
@@ -458,44 +666,136 @@ func (r *Z5Labs) AsNode() Node {
 	}
 }
 
-// Builder produces the same image GoApp.Ci would publish, single-arch
-// (host platform). Used for local development to verify the artifact
-// before pushing. Both of its functions route through the same
-// per-platform build Ci uses, so the binary carries the same version and
-// commit stamp and a local build is the same artifact.
-type Z5LabsBuilder struct { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L15)
+// App is a built application: one container image per platform, the
+// documents describing each of them, and the version they all carry.
+// Construct it with GoChain.App and publish it with Publish.
+//
+// # It does not know what built it
+//
+// App holds images, documents and build facts — never a binary, never a
+// source tree, never a name. That is why there is no binary-name input and
+// no Binary accessor: an application's binary name is a detail of the
+// language chain that compiled it, and an App that carried one would make
+// every future chain — a Zig chain, a Java chain, an App assembled from
+// nothing at all — have to invent one.
+//
+// The consequence worth stating is that App cannot describe its own
+// contents. `dag.Go().Spdx(binary, source)` needs both of the things App
+// refuses to hold, so a document is produced by whoever contributed each
+// thing in the image and carried here as one file per contribution. Publish
+// assembles them into the SPDX and CycloneDX pair it attaches, and the `oci`
+// module that does the attaching never learns that any of it is an SBOM —
+// the separation daggerverse/CLAUDE.md asks for. It costs nothing, because
+// dag.Go().Spdx returns a lazy *dagger.File that no unpublished app ever
+// evaluates. sbom.go carries the whole arrangement and why the documents
+// describe the image rather than the binary.
+//
+// # Configuration is chained, not constructed
+//
+// Where the images are published, whose identity vouches for them and
+// whether the connection is verified are all With* methods rather than
+// constructor arguments, because none of them is a property of the
+// artifact. The same App can be published to a mirror, to an internal
+// registry, or nowhere at all.
+type Z5LabsApp struct { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L45)
 	query *querybuilder.Selection
 
 	id *ID
 }
+type WithZ5LabsAppFunc func(r *Z5LabsApp) *Z5LabsApp
 
-func (r *Z5LabsBuilder) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsBuilder {
-	return &Z5LabsBuilder{
+// With calls the provided function with current Z5LabsApp.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Z5LabsApp) With(f WithZ5LabsAppFunc) *Z5LabsApp {
+	return f(r)
+}
+
+func (r *Z5LabsApp) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsApp {
+	return &Z5LabsApp{
 		query: q,
 	}
 }
 
-// Binary returns the host-platform compiled binary as a *dagger.File.
-func (r *Z5LabsBuilder) Binary() *File { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L44)
-	q := r.query.Select("binary")
-
-	return &File{
-		query: q,
-	}
-}
-
-// Container returns the host-platform scratch image containing the
-// compiled binary at /app/<binaryName> with that path as entrypoint.
-func (r *Z5LabsBuilder) Container() *Container { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/builder.go#L24)
+// Container returns the image built for platform.
+//
+// This is the same container Publish pushes, not a second build that merely
+// agrees with it: GoChain.App and this method are both session-cached, so
+// within one chained call the app is built once and everything downstream —
+// a check on the image, the publish, an export — sees those exact bytes.
+// That is what makes a check seam meaningful, and it is why the caching is
+// part of the API rather than an optimization.
+//
+// The guarantee is bounded by the session. Two separate `dagger call`
+// invocations are two sessions and two builds, and while a build of one
+// (commit, version) pair is byte-identical to another by construction,
+// nothing here promises that the second invocation reuses the first's
+// containers. A caller that needs one build inspected and then published
+// chains both onto one call.
+//
+// What this container has *not* been through is the image-configuration
+// check. That is a publish-time gate — App.Publish holds every variant to
+// expectedImageConfig before the first byte moves — and it deliberately does
+// not run here. An inspection seam exists for the image that is wrong as much
+// as for the one that is right, and a Container that refused to hand back a
+// container whose configuration failed the gate would withhold the bytes at
+// exactly the moment somebody is trying to find out what is wrong with them;
+// `docker load` and a look at the config is how that is done.
+//
+// That is a statement about *this module's* publish path and not a guarantee
+// about the bytes. What comes back is an ordinary core Container, and a caller
+// who wants to can push it themselves — `container --platform=linux/amd64
+// publish --address=…` — which goes round this gate exactly as it goes round
+// the annotations, the assembled SBOMs, the provenance and the signature that
+// make a z5labs release what it is. An image that leaves through Publish has
+// been checked; an image somebody exported from here and pushed by hand is
+// theirs.
+func (r *Z5LabsApp) Container(platform Platform) *Container { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L222)
 	q := r.query.Select("container")
+	q = q.Arg("platform", platform)
 
 	return &Container{
 		query: q,
 	}
 }
 
-// A unique identifier for this Z5LabsBuilder.
-func (r *Z5LabsBuilder) ID(ctx context.Context) (ID, error) {
+// Containers returns every platform's image, in the order the platforms
+// were given to App. Same guarantee, and the same session bound, as
+// Container.
+func (r *Z5LabsApp) Containers(ctx context.Context) ([]Container, error) { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L236)
+	q := r.query.Select("containers")
+
+	q = q.Select("id")
+
+	type containers struct {
+		Id ID
+	}
+
+	convert := func(fields []containers) []Container {
+		out := []Container{}
+
+		for i := range fields {
+			val := Container{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "Container")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []containers
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
+// A unique identifier for this Z5LabsApp.
+func (r *Z5LabsApp) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
@@ -508,17 +808,17 @@ func (r *Z5LabsBuilder) ID(ctx context.Context) (ID, error) {
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
-func (r *Z5LabsBuilder) XXX_GraphQLType() string {
-	return "Z5LabsBuilder"
+func (r *Z5LabsApp) XXX_GraphQLType() string {
+	return "Z5LabsApp"
 }
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
-func (r *Z5LabsBuilder) XXX_GraphQLIDType() string {
+func (r *Z5LabsApp) XXX_GraphQLIDType() string {
 	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
-func (r *Z5LabsBuilder) XXX_GraphQLID(ctx context.Context) (string, error) {
+func (r *Z5LabsApp) XXX_GraphQLID(ctx context.Context) (string, error) {
 	id, err := r.ID(ctx)
 	if err != nil {
 		return "", err
@@ -526,97 +826,515 @@ func (r *Z5LabsBuilder) XXX_GraphQLID(ctx context.Context) (string, error) {
 	return string(id), nil
 }
 
-func (r *Z5LabsBuilder) MarshalJSON() ([]byte, error) {
+func (r *Z5LabsApp) MarshalJSON() ([]byte, error) {
 	id, err := r.ID(marshalCtx)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(id)
 }
-func (r *Z5LabsBuilder) UnmarshalJSON(bs []byte) error {
+func (r *Z5LabsApp) UnmarshalJSON(bs []byte) error {
 	var id string
 	err := json.Unmarshal(bs, &id)
 	if err != nil {
 		return err
 	}
-	*r = Z5LabsBuilder{query: selectNode(dag.query, id, "Z5LabsBuilder")}
+	*r = Z5LabsApp{query: selectNode(dag.query, id, "Z5LabsApp")}
 	return nil
 }
 
-// AsNode returns this Z5LabsBuilder as a Node.
+// Publish pushes this app to every repository named and returns one
+// digest-pinned reference per published tag.
+//
+// Each repository is a *path* appended to the address given to
+// WithRegistry: "z5labs/hello" against "ghcr.io" publishes
+// ghcr.io/z5labs/hello. The registry stays a separate input because a
+// mirror or an internal registry serves the same release, and the
+// repository is stated here rather than derived from the binary because the
+// two are not the same thing — a binary called `hello` is routinely
+// published as `hello-service`.
+//
+// One manifest list is pushed per repository, naming every platform
+// variant, so a consumer pulls a repository and gets their architecture.
+// The returned references are `<address>/<repository>:<tag>@<digest>`:
+// pinned, because a tag is a mutable name and a caller anchoring a
+// deployment or a release note to what shipped has to be able to name
+// immutable bytes.
+//
+// # One release, a family of tags
+//
+// A release is published under every tag its version implies, not under the
+// version alone: `v1.2.3` also comes to name `v1.2`, `v1` and `latest`, so a
+// consumer can pin at the level of risk they want. Every tag of one release
+// names one digest — the same manifest list, pushed once — and one reference
+// comes back per tag, in the order the tags were written.
+//
+// A SemVer **prerelease** publishes its own full version tag and moves none
+// of the moving ones, and a version that is not SemVer publishes as a single
+// tag. versionTags derives the family and is where those rules are stated;
+// it is a pure function of the version, so what it cannot see — a release
+// published out of order walking `v1` backwards — is recorded there too.
+//
+// # How to read what comes back
+//
+// The references are grouped **repository-major**: every tag of the first
+// repository, in family order, then every tag of the second. The first
+// reference of each group is the immutable one — the full version — so the
+// reference a caller pins a deployment or a release note to is
+// `refs[i*len(family)]`, and a caller who does not want to know the family's
+// size can take the references whose tag is the version they passed.
+//
+// This was one reference per repository before the family existed, so a
+// caller indexing `refs[i]` per repository reads a tag of the first
+// repository now rather than the reference for `repositories[i]`. The
+// grouping is stated here because there is nowhere better: a structured
+// return — a repository, a digest and its tags — is the shape this wants,
+// and it is a schema object that every consumer of this module would have to
+// take a binding for, so it is worth doing deliberately rather than as part
+// of this change.
+//
+// Every published digest carries an SPDX and a CycloneDX document per
+// platform and a signed SLSA provenance statement whose build identity
+// comes from an exchanged workload identity token. A publish that cannot
+// produce provenance fails rather than publishing without it — see
+// newSigner — and so does one that cannot produce a complete document for
+// every platform, for the same reason and by the same rule.
+//
+// Those two documents describe the *image*: every byte in it, not only the
+// executable a language chain built. They are assembled here, at publish
+// time, out of one document per thing that entered the image, and they
+// replace those rather than sitting beside them — a consumer fetches two
+// documents per platform and nothing else. sbom.go records why the subject
+// is the image, why assembly is not a scan, and what a contribution has to
+// supply.
+//
+// Those documents are attached as OCI referrers of the digest and are
+// discoverable that way alone, so `cosign verify-attestation` finds nothing
+// even though they are there. The package doc says why and gives the
+// `oras discover` commands that do find them; a consumer pointed at this
+// method needs that section too.
+//
+// The image is signed too, and not merely the provenance statement about
+// it: the manifest list and every per-platform manifest beneath it each
+// carry a cosign signature, so a consumer runs
+//
+//	cosign verify <address>/<repository>:<version> \
+//	  --certificate-identity-regexp '^https://github.com/<owner>/<repo>/\.github/workflows/' \
+//	  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+//
+// against the tag, and the same command against any per-platform digest
+// their runtime resolved. Both pass, which is the point of signing every
+// manifest rather than only the one the tag names — see signImage. A
+// publish that cannot sign fails in the same way and for the same reason as
+// one that cannot attest. WithSigningKey changes the verifying command; its
+// doc comment says how.
+//
+// Within one repository the tag is the last thing written: the manifest list
+// goes up under its own digest, the attestations are attached to that digest,
+// and only then does the tag come to name it. So a publish that fails leaves
+// no tag pointing at an unattested image — it leaves an unreferenced manifest,
+// or, when the version was already published, the previous release still in
+// place. attachAttestations records why that ordering was chosen and what the
+// alternatives cost.
+//
+// Repositories are published in the order given, and the operation is not
+// atomic: a failure part way through leaves the earlier repositories
+// published, and says which ones in its error. A registry has no transaction
+// spanning repositories, so the alternative to saying so is not atomicity —
+// it is a caller who cannot tell what shipped.
+//
+// Publishing is a side effect against an external registry, so it is
+// uncached: a re-run must actually push. The build above it is session
+// cached, so the bytes pushed are the bytes Container returned.
+func (r *Z5LabsApp) Publish(ctx context.Context, repositories []string) ([]string, error) { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L531)
+	q := r.query.Select("publish")
+	q = q.Arg("repositories", repositories)
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// WithApp composes another application's payload into every platform of this
+// one's image.
+//
+// The result is an ordinary App: published, annotated, signed and attested
+// exactly like any other, to a repository of its own that has nothing to do
+// with any binary's name. What comes out is the base program wearing one more
+// executable — it keeps the base's entrypoint, user, environment and
+// executable directory, and it is published under the base's version, because
+// the release it belongs to is the base's release.
+//
+// from's entry lands in the standardized plugin directory under its own file
+// name, so a base image whose CLI discovers plugins on the PATH finds it
+// without either side agreeing on anything but that directory. Everything else
+// from carries — its contributed files and directories — lands at its own
+// path. The file comment above records why the entry is read from the
+// declaration rather than from the entrypoint, and it is the single most
+// important thing about this method.
+//
+// There is no path argument and nothing is inferred. A composed application is
+// composed whole or refused: see the file comment for the four refusals and
+// why each is a failure that would otherwise publish cleanly and die on first
+// exec.
+//
+// Composition is not restricted to applications this module compiled, and a
+// derived image may be composed into in turn — the payload of the result is
+// the union of both sides', the collision surface grows and the semantics do
+// not. What gets nothing from this seam is an out-of-pipeline image built
+// `FROM` a published base: a stranger's Dockerfile adds bytes with no document
+// and has no mechanism to produce one, so that image's attestation describes
+// the base and nothing else.
+func (r *Z5LabsApp) WithApp(from *Z5LabsApp) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/compose.go#L168)
+	assertNotNil("from", from)
+	q := r.query.Select("withApp")
+	q = q.Arg("from", from)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithDirectory contributes a directory tree to every platform's image at
+// path.
+//
+// The tree lands at path in each variant, mode 0555 throughout, owned by the
+// image's non-root user. The mode is uniform — every file inside it is 0555
+// too, rather than 0444 under a traversable parent — and the comment on
+// contributedDirectoryMode above records why that is accepted rather than
+// worked around.
+//
+// An executable inside such a tree is therefore executable, and that is not a
+// way to extend the image: like WithFile, this refuses a path at, under or over
+// any directory the image's PATH resolves against, so nothing a caller
+// contributes is ever discovered on the PATH by name. Wrapping a binary in a
+// directory used to be exactly that bypass — see the file comment above and
+// App.WithApp, which is the seam that names the platform of every byte it
+// brings.
+//
+// The tree may hold directories and regular files and nothing else. A
+// symbolic link in it is refused — when the document is produced, and again at
+// publish time for a caller who brought one of their own — because a link is
+// the one kind of content none of the rules here can see: it is not given the
+// mode, the path it names is not compared against anything, and it is in no
+// document and no digest. The file comment above carries the decision and what
+// was measured to reach it; contribute what the link pointed at instead.
+//
+// document is an SPDX 2.3 JSON document describing the tree, and it is
+// required for the reason WithFile's is. Z5labs.DirectoryDocument produces one
+// for content with no ecosystem, and it enumerates: the document it writes
+// carries one file element per file in the tree, because "the contribution is
+// described" and "every file in the image is accounted for" are different
+// promises and only the second one is the point.
+func (r *Z5LabsApp) WithDirectory(path string, dir *Directory, document *File) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/contribute.go#L341)
+	assertNotNil("dir", dir)
+	assertNotNil("document", document)
+	q := r.query.Select("withDirectory")
+	q = q.Arg("path", path)
+	q = q.Arg("dir", dir)
+	q = q.Arg("document", document)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithFile contributes a file to every platform's image at path.
+//
+// The file lands at path in each variant, mode 0444, owned by the image's
+// non-root user. Neither the mode nor the owner is a caller's to state: see
+// the file comment above.
+//
+// document is an SPDX 2.3 JSON document describing what is in the file, and it
+// is required — content arrives described or it does not arrive, because the
+// documents a publish attaches describe the whole image rather than the binary
+// a chain built. Z5labs.FileDocument produces one for content with no
+// ecosystem, computing the digests itself; content that *has* an ecosystem
+// should carry that ecosystem's document, the way a Go binary carries
+// dag.Go().Spdx.
+//
+// The bytes are platform-neutral by construction: one *dagger.File is
+// contributed to every variant. That is why there is no WithExecutable beside
+// this — a raw file carries no platform, so a helper landing one in the
+// executable directory would silently admit a binary built for the wrong
+// architecture — and it is why a path at, under or over any directory the
+// image's PATH resolves against is refused here rather than merely being
+// useless. Platform-specific executables arrive as an App instead: App.WithApp
+// composes one, matched platform by platform, and lands its entry in the plugin
+// directory.
+func (r *Z5LabsApp) WithFile(path string, file *File, document *File) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/contribute.go#L281)
+	assertNotNil("file", file)
+	assertNotNil("document", document)
+	q := r.query.Select("withFile")
+	q = q.Arg("path", path)
+	q = q.Arg("file", file)
+	q = q.Arg("document", document)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithInsecure publishes over plain HTTP with no TLS verification.
+//
+// It is off unless a caller asks for it, and it is deliberately not
+// inferred from WithRegistryService being set: that inference made a caller
+// who supplied a service for their own reasons silently publish over an
+// unverified connection. It is spelled insecure rather than tlsVerify
+// because a bool defaulting to true cannot be turned off from the CLI —
+// which is also why this method takes no argument at all.
+func (r *Z5LabsApp) WithInsecure() *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L329)
+	q := r.query.Select("withInsecure")
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithOidc supplies the CI provider's OIDC token request machinery, which
+// is what a publish signs its provenance with.
+//
+// requestUrl is the token request endpoint — ACTIONS_ID_TOKEN_REQUEST_URL
+// on GitHub Actions, and whatever the equivalent is elsewhere.
+// requestToken is the bearer for it, a secret because it is a credential
+// for minting identity tokens.
+//
+// There is deliberately no repository, ref or commit parameter beside them.
+// Every identifying field in the provenance comes out of the exchanged
+// token's claims, because anything a caller could have supplied attests to
+// nothing.
+func (r *Z5LabsApp) WithOidc(requestUrl string, requestToken *Secret) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L283)
+	assertNotNil("requestToken", requestToken)
+	q := r.query.Select("withOidc")
+	q = q.Arg("requestUrl", requestUrl)
+	q = q.Arg("requestToken", requestToken)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithOidcService points the token exchange at a Dagger-hosted OIDC
+// endpoint, reached over the session network instead of the public one.
+// Its engine-assigned endpoint replaces the host in WithOidc's requestUrl;
+// the path and query stay the caller's, because those are part of the
+// provider's protocol.
+//
+// This exists for the same reason WithRegistryService does, and is used by
+// the test suite, which runs a real token endpoint rather than relaxing the
+// provenance requirement into the shape of the tests.
+func (r *Z5LabsApp) WithOidcService(svc *Service) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L359)
+	assertNotNil("svc", svc)
+	q := r.query.Select("withOidcService")
+	q = q.Arg("svc", svc)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithRegistry sets the registry to publish to.
+//
+// address is the registry alone — "ghcr.io", "registry.example.internal:5000"
+// — and never a repository path. The repository is stated to Publish, so
+// that the same app can go to a mirror or to an internal registry by
+// changing this and nothing else.
+//
+// username and auth are the credential. There is no unauthenticated
+// publish: a registry that accepts anonymous writes is one this pipeline
+// has no way to tell from a misconfigured one.
+//
+// The +cache directive is repeated here rather than stated once for the
+// chain: caching is per function in Dagger, so a chained method left
+// undirected takes the default seven-day TTL and can hand a later session a
+// stale object built from arguments it only appears to share — a registry
+// service, for one, whose engine-assigned address is long gone.
+func (r *Z5LabsApp) WithRegistry(address string, username string, auth *Secret) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L262)
+	assertNotNil("auth", auth)
+	q := r.query.Select("withRegistry")
+	q = q.Arg("address", address)
+	q = q.Arg("username", username)
+	q = q.Arg("auth", auth)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithRegistryService points the publish at a Dagger-hosted registry
+// reached over the session network instead of over the public network.
+//
+// A service's endpoint is assigned by the engine, so it cannot be written
+// into an address ahead of time; this is how the publish learns it. Used by
+// the test suite against a local registry, and by anyone whose private
+// registry is itself a Dagger service.
+func (r *Z5LabsApp) WithRegistryService(svc *Service) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L343)
+	assertNotNil("svc", svc)
+	q := r.query.Select("withRegistryService")
+	q = q.Arg("svc", svc)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithSessionSigstore points keyless signing at a certificate authority and
+// a transparency log running inside this Dagger session, instead of at the
+// public sigstore.
+//
+// It exists so the keyless path can be *executed* rather than only
+// described: without it, the certificate request, the chain split, the log
+// uploads — the image signatures' and the provenance envelope's — and the
+// three annotations that carry them are reachable only by publishing a real
+// release. The suite stands up a CA of its own and
+// verifies the result with stock `cosign verify --certificate-identity`,
+// which is the command Publish's doc comment tells consumers to run.
+//
+// # What it takes to redirect a real publish with this
+//
+// Deliberate work, which is the property being bought — not impossibility,
+// which would be a stronger claim than the type supports. A *dagger.Service
+// is a container the caller controls, and a container can proxy: a service
+// running `socat` forwards a certificate request, workload identity token
+// and all, straight out of the session. So this is not a boundary; it is a
+// seam that cannot be crossed by accident. Three decisions make that so:
+//
+//   - It takes services, never URLs. There is no string argument here for a
+//     typo, an inherited environment variable or a templated value to land
+//     in, which is the whole class of accident a `--fulcio-url` flag would
+//     have opened: one wrong character and a release is certified by
+//     somebody else's CA. Redirecting this one takes a caller writing a
+//     service and passing it, which is not a thing that happens to a release
+//     pipeline unattended.
+//   - Both are required, in one call. A publish is either wholly against a
+//     session-hosted sigstore or wholly against the public one; there is no
+//     state in which the certificate comes from one place and the log entry
+//     from another, which is incoherent rather than merely unusual. A pair
+//     that arrives half set is refused rather than quietly completed from
+//     the public sigstore — see sigstoreEndpoints.
+//   - It is never inferred. Not from WithRegistryService, not from
+//     WithOidcService, not from WithInsecure — inferring it from the shape
+//     of a test session is the relaxation daggerverse/CLAUDE.md names, and
+//     it would leave the production path as the only unexercised one, which
+//     is the situation this method exists to end.
+//
+// It also conflicts with WithSigningKey rather than being ignored beside it.
+// A supplied key is never certified by anything, so a call setting both has
+// asked for two different modes; Publish refuses instead of picking one
+// silently.
+//
+// The name says "session" for the same reason WithInsecure says "insecure":
+// this method's job is to be conspicuous in a file where it does not belong.
+// A release pipeline signing against a sigstore that exists only for the
+// length of one build is a thing a reader should stop at.
+//
+// What a session-hosted sigstore cannot establish is stated where it is
+// asserted: a local log's countersignature is trusted by nobody, so a
+// verifier still has to be told to ignore the log, and nothing here says
+// anything about the public services' availability.
+func (r *Z5LabsApp) WithSessionSigstore(fulcio *Service, rekor *Service) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L420)
+	assertNotNil("fulcio", fulcio)
+	assertNotNil("rekor", rekor)
+	q := r.query.Select("withSessionSigstore")
+	q = q.Arg("fulcio", fulcio)
+	q = q.Arg("rekor", rekor)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// WithSigningKey signs the provenance with a caller-supplied PEM-encoded EC
+// private key instead of an ephemeral key certified by the public sigstore
+// CA.
+//
+// This selects the signing mode and nothing else: the workload identity
+// token is still exchanged, and the predicate still says only what that
+// token's claims say. Use it for a build that cannot reach a public CA.
+// Leaving it unset is keyless signing and is what a normal CI publish
+// should do.
+//
+// It changes what a consumer has to run, and the change is a downgrade
+// worth stating. Nothing certifies a supplied key, so there is no identity
+// to verify against and nothing to record in the public transparency log.
+// That covers both signed things: the image signature carries the signature
+// alone, and the provenance envelope carries a bare public key with no log
+// entry, where a keyless publish gives each of them a certificate and a
+// countersigned log entry. Verifying the image then means
+//
+//	cosign verify <ref> --key cosign.pub --insecure-ignore-tlog=true
+//
+// where the keyless mode gets an identity and an issuer and no such flag.
+// A caller who does not want to hand their consumers that flag should not
+// be supplying a key.
+func (r *Z5LabsApp) WithSigningKey(key *Secret) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/app.go#L314)
+	assertNotNil("key", key)
+	q := r.query.Select("withSigningKey")
+	q = q.Arg("key", key)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// AsNode returns this Z5LabsApp as a Node.
 // This is a local type conversion — no GraphQL call.
-func (r *Z5LabsBuilder) AsNode() Node {
+func (r *Z5LabsApp) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}
 }
 
-// GoApp is the application archetype. Construct via Z5labs.GoApp.
-type Z5LabsGoApp struct { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L14)
+// AppBuilder assembles an App from executables somebody else built: one
+// entry per platform, each with the document describing it, terminated by
+// Build.
+//
+// Construct it with Z5labs.App. The file comment above records why the
+// intermediate type exists at all and why it is this shape.
+type Z5LabsAppBuilder struct { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L73)
 	query *querybuilder.Selection
 
-	ci *string
 	id *ID
 }
+type WithZ5LabsAppBuilderFunc func(r *Z5LabsAppBuilder) *Z5LabsAppBuilder
 
-func (r *Z5LabsGoApp) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsGoApp {
-	return &Z5LabsGoApp{
+// With calls the provided function with current Z5LabsAppBuilder.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Z5LabsAppBuilder) With(f WithZ5LabsAppBuilderFunc) *Z5LabsAppBuilder {
+	return f(r)
+}
+
+func (r *Z5LabsAppBuilder) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsAppBuilder {
+	return &Z5LabsAppBuilder{
 		query: q,
 	}
 }
 
-// Builder returns the local-dev sibling that produces the same image CI
-// would publish, single-arch (host platform).
-func (r *Z5LabsGoApp) Builder() *Z5LabsBuilder { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L380)
-	q := r.query.Select("builder")
+// Build packages every contributed executable as an image and returns the
+// application.
+//
+// This is where an empty variant set is refused. An App with no variants is
+// publishable-looking and publishes nothing, and — because WithFile and
+// WithDirectory apply content to every variant there is — it would swallow
+// every contribution made to it without a word. Build existing is what keeps
+// that state out of an App entirely.
+//
+// The version is validated here rather than by the constructor, which has no
+// way to report an error. Publish validates it a third time, which is what
+// keeps the refusal of SemVer build metadata a property of publishing rather
+// than of one constructor.
+func (r *Z5LabsAppBuilder) Build() *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L318)
+	q := r.query.Select("build")
 
-	return &Z5LabsBuilder{
+	return &Z5LabsApp{
 		query: q,
 	}
 }
 
-// Ci runs the standardized GoApp pipeline: verify .git exists, run the
-// shared check stages (fmt+vet+lint+test -race) once, build a scratch
-// image per platform, then conditionally publish per the publishOn
-// filter.
-//
-// It returns the digest of what was published — the manifest list naming
-// every platform variant, or the single image manifest when only one
-// platform was built. Every matching ref publishes the same bytes under
-// its own tag, so one digest describes them all. A run that publishes
-// nothing — no ref matched, or no registry was configured — returns the
-// empty string rather than an error.
-//
-// Returning the digest rather than only an error is what lets a caller
-// reference what was published: an attestation, a deployment manifest or
-// a release note has to name an immutable artifact, and a tag is not one.
-//
-// Every published image carries the standard OCI source annotations —
-// revision, source, created, and version on a tag build — on each
-// platform variant, and every published digest carries three
-// attestations: an SPDX and a CycloneDX SBOM per platform, produced by
-// the `go` module from the binaries this pipeline compiled, and a signed
-// SLSA provenance statement whose build identity comes from an exchanged
-// workload identity token. A publish that cannot produce provenance
-// fails rather than publishing without it.
-//
-// Publish is a side-effecting operation against an external registry, so
-// the whole pipeline is uncached — re-runs (e.g. after a retry, or after
-// a new ref appears within the same engine session) must actually push.
-func (r *Z5LabsGoApp) Ci(ctx context.Context) (string, error) { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/goapp.go#L80)
-	if r.ci != nil {
-		return *r.ci, nil
-	}
-	q := r.query.Select("ci")
-
-	var response string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-// A unique identifier for this Z5LabsGoApp.
-func (r *Z5LabsGoApp) ID(ctx context.Context) (ID, error) {
+// A unique identifier for this Z5LabsAppBuilder.
+func (r *Z5LabsAppBuilder) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
@@ -629,17 +1347,17 @@ func (r *Z5LabsGoApp) ID(ctx context.Context) (ID, error) {
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
-func (r *Z5LabsGoApp) XXX_GraphQLType() string {
-	return "Z5LabsGoApp"
+func (r *Z5LabsAppBuilder) XXX_GraphQLType() string {
+	return "Z5LabsAppBuilder"
 }
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
-func (r *Z5LabsGoApp) XXX_GraphQLIDType() string {
+func (r *Z5LabsAppBuilder) XXX_GraphQLIDType() string {
 	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
-func (r *Z5LabsGoApp) XXX_GraphQLID(ctx context.Context) (string, error) {
+func (r *Z5LabsAppBuilder) XXX_GraphQLID(ctx context.Context) (string, error) {
 	id, err := r.ID(ctx)
 	if err != nil {
 		return "", err
@@ -647,48 +1365,241 @@ func (r *Z5LabsGoApp) XXX_GraphQLID(ctx context.Context) (string, error) {
 	return string(id), nil
 }
 
-func (r *Z5LabsGoApp) MarshalJSON() ([]byte, error) {
+func (r *Z5LabsAppBuilder) MarshalJSON() ([]byte, error) {
 	id, err := r.ID(marshalCtx)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(id)
 }
-func (r *Z5LabsGoApp) UnmarshalJSON(bs []byte) error {
+func (r *Z5LabsAppBuilder) UnmarshalJSON(bs []byte) error {
 	var id string
 	err := json.Unmarshal(bs, &id)
 	if err != nil {
 		return err
 	}
-	*r = Z5LabsGoApp{query: selectNode(dag.query, id, "Z5LabsGoApp")}
+	*r = Z5LabsAppBuilder{query: selectNode(dag.query, id, "Z5LabsAppBuilder")}
 	return nil
 }
 
-// AsNode returns this Z5LabsGoApp as a Node.
+// Z5LabsAppBuilderWithVariantOpts contains options for Z5LabsAppBuilder.WithVariant
+type Z5LabsAppBuilderWithVariantOpts struct {
+	//
+	// What the executable is called in the image. Defaults to the file's
+	// own name.
+	//
+	Name string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L253)
+}
+
+// WithVariant contributes one platform's executable, and the document
+// describing it.
+//
+// platform is stated rather than inferred, and that is the rule the whole
+// design turns on. A *dagger.File carries no architecture, so a helper that
+// took an executable and worked out where it belonged would silently admit
+// the failure devex#397 exists to refuse: an index whose arm64 manifest holds
+// an amd64 binary, which fails at exec time with the kernel's message and for
+// nobody here. Nothing in this module infers a platform from a file.
+//
+// entry becomes the image's entrypoint. It lands in the standardized
+// executable directory, mode 0555, owned by the image's non-root user — the
+// same treatment a compiled binary gets, because it goes through the same
+// code.
+//
+// name is what it lands as, and it defaults to the file's own name. Supply one
+// when the artifact's file name is not what the application should be called,
+// which is the common case for prebuilt binaries: a release pipeline names its
+// cross-compiled artifacts app-amd64 and app-arm64, and the entry has to be
+// one path in every variant or the entrypoint differs per architecture. Given
+// no name and per-platform file names, this refuses the set rather than
+// picking one — so `--name` is how a normal `dist/` directory is contributed,
+// and the default is for the case where the file is already called the right
+// thing.
+//
+// document is an SPDX 2.3 JSON document describing the executable, and it is
+// required for the reason every contribution's is: the SBOM a publish attaches
+// accounts for the whole image, and a helper admitting undescribed content
+// would make that contract true by the letter and false in substance.
+// Z5labs.FileDocument produces one for an executable whose ecosystem has no
+// module able to; a Go binary should carry dag.Go().Spdx instead.
+//
+// # What is refused, and why each one is a real failure
+//
+// A platform contributed twice, because the second would silently replace the
+// first and the App would ship fewer architectures than it was asked for. A
+// platform that is not GOOS/GOARCH, because it cannot name a manifest. And an
+// entry whose file name differs from the entries already contributed, because
+// the entrypoint would then be a different path per architecture — a consumer
+// who overrides the entrypoint, or writes a COPY --from= line against the
+// image, would be right on one platform and wrong on another with nothing in
+// the manifest list to say so.
+//
+// A single-platform App is expressible and is not a degenerate case: one
+// WithVariant and a Build is a complete application, published as one variant
+// rather than as a multi-platform index pretending to be one.
+func (r *Z5LabsAppBuilder) WithVariant(platform Platform, entry *File, document *File, opts ...Z5LabsAppBuilderWithVariantOpts) *Z5LabsAppBuilder { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/prebuilt.go#L241)
+	assertNotNil("entry", entry)
+	assertNotNil("document", document)
+	q := r.query.Select("withVariant")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `name` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Name) {
+			q = q.Arg("name", opts[i].Name)
+		}
+	}
+	q = q.Arg("platform", platform)
+	q = q.Arg("entry", entry)
+	q = q.Arg("document", document)
+
+	return &Z5LabsAppBuilder{
+		query: q,
+	}
+}
+
+// AsNode returns this Z5LabsAppBuilder as a Node.
 // This is a local type conversion — no GraphQL call.
-func (r *Z5LabsGoApp) AsNode() Node {
+func (r *Z5LabsAppBuilder) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}
 }
 
-// GoLib is the library archetype. Construct via Z5labs.GoLib.
-type Z5LabsGoLib struct { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/golib.go#L10)
+// GoChain is the Go language chain: a source tree, and the standardized
+// checks over it. Construct via Z5labs.Go and call the terminal Ci.
+//
+// The type is not named Go, which is what the design called for, because
+// this module depends on the `go` module and that module's root object is
+// literally Go. A dependency's objects occupy their bare names in the
+// dependent module's type space, so a local object of the same name is
+// resolved as the dependency's and the module fails to load:
+//
+//	failed to add object to module "z5labs": failed to validate type def:
+//	object "Z5labs" function "Go" cannot return external type from
+//	dependency module "go"
+//
+// The *method* is unaffected — Z5labs.Go is the constructor and the CLI
+// path is still `dagger call go ...` — so the collision costs the type's
+// spelling and nothing else. See daggerverse/CLAUDE.md.
+//
+// The stages are not opt-in. Ci always runs fmt, vet, lint and test, which
+// is what makes "the z5labs pipeline ran" mean the same thing in every
+// repository that adopts it — the same guarantee the archetype factories
+// gave before this chain replaced them. The With* methods configure those
+// stages; none of them switches one on or off. A caller who wants a subset
+// is describing a different pipeline and should reach for the `go` module's
+// own Ci builder, which is exactly that: stages enabled one by one.
+//
+// A library is a Go you never build an application from, so there is no
+// separate library archetype.
+type Z5LabsGoChain struct { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L36)
 	query *querybuilder.Selection
 
 	ci *Void
 	id *ID
 }
+type WithZ5LabsGoChainFunc func(r *Z5LabsGoChain) *Z5LabsGoChain
 
-func (r *Z5LabsGoLib) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsGoLib {
-	return &Z5LabsGoLib{
+// With calls the provided function with current Z5LabsGoChain.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Z5LabsGoChain) With(f WithZ5LabsGoChainFunc) *Z5LabsGoChain {
+	return f(r)
+}
+
+func (r *Z5LabsGoChain) WithGraphQLQuery(q *querybuilder.Selection) *Z5LabsGoChain {
+	return &Z5LabsGoChain{
 		query: q,
 	}
 }
 
-// Ci runs the standardized check stages (fmt, vet, lint, test -race)
-// against the supplied library source.
-func (r *Z5LabsGoLib) Ci(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/47e25f065653c481a6d1567537307f2565bfa316/daggerverse/z5labs/golib.go#L24)
+// Z5LabsGoChainAppOpts contains options for Z5LabsGoChain.App
+type Z5LabsGoChainAppOpts struct {
+	//
+	// The package to build, in go build package syntax, relative to the
+	// source root.
+	//
+	//
+	// Default: "."
+	Pkg string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L196)
+	//
+	// The platforms to build for, e.g. linux/amd64. Empty takes the
+	// pipeline's pair, linux/amd64 and linux/arm64.
+	//
+	Platforms []Platform // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L201)
+}
+
+// App builds the application at pkg for every platform and returns it.
+//
+// One binary is cross-compiled per platform, stamped at link time with
+// version and with the commit; each is packaged as an image carrying the
+// module's standardized environment, the absolute entrypoint and the OCI
+// source annotations; and an SPDX document describing each binary is
+// generated for it. What comes back holds the images and those documents
+// and knows nothing about the chain that produced them — see App.
+//
+// The document per binary is a *contribution* document rather than the
+// image's. Publish assembles every contribution to an image into the SPDX
+// and CycloneDX pair it attaches, so what a consumer reads describes the
+// whole image; see sbom.go. For an app built only from a language chain the
+// image is the binary, so the two are the same set of components — which is
+// what makes this a change of subject rather than of content.
+//
+// # version is the caller's, and is validated here
+//
+// The version was a pure function of HEAD before this chain existed, which
+// suits a high-frequency install with no semantic versioning and does not
+// suit a project releasing on semver. It is now stated by whoever is
+// releasing, and the only thing this module has an opinion about is that it
+// can be an image tag: an OCI tag is `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`,
+// and a version outside that charset is refused rather than rewritten.
+//
+// SemVer build metadata — the `+` and everything after it — is called out
+// separately when it is refused, because it is the case where rewriting
+// would silently do damage: `+` is not in the tag charset, so dropping it
+// would publish `1.0.0+build.1` and `1.0.0+build.2` under one tag, and the
+// second would quietly replace the first.
+//
+// # commit still comes from HEAD and from nothing else
+//
+// Every binary is stamped with `main.version` and `main.commit`. Declare
+// the two package-level vars in your main package and they are filled in:
+//
+//	var (
+//		version = "dev"
+//		commit  = "none"
+//	)
+//
+// The names are fixed by the module. commit is the short HEAD SHA and is
+// never a parameter — a build identity a caller could have supplied
+// identifies nothing — so two builds of one (commit, version) pair are
+// byte-identical. Source without git metadata at HEAD is an error.
+//
+// pkg is the package to build, in `go build` package syntax, relative to
+// the source root. platforms defaults to linux/amd64 and linux/arm64.
+func (r *Z5LabsGoChain) App(version string, opts ...Z5LabsGoChainAppOpts) *Z5LabsApp { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L185)
+	q := r.query.Select("app")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `pkg` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Pkg) {
+			q = q.Arg("pkg", opts[i].Pkg)
+		}
+		// `platforms` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platforms) {
+			q = q.Arg("platforms", opts[i].Platforms)
+		}
+	}
+	q = q.Arg("version", version)
+
+	return &Z5LabsApp{
+		query: q,
+	}
+}
+
+// Ci runs the standardized check stages against the source: gofmt, go vet,
+// golangci-lint against the bundled policy unless WithLint supplied one,
+// and `go test ./...` with the race detector unless WithTest turned it off.
+// The stages run in parallel and their errors are aggregated.
+func (r *Z5LabsGoChain) Ci(ctx context.Context) error { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L131)
 	if r.ci != nil {
 		return nil
 	}
@@ -697,8 +1608,8 @@ func (r *Z5LabsGoLib) Ci(ctx context.Context) error { // z5labs (https://github.
 	return q.Execute(ctx)
 }
 
-// A unique identifier for this Z5LabsGoLib.
-func (r *Z5LabsGoLib) ID(ctx context.Context) (ID, error) {
+// A unique identifier for this Z5LabsGoChain.
+func (r *Z5LabsGoChain) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
@@ -711,17 +1622,17 @@ func (r *Z5LabsGoLib) ID(ctx context.Context) (ID, error) {
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
-func (r *Z5LabsGoLib) XXX_GraphQLType() string {
-	return "Z5LabsGoLib"
+func (r *Z5LabsGoChain) XXX_GraphQLType() string {
+	return "Z5LabsGoChain"
 }
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
-func (r *Z5LabsGoLib) XXX_GraphQLIDType() string {
+func (r *Z5LabsGoChain) XXX_GraphQLIDType() string {
 	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
-func (r *Z5LabsGoLib) XXX_GraphQLID(ctx context.Context) (string, error) {
+func (r *Z5LabsGoChain) XXX_GraphQLID(ctx context.Context) (string, error) {
 	id, err := r.ID(ctx)
 	if err != nil {
 		return "", err
@@ -729,26 +1640,105 @@ func (r *Z5LabsGoLib) XXX_GraphQLID(ctx context.Context) (string, error) {
 	return string(id), nil
 }
 
-func (r *Z5LabsGoLib) MarshalJSON() ([]byte, error) {
+func (r *Z5LabsGoChain) MarshalJSON() ([]byte, error) {
 	id, err := r.ID(marshalCtx)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(id)
 }
-func (r *Z5LabsGoLib) UnmarshalJSON(bs []byte) error {
+func (r *Z5LabsGoChain) UnmarshalJSON(bs []byte) error {
 	var id string
 	err := json.Unmarshal(bs, &id)
 	if err != nil {
 		return err
 	}
-	*r = Z5LabsGoLib{query: selectNode(dag.query, id, "Z5LabsGoLib")}
+	*r = Z5LabsGoChain{query: selectNode(dag.query, id, "Z5LabsGoChain")}
 	return nil
 }
 
-// AsNode returns this Z5LabsGoLib as a Node.
+// WithBuild records build tags for the App terminal. Ci does not build, so
+// tags have no effect on it.
+//
+// tags are passed to the Go toolchain as `-tags a,b,c`, selecting which
+// `//go:build`-constrained files compile. The build belongs to App — the
+// terminal that produces container images — and these are the tags it
+// builds every platform's binary with.
+func (r *Z5LabsGoChain) WithBuild(tags []string) *Z5LabsGoChain { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L119)
+	q := r.query.Select("withBuild")
+	q = q.Arg("tags", tags)
+
+	return &Z5LabsGoChain{
+		query: q,
+	}
+}
+
+// Z5LabsGoChainWithLintOpts contains options for Z5LabsGoChain.WithLint
+type Z5LabsGoChainWithLintOpts struct {
+	Version string // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L82)
+
+	Config *File // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L84)
+}
+
+// WithLint configures the lint stage.
+//
+// version is the golangci-lint release the stage installs, e.g. "v2.12.2".
+// Empty takes the version pinned by the `go` module, which is a v2 release;
+// pinning a "v1.x" release rolls the whole stage — config dialect included
+// — back to v1.
+//
+// config is a `.golangci.yml` replacing the bundled policy in
+// configs/golangci.yml. It has to be written in the dialect the pinned
+// major speaks: a v2 binary refuses a v1 file outright, before any linter
+// runs, and v1 refuses a v2 file the same way.
+//
+// Both arguments are optional, because pinning a version and replacing the
+// policy are independent decisions and requiring one to state the other
+// would make every version pin also a policy fork. An argument left out
+// leaves that setting alone rather than clearing it, so the independence
+// holds across calls as well as within one: `with-lint --config=x
+// with-lint --version=y` keeps both, where an unconditional assignment
+// would have dropped the config and run the bundled policy the caller
+// thought they had replaced. Nothing can un-set either one, which is not a
+// use case — a caller who wants the defaults does not call this.
+func (r *Z5LabsGoChain) WithLint(opts ...Z5LabsGoChainWithLintOpts) *Z5LabsGoChain { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L80)
+	q := r.query.Select("withLint")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
+		}
+		// `config` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Config) {
+			q = q.Arg("config", opts[i].Config)
+		}
+	}
+
+	return &Z5LabsGoChain{
+		query: q,
+	}
+}
+
+// WithTest configures the test stage. race turns the data-race detector on
+// or off; it is on unless this method says otherwise.
+//
+// race is a required argument rather than an optional one, because an
+// optional bool takes its zero value when the flag is absent, so a bare
+// `with-test` would silently drop the race detector the pipeline otherwise
+// guarantees. Turning it off is a real weakening of the check, so the
+// caller states it.
+func (r *Z5LabsGoChain) WithTest(race bool) *Z5LabsGoChain { // z5labs (https://github.com/z5labs/devex/tree/c10a12007999eb807f68cd9af9000fbaeab159cb/daggerverse/z5labs/go.go#L105)
+	q := r.query.Select("withTest")
+	q = q.Arg("race", race)
+
+	return &Z5LabsGoChain{
+		query: q,
+	}
+}
+
+// AsNode returns this Z5LabsGoChain as a Node.
 // This is a local type conversion — no GraphQL call.
-func (r *Z5LabsGoLib) AsNode() Node {
+func (r *Z5LabsGoChain) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -6,56 +6,72 @@
 // Package main implements avroc's root Dagger module: the one definition of
 // this repository's pipeline, called by CI and by contributors alike.
 //
-// # Why this wraps the Z5Labs standard pipeline
+// # What this module still owns, now that the archetype builds the image
 //
-// Ci does not implement fmt, vet, lint and `go test -race`. It hands the source
-// to github.com/z5labs/devex/daggerverse/z5labs and lets that module's GoLib
-// archetype run them, which is the same standard every other Z5Labs repository
-// runs. A reimplementation here would be a second definition of what "checked"
-// means in a Z5Labs repository, and two definitions drift: a stage added to the
-// standard would silently not apply to avroc, and a difference in how a stage is
-// invoked would show up as this repository disagreeing with every other one for
-// reasons nobody wrote down. Wrapping costs one dependency and keeps that
-// impossible.
+// This module used to build avroc's published images itself, and about 1,900 of
+// its lines existed for that reason alone. The argument was recorded here and in
+// image.go at length: the Z5Labs standard pipeline's image half produced one
+// scratch image per binary with /app/<binaryName> as entrypoint and nothing
+// else — no PATH, no user, no plugin directory — and avroc's image is a
+// documented public contract that has to promise all three (#126, #127, #128).
 //
-// # Why GoLib, when avroc has four commands
+// That premise is gone (#217). github.com/z5labs/devex/daggerverse/z5labs is now
+// a chainable Go -> App -> Publish API, and every one of the three things avroc
+// needed is the archetype's own: /usr/local/bin is its fixed executable
+// directory with PATH composed from the same constant, 65532:65532 is its pinned
+// non-root user, and App.WithApp composes one application's executable into
+// another's plugin directory, which is exactly what a generator image is. So the
+// image, the multi-platform publish, the tag family, the recursive signature and
+// the attestations are all the standard's, and this module states the version and
+// the repositories and gets out of the way.
 //
-// The library archetype is not a claim that avroc is a library. avroc has four
-// `package main` binaries under cmd/, so the usual reason to call GoLib — there
-// being no main package for the image half of the standard to act on — does not
-// apply here. Two reasons that do:
+// Three things did not move, and each is a fact about *this* project rather than
+// about how an image gets built:
 //
-// The check stages are identical either way. GoApp and GoLib route fmt, vet,
-// lint and `go test -race` through the same shared check in the standard, so
-// choosing GoLib costs this pipeline nothing in coverage.
+//   - The contract checks. ImageContract, GeneratorImageContract, Regeneration,
+//     WorkedExample, CompanionModule, TlsEgress, TracePropagation and
+//     IrDescriptorSet are assertions about docs/container/SPEC.md and
+//     docs/plugin/SPEC.md, and every one of them holds against a container
+//     whoever built it. They are also the evidence that adopting the archetype
+//     changed nothing a consumer can see, which is the only thing that makes a
+//     change of this size reviewable.
+//   - Whether this commit is a release. The archetype takes a version from its
+//     caller and derives the tag family from it; reading the refs at HEAD to
+//     decide whether there is a release here at all, refusing two version tags
+//     and refusing `+build` metadata stay in release.go, because they are facts
+//     about this repository's release process. TagScheme is what checks them.
+//   - The set of generators, and what each one is. builtinGenerators is this
+//     repository's list; the archetype has no opinion about it.
 //
-// GoApp's image half is not the image avroc needs. It builds a scratch image
-// per binary with /app/<binaryName> as entrypoint and nothing else: no PATH, no
-// USER, no plugin directory. avroc's published image is a documented public
-// contract that has to promise all three, because generator images are built
-// FROM it and avroc discovers generators on PATH. GoApp's output cannot satisfy
-// that as-is, and deciding how it should is a live design question that belongs
-// to the base-image story rather than being pre-decided here by an archetype.
+// # Why the stage functions exist alongside Ci
 //
-// So this module takes the checks from the standard and builds the image itself,
-// in image.go, which records why that was chosen over extending GoApp upstream
-// or accepting a non-scratch base (#126). Moving the *checks* to GoApp remains a
-// change to which factory New calls, plus dropping .git from the ignore list
-// below; it is not a change to what the pipeline is.
-//
-// # Why the stage functions exist alongside it
-//
-// GoLib exposes only the whole pipeline, and waiting on four stages to learn
-// that one file is unformatted is not the loop to develop in. So Fmt, Vet, Lint
-// and Test are here too. They are not a second implementation: each one drives
-// the same github.com/z5labs/devex/daggerverse/go builder that the standard
-// pipeline drives, with one stage enabled instead of four, against the same lint
-// configuration. Both dependencies are pinned to a single devex commit for that
-// reason — a bump has to move them together, or a stage run on its own stops
-// being the stage Ci runs.
+// GoChain.Ci exposes only the whole pipeline, and waiting on four stages to
+// learn that one file is unformatted is not the loop to develop in. So Fmt, Vet,
+// Lint and Test are here too. They are not a second implementation: each one
+// drives the same github.com/z5labs/devex/daggerverse/go builder that the
+// standard pipeline drives, with one stage enabled instead of four, against the
+// same lint configuration. All four devex dependencies are pinned to a single
+// commit for that reason — a bump has to move them together, or a stage run on
+// its own stops being the stage Ci runs.
 //
 // Ci is what CI calls and what a contributor should run before pushing. The
 // stage functions are for narrowing down what Ci reported.
+//
+// # Why .git is bound separately from the source
+//
+// The archetype stamps every binary with the short HEAD SHA and annotates every
+// image with the commit, its committer time and the origin remote, so building
+// an App needs real git metadata — which the ignore list on New deliberately
+// keeps out of Source, because none of fmt, vet, lint or test reads it and
+// leaving it in would make every commit a cache miss for all four.
+//
+// Both are had by binding it as its own argument, the way Release already took
+// one, and folding it back in on the single path that builds an App
+// (appSource). The check stages keep the tree they always had; the image path
+// gets the metadata it needs; and nothing that was cache-stable per commit
+// became a cache miss per commit. The workflow half of that is
+// .github/workflows/build.yaml, which fetches full history because an image is
+// built on every pull request.
 package main
 
 import (
@@ -75,6 +91,10 @@ type Avroc struct {
 	Source *dagger.Directory
 	// +private
 	LintConfig *dagger.File
+	// GitDir is the repository's .git, bound apart from Source so that the
+	// check stages never see it. Only appSource folds it back in.
+	// +private
+	GitDir *dagger.Directory
 }
 
 // New binds the repository to the pipeline.
@@ -82,15 +102,27 @@ type Avroc struct {
 // source defaults to the repository root, so `dagger call ci` from a checkout
 // needs no arguments. The ignore list drops what no check stage reads: .git is
 // excluded because none of fmt, vet, lint or test looks at git metadata, and
-// leaving it in would make every commit a cache miss for all four. That changes
-// if the archetype ever becomes GoApp — it stamps binaries from the refs at HEAD
-// and does need real git metadata, so .git has to come off this list in the same
-// change that switches factories, and .github/workflows/build.yaml has to stop
-// checking out shallow in that same change.
+// leaving it in would make every commit a cache miss for all four.
+//
+// It stays excluded now that the archetype builds the image (#217), rather than
+// coming off the list as the comment here used to predict. The archetype does
+// need real git metadata — it stamps the short HEAD SHA into every binary and
+// annotates every image with the commit, its committer time and the origin — but
+// it needs it on one path out of nine, and folding .git into Source would have
+// bought that by making fmt, vet, lint and test miss their cache on every
+// commit. gitDir is that metadata bound as its own input, and appSource is the
+// only thing that puts the two back together.
 //
 // bin and the per-issue worktrees under .claude go too: both are local build
 // output, neither is committed, and both would otherwise vary between a
 // contributor's checkout and CI's for no effect on any stage.
+//
+// gitDir defaults to the repository's own .git. It is a *directory* rather than
+// something derived, because git's own answers are what the archetype stamps and
+// anything this module computed would be a build identity a caller could have
+// supplied. Note that a git *worktree* has a .git file rather than a directory,
+// so the stages that build an image are the ones that do not run from one; that
+// was already true of Release and is now true of the image checks too.
 //
 // lintConfig defaults to the repository's own .golangci.yml. It is passed
 // explicitly rather than left to the standard pipeline's bundled default so that
@@ -106,11 +138,14 @@ func New(
 	source *dagger.Directory,
 	// +optional
 	lintConfig *dagger.File,
+	// +optional
+	// +defaultPath="/.git"
+	gitDir *dagger.Directory,
 ) *Avroc {
 	if lintConfig == nil {
 		lintConfig = source.File(".golangci.yml")
 	}
-	return &Avroc{Source: source, LintConfig: lintConfig}
+	return &Avroc{Source: source, LintConfig: lintConfig, GitDir: gitDir}
 }
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
@@ -125,9 +160,43 @@ func New(
 // +check
 // +cache="session"
 func (m *Avroc) Ci(ctx context.Context) error {
+	return m.goChain().Ci(ctx)
+}
+
+// goChain is the standard Go chain bound to this repository's source and
+// configured the one way this repository is checked.
+//
+// It is one helper rather than a call at each site because Ci and the App path
+// have to agree about the source they are given and about the lint
+// configuration: a chain configured twice is two definitions of what "checked"
+// means here, which is the thing wrapping the standard exists to prevent.
+//
+// WithTest(true) is written out rather than left to the default. The archetype's
+// race detector is on unless a caller says otherwise, so the argument is
+// redundant today and is stated anyway — avroc runs generators concurrently, and
+// "the race detector is on because nobody turned it off" is not the same claim as
+// "the race detector is on because this repository asked for it".
+//
+// The chain carries no .git: Ci does not build, and the stages it does run are
+// the ones the ignore list on New exists to keep cache-stable. appSource is
+// where the metadata arrives.
+func (m *Avroc) goChain() *dagger.Z5LabsGoChain {
 	return dag.Z5Labs().
-		GoLib(m.Source, dagger.Z5LabsGoLibOpts{LintConfig: m.LintConfig}).
-		Ci(ctx)
+		Go(m.Source).
+		WithLint(dagger.Z5LabsGoChainWithLintOpts{Config: m.LintConfig}).
+		WithTest(true)
+}
+
+// appSource is the source tree an App is built from: this repository's, with
+// its git metadata folded back in.
+//
+// This is the only place the two are put together, and that is the whole of
+// #217's answer to a problem the old comment on New predicted: the archetype
+// stamps binaries and annotates images from the refs at HEAD, so it needs real
+// git metadata, and the check stages need a tree that does not change when a
+// commit is made. One argument, folded in on one path, gives both.
+func (m *Avroc) appSource() *dagger.Directory {
+	return m.Source.WithDirectory(".git", m.GitDir)
 }
 
 // Fmt reports any file that gofmt would rewrite, as a diff.
@@ -379,10 +448,19 @@ func generateWorkedExample(
 		Directory(run.root)
 }
 
-// pluginDir is where the binaries go, and it is docs/container/SPEC.md's plugin
-// directory rather than an arbitrary one: avroc discovers generators on PATH, so
-// the run container's layout is the published image's layout. image.go reads the
-// same constant, which is what makes that sentence true rather than aspirational.
+// pluginDir is docs/container/SPEC.md's plugin directory — the one directory on
+// the published image's PATH that an extension's executables land in, and the one
+// the archetype composes a generator into (#217).
+//
+// The regeneration container below puts all four binaries here, which is not quite
+// the published layout any more: since #217 the archetype puts the *application's
+// own* binary in appDir and names it absolutely in the entrypoint, so the image has
+// avroc in one place and its generators in another. What that container is
+// reproducing is the half that matters to a generation — the generators are found
+// on PATH, by the name a manifest asked for, in a scratch container with no shell —
+// and it names avroc by absolute path for the reason the comment above gives, which
+// is that PATH is one of the things this check varies. image.go reads the same
+// constant for the listing, so the day the plugin directory moves, both move.
 const pluginDir = "/usr/local/bin"
 
 // regenerationRun is one generation's arrangement of everything the output must

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -67,11 +67,17 @@
 //
 // Both are had by binding it as its own argument, the way Release already took
 // one, and folding it back in on the single path that builds an App
-// (appSource). The check stages keep the tree they always had; the image path
-// gets the metadata it needs; and nothing that was cache-stable per commit
-// became a cache miss per commit. The workflow half of that is
-// .github/workflows/build.yaml, which fetches full history because an image is
-// built on every pull request.
+// (appSource). The check stages keep the tree they always had, and the image path
+// gets the metadata it needs.
+//
+// Stated precisely, because the loose version of it is wrong: fmt, vet, lint and
+// test are cache-stable per commit exactly as before, and the image stages now key
+// on git metadata, which is what they have to do to stamp a commit into a binary.
+// What that does not have to include is the part of a .git directory that is *not*
+// a function of the commit — a reflog, a FETCH_HEAD, an index — so New's gitDir
+// argument carries an ignore list of its own, and that comment is where the
+// reasoning is. The workflow half is .github/workflows/build.yaml, which fetches
+// full history because an image is built on every pull request.
 package main
 
 import (
@@ -124,6 +130,16 @@ type Avroc struct {
 // so the stages that build an image are the ones that do not run from one; that
 // was already true of Release and is now true of the image checks too.
 //
+// Its own ignore list is the other half of the caching argument, and it is not
+// decoration. Everything read out of here is a function of the commit — HEAD, the
+// refs pointing at it, the commit object's committer time, and the origin in
+// config — while a .git directory also holds a great deal that is not: the reflog
+// under logs/, FETCH_HEAD and ORIG_HEAD, the staging index, the hooks, and whatever
+// gc last repacked. Folded in whole, two builds of one commit could hash
+// differently — a re-run, a second job, or any local `git fetch` — and the image
+// stages would miss their cache for reasons nothing in the tree explains. What is
+// excluded is chosen to be exactly what none of those four reads.
+//
 // lintConfig defaults to the repository's own .golangci.yml. It is passed
 // explicitly rather than left to the standard pipeline's bundled default so that
 // the configuration committed to this repository is the configuration CI lints
@@ -140,6 +156,7 @@ func New(
 	lintConfig *dagger.File,
 	// +optional
 	// +defaultPath="/.git"
+	// +ignore=["logs", "hooks", "index", "FETCH_HEAD", "ORIG_HEAD", "COMMIT_EDITMSG"]
 	gitDir *dagger.Directory,
 ) *Avroc {
 	if lintConfig == nil {
@@ -196,6 +213,20 @@ func (m *Avroc) goChain() *dagger.Z5LabsGoChain {
 // git metadata, and the check stages need a tree that does not change when a
 // commit is made. One argument, folded in on one path, gives both.
 func (m *Avroc) appSource() *dagger.Directory {
+	// A nil GitDir is handed on rather than dereferenced. It is not reachable from
+	// the command line — the argument carries a default path — but it is reachable
+	// from a module-to-module call and from any struct literal, and
+	// Directory.WithDirectory asserts its argument is non-nil and *panics*, a long
+	// way from whoever left it out. Returning the source unchanged instead puts the
+	// failure where it belongs: the archetype refuses a tree with no .git in it, in
+	// its own words, naming what it was looking for.
+	//
+	// That is also the message somebody running an image stage from a git worktree
+	// gets, where .git is a file and the default path resolves to nothing useful.
+	// CONTRIBUTING.md says to run those from an ordinary clone.
+	if m.GitDir == nil {
+		return m.Source
+	}
 	return m.Source.WithDirectory(".git", m.GitDir)
 }
 

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -4,8 +4,8 @@
 // https://opensource.org/licenses/MIT
 
 // This file publishes a release: it decides from the refs at HEAD whether there
-// is one, works out which tags it carries, pushes every image under all of them,
-// and signs each published digest with provenance and an SBOM beside it (#128).
+// is one and hands the archetype the version and the repositories to publish it
+// under (#128, #217).
 //
 // # Why the decision is here and not an `if:` on a job
 //
@@ -21,85 +21,65 @@
 // reading is a function of them. TagScheme runs the same function over a table
 // of cases on every pull request, which is what makes the scheme a thing this
 // repository checks rather than a thing it intends. The workflow's remaining job
-// is to say *where* — the registry repository and the credentials — which is the
-// half that genuinely is a property of the deployment and not of the release.
+// is to say *where* — the registry, the repository and the credentials — which is
+// the half that genuinely is a property of the deployment and not of the release.
 //
-// # Why cosign, and why built rather than pulled
+// # What moved to the archetype, and what did not
 //
-// docs/container/SPEC.md's "Tags and what pinning one buys" promises a consumer
-// can verify a signature before trusting a tag, and a promise like that is only
-// worth what the verifying command is worth. cosign's keyless flow is the one a
-// consumer already has: `cosign verify` with the certificate identity and issuer
-// is a command somebody can run without this project having published a key,
-// rotated it, or asked anybody to trust a key distribution channel. The signing
-// identity is the workflow itself, certified by the public sigstore CA from the
-// OIDC token GitHub mints for the run, and it is recorded in a public
-// transparency log — so verification checks who built the image rather than who
-// holds a secret.
+// The tag *family* moved (#217). Which tags a version implies — `v0.2.0` also
+// coming to name `v0.2`, `v0` and `latest`, a prerelease moving none of them — is
+// the archetype's now, derived from the version a caller states, checked by its own
+// table, and published as one manifest list pushed once with every tag pointing at
+// the one digest. So did the signature, the provenance and the SBOMs: every
+// published digest carries a recursive cosign signature, a signed SLSA provenance
+// statement whose build identity comes from the exchanged OIDC token rather than
+// from anything this module could have asserted, and an SPDX and CycloneDX
+// document per platform describing the whole image. `cosignPackage`,
+// `provenanceStatement`, `attest`, `publishTags` and `versionTags` are gone with
+// them.
 //
-// It is built by `go install` at a pinned version rather than pulled as a tool
-// image, which is what every other container in this module does: the toolchain
-// is the one dag.Go() already provides, the pin is a module version rather than
-// a tag somebody can repoint, and there is no image reference here to keep in
-// step with an upstream release.
+// What did not move is the sentence "this commit is a release". The archetype
+// takes a version from its caller and has no opinion about where one comes from,
+// and *this repository* releases by tagging a commit: a single canonical version
+// tag at HEAD is a release, no tag or a tag that is not a canonical version
+// publishes nothing, two version tags is an error because which of them `latest`
+// should follow has no defensible answer, and a version carrying `+build`
+// metadata is refused because `+` cannot be spelled in an OCI tag and mangling it
+// away would publish two releases under one name. planRelease is all four, and
+// TagScheme is what checks them.
 //
-// # What is attached, and to what
+// # Why the contract check is a gate inside Release
 //
-// Everything is attached to the *digest* the publish returned, never to a tag.
-// A tag is a name that moves; an attestation about a name that moves says
-// nothing. Three kinds, for each of the four published images:
+// docs/container/SPEC.md's guarantees are checked by ImageContract and
+// GeneratorImageContract, and the release workflow used to call both as steps of
+// their own before calling this. That worked while this module built the image,
+// because both calls came through one `image` function; it stops meaning what it
+// said once the container is the archetype's, because the guarantee that the
+// container a check read is *the very container that will be pushed* holds only
+// within one chained call. Two separate `dagger call` invocations are a second,
+// cache-identical build that merely agrees with the first.
 //
-//   - A signature over the manifest, which is what `cosign verify` checks.
-//   - A SLSA v1 provenance statement naming the source commit, the ref that
-//     triggered the release and the workflow that ran it.
-//   - An SPDX SBOM per executable per platform, produced by the shared `go`
-//     module from the very binaries this pipeline compiled. One per platform
-//     rather than one per image, because each document is tied to a specific
-//     binary's SHA-256 and a single document would have to name one of them and
-//     be wrong about the rest.
+// A published version tag is never repointed here, so "the image was checked, and
+// then an identical one was pushed" is not a property worth resting a release on.
+// The check is therefore a gate inside this function, over the Apps this function
+// is about to publish: releaseContract runs it, and a failure means nothing was
+// pushed. The standalone `dagger call image-contract` and
+// `dagger call generator-image-contract` stay, because a pull request has no
+// release to gate and wants the check on its own.
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
-	"time"
 
 	"dagger/avroc/internal/dagger"
 )
 
-const (
-	// cosignPackage is the signing tool, pinned to a module version. `go
-	// install` refuses an unpinned package, which is the property that makes
-	// the binary this release signs with the binary the pin names.
-	//
-	// renovate: datasource=go depName=github.com/sigstore/cosign/v2
-	cosignPackage = "github.com/sigstore/cosign/v2/cmd/cosign@v3.1.3"
-
-	// rollingTag is docs/container/SPEC.md's rolling tag, the one that moves on
-	// every release.
-	rollingTag = "latest"
-
-	// buildType names this pipeline in the provenance predicate. It is a URI
-	// because SLSA requires one, and it points at the file that implements it
-	// rather than at a specification somebody would have to be told about
-	// separately: what "built by avroc's release" means is what is written here.
-	buildType = "https://github.com/z5labs/avroc/blob/main/.dagger/release.go"
-
-	// provenancePredicate and sbomPredicate are cosign's names for the two
-	// attestation shapes. slsaprovenance1 is SLSA v1, which is the version whose
-	// predicate provenanceStatement renders; spdxjson is the SPDX 2.3 JSON the
-	// `go` module emits.
-	provenancePredicate = "slsaprovenance1"
-	sbomPredicate       = "spdxjson"
-)
-
-// Release publishes this repository's images for the release at HEAD, signs each
-// one, and attaches provenance and an SBOM (#128).
+// Release publishes this repository's images for the release at HEAD (#128,
+// #217).
 //
 // Whether there is a release at all is decided here, from the refs at HEAD: a
 // single version tag pointing at HEAD is a release, and anything else — a branch
@@ -108,15 +88,21 @@ const (
 // rather than a fault; a run with two version tags fails, because which of them
 // `latest` should follow is not a question this function is entitled to guess.
 //
-// repository is the base image's full repository, without a tag —
-// `ghcr.io/z5labs/avroc`. The generator images derive from it by the same rule
-// docs/container/SPEC.md names them under, so the caller supplies one location
-// rather than four. Where to publish is the caller's, because a mirror or an
-// internal registry serves the same release; which tags exist is not, for the
-// reason this file's comment gives.
+// registry is the registry alone — `ghcr.io` — and repository is the base image's
+// path within it — `z5labs/avroc`. They are two arguments because the archetype
+// separates them, and it separates them so that a mirror or an internal registry
+// serves the same release by changing one of the two and nothing else. The
+// generator images derive from repository by the rule docs/container/SPEC.md names
+// them under, so the caller supplies one location rather than four.
 //
-// It returns a report naming every repository published, the digest it resolved
-// to and the tags now pointing at it.
+// Every published image is signed and carries provenance and an SBOM, and none of
+// that is optional: a publish the archetype cannot produce provenance for fails
+// rather than publishing without it. That is why the OIDC arguments are required
+// here and why there is no `dagger call publish` beside this one — the only caller
+// with a token to exchange is the workflow.
+//
+// It returns a report naming every reference published, which is one line per tag
+// per repository, each pinned to the digest it resolved to.
 //
 // +cache="never"
 func (m *Avroc) Release(
@@ -125,38 +111,35 @@ func (m *Avroc) Release(
 	// this commit is a release, so a checkout without tags publishes nothing.
 	// +defaultPath="/.git"
 	gitDir *dagger.Directory,
-	// The base image's repository, without a tag — `ghcr.io/z5labs/avroc`.
+	// The registry to publish to, without a repository path — `ghcr.io`.
+	registry string,
+	// The base image's repository within that registry, without a tag —
+	// `z5labs/avroc`.
 	repository string,
 	// The registry username to authenticate as.
 	username string,
 	// The registry password or token to authenticate with.
 	password *dagger.Secret,
 	// The CI provider's OIDC token request endpoint —
-	// `ACTIONS_ID_TOKEN_REQUEST_URL` on GitHub Actions. cosign exchanges a token
-	// from it for the short-lived certificate that signs, so a run that
-	// publishes needs it.
+	// `ACTIONS_ID_TOKEN_REQUEST_URL` on GitHub Actions. The publish exchanges a
+	// token from it for the identity that signs, so a run that publishes needs it.
 	idTokenRequestUrl string,
 	// The bearer token for that endpoint — `ACTIONS_ID_TOKEN_REQUEST_TOKEN` on
 	// GitHub Actions. A secret, because it mints identity tokens.
 	idTokenRequestToken *dagger.Secret,
-	// What ran this release, for the provenance predicate's builder — the
-	// workflow reference on GitHub Actions. The module cannot know what invoked
-	// it, and provenance that guessed would be provenance about nothing.
-	builder string,
-	// The run this release came from, for the provenance predicate — a URL to
-	// the workflow run on GitHub Actions.
-	// +optional
-	invocation string,
 ) (string, error) {
+	// The refs are read before the arguments are checked, because "this commit is
+	// not a release" is the common answer and reaching it should not depend on a
+	// credential nobody is going to use.
 	refs, err := headRefs(ctx, m.Source, gitDir)
 	if err != nil {
 		return "", err
 	}
-	plan, err := planRelease(refs)
+	version, err := planRelease(refs)
 	if err != nil {
 		return "", err
 	}
-	if plan.version == "" {
+	if version == "" {
 		return fmt.Sprintf("no version tag points at HEAD (refs: %s); nothing published", strings.Join(refs, ", ")), nil
 	}
 
@@ -165,71 +148,58 @@ func (m *Avroc) Release(
 	// would leave a tag pointing at an unattested image, and a published tag is
 	// never repointed.
 	switch {
+	case registry == "":
+		return "", errors.New("registry is required: it is the registry alone, such as `ghcr.io`, and never a repository path")
 	case repository == "":
-		return "", errors.New("repository is required: it is the base image's full repository, without a tag")
+		return "", errors.New("repository is required: it is the base image's path within the registry, without a tag")
 	case username == "" || password == nil:
 		return "", errors.New("username and password are both required: a release is pushed to a registry that authenticates")
 	case idTokenRequestUrl == "" || idTokenRequestToken == nil:
 		return "", errors.New("idTokenRequestUrl and idTokenRequestToken are both required: every published image is signed, and signing exchanges a workload identity token")
-	case builder == "":
-		return "", errors.New("builder is required: the provenance predicate names what ran the release, and this module cannot know that")
 	}
 
-	commit, err := headCommit(ctx, m.Source, gitDir)
-	if err != nil {
-		return "", err
-	}
-	source, err := sourceURI(ctx, m.Source, gitDir)
-	if err != nil {
-		return "", err
-	}
+	images := m.releaseImages(repository, version)
 
-	startedOn := time.Now().UTC()
-	signer := m.cosign(idTokenRequestUrl, idTokenRequestToken, registryHost(repository), username, password, startedOn)
+	// The gate. Nothing is pushed until every published image has been checked
+	// against docs/container/SPEC.md, and it is checked on the containers these
+	// very Apps carry — see this file's comment for why that is not the same as
+	// having run `dagger call image-contract` a moment earlier.
+	if err := m.releaseContract(ctx, images); err != nil {
+		return "", fmt.Errorf("refusing to publish %s: %w", version, err)
+	}
 
 	var report strings.Builder
-	for _, image := range m.releaseImages(repository, username, password) {
-		digest, err := publishTags(ctx, image, plan.tags)
+	for _, image := range images {
+		refs, err := image.app.
+			WithRegistry(registry, username, password).
+			WithOidc(idTokenRequestUrl, idTokenRequestToken).
+			Publish(ctx, []string{image.repository})
 		if err != nil {
-			return report.String(), err
+			return report.String(), fmt.Errorf("publishing %s/%s: %w", registry, image.repository, err)
 		}
-
-		predicate, err := provenanceStatement(provenanceFacts{
-			Repository: image.repository,
-			Version:    plan.version,
-			Tags:       plan.tags,
-			Source:     source,
-			Commit:     commit,
-			Builder:    builder,
-			Invocation: invocation,
-			StartedOn:  startedOn,
-		})
-		if err != nil {
-			return report.String(), err
+		for _, ref := range refs {
+			fmt.Fprintf(&report, "%s\n", ref)
 		}
-		if err := m.attest(ctx, signer, image, digest, predicate); err != nil {
-			return report.String(), err
-		}
-
-		fmt.Fprintf(&report, "%s\n  digest: %s\n  tags:   %s\n", image.repository, digest, strings.Join(plan.tags, ", "))
 	}
 	return report.String(), nil
 }
 
-// TagScheme is docs/container/SPEC.md's tag table executed rather than read.
+// TagScheme is the half of docs/container/SPEC.md's tag table this repository
+// still decides, executed rather than read.
 //
-// The table is the part of a release that cannot be checked by releasing: a tag
-// that moved when it should not have is discovered by a consumer whose `FROM`
-// line resolved to something they did not ask for, and by then the tag has been
-// published and this project's own contract says it is never repointed. So the
-// derivation is a pure function of the version, and this runs it over the cases
-// that matter — including the ones with no release in them, since "publishes
-// nothing" is as much a promise as "publishes four tags".
+// What it covers is what planRelease answers: whether the refs at HEAD are a
+// release at all, and which version it is. The tag *family* that version implies
+// is the archetype's since #217, and is checked by its own table over its own
+// literals — restating it here would be a second copy of somebody else's rule,
+// which is the thing this whole file exists to avoid having.
 //
-// Every expected tag below is a literal, never one of this file's own constants.
-// A table written in terms of rollingTag would move with it and pass on a
-// release that had quietly started publishing something else under a different
-// name, which is the one failure this check exists to catch.
+// This is the part of a release that cannot be checked by releasing: a commit
+// that published when it should not have, or published under a version nobody
+// tagged, is discovered afterwards, and by then the tag is out and this project's
+// own contract says it is never repointed.
+//
+// Every expected value below is a literal, never one of this file's own
+// constants, so the check cannot move with the code it checks.
 //
 // +check
 // +cache="session"
@@ -237,28 +207,14 @@ func (m *Avroc) TagScheme() error {
 	cases := []struct {
 		refs    []string
 		version string
-		tags    []string
 		fails   bool
 	}{
-		// A release: the full version tag, plus the three that move.
-		{
-			refs:    []string{"refs/tags/v0.2.0", "refs/heads/main"},
-			version: "v0.2.0",
-			tags:    []string{"v0.2.0", "v0.2", "v0", "latest"},
-		},
-		{
-			refs:    []string{"refs/tags/v1.10.3"},
-			version: "v1.10.3",
-			tags:    []string{"v1.10.3", "v1.10", "v1", "latest"},
-		},
-		// A prerelease publishes itself and moves nothing: `v0`, `v0.2` and
-		// `latest` are what a derived Dockerfile pins to get fixes, and a
-		// release candidate is not a fix anybody asked to be given.
-		{
-			refs:    []string{"refs/tags/v0.3.0-rc.1"},
-			version: "v0.3.0-rc.1",
-			tags:    []string{"v0.3.0-rc.1"},
-		},
+		// A release: one canonical version tag at HEAD, whatever else is there.
+		{refs: []string{"refs/tags/v0.2.0", "refs/heads/main"}, version: "v0.2.0"},
+		{refs: []string{"refs/tags/v1.10.3"}, version: "v1.10.3"},
+		// A prerelease is a release, and it is the archetype that then declines to
+		// move `v0`, `v0.2` and `latest` onto it.
+		{refs: []string{"refs/tags/v0.3.0-rc.1"}, version: "v0.3.0-rc.1"},
 		// Not a release. A branch, a tag that is not a version, and a tag that
 		// looks like one but is not canonical all publish nothing rather than
 		// publishing something surprising.
@@ -269,7 +225,10 @@ func (m *Avroc) TagScheme() error {
 		{refs: []string{"refs/tags/v0.2"}},
 		{refs: []string{"refs/tags/v01.2.0"}},
 		// Build metadata cannot be spelled in an OCI tag, so a version carrying
-		// it is refused rather than silently mangled into one that can.
+		// it is refused rather than silently mangled into one that can. The
+		// archetype refuses it too, and this repository refuses it first: the
+		// version never reaches a publish, so the refusal is the same whether or
+		// not a registry was ever going to be contacted.
 		{refs: []string{"refs/tags/v0.2.0+build.5"}, fails: true},
 		// Two version tags at HEAD: which of them `latest` should follow is not
 		// a question with a defensible answer, so it is an error and not a
@@ -279,37 +238,28 @@ func (m *Avroc) TagScheme() error {
 
 	var errs []error
 	for _, c := range cases {
-		plan, err := planRelease(c.refs)
+		version, err := planRelease(c.refs)
 		switch {
 		case c.fails && err == nil:
-			errs = append(errs, fmt.Errorf("%v: planned %v, want an error", c.refs, plan.tags))
+			errs = append(errs, fmt.Errorf("%v: planned %q, want an error", c.refs, version))
 		case c.fails:
 		case err != nil:
 			errs = append(errs, fmt.Errorf("%v: %w", c.refs, err))
-		case plan.version != c.version:
-			errs = append(errs, fmt.Errorf("%v: version is %q, want %q", c.refs, plan.version, c.version))
-		case !slices.Equal(plan.tags, c.tags):
-			errs = append(errs, fmt.Errorf("%v: tags are %v, want %v", c.refs, plan.tags, c.tags))
+		case version != c.version:
+			errs = append(errs, fmt.Errorf("%v: version is %q, want %q", c.refs, version, c.version))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// releasePlan is what the refs at HEAD decided: the version being released, and
-// every tag that ends up pointing at it. A zero value is "this commit is not a
-// release".
-type releasePlan struct {
-	version string
-	tags    []string
-}
-
-// planRelease reads the refs at HEAD and returns what to publish.
+// planRelease reads the refs at HEAD and returns the version being released, or
+// the empty string when this commit is not a release.
 //
 // A ref counts only if it is a tag whose name is a canonical version. Everything
 // else — branches, remote refs, `refs/stash`, a tag named `nightly` — is ignored
 // rather than rejected, because a release commit routinely carries several refs
 // and none of the others is evidence of a mistake.
-func planRelease(refs []string) (releasePlan, error) {
+func planRelease(refs []string) (string, error) {
 	var versions []string
 	for _, ref := range refs {
 		name, ok := strings.CutPrefix(strings.TrimSpace(ref), "refs/tags/")
@@ -323,17 +273,22 @@ func planRelease(refs []string) (releasePlan, error) {
 
 	switch len(versions) {
 	case 0:
-		return releasePlan{}, nil
+		return "", nil
 	case 1:
 	default:
-		return releasePlan{}, fmt.Errorf("HEAD carries more than one version tag (%s): which release this is, and which of them the moving tags should follow, is not a question this pipeline can answer", strings.Join(versions, ", "))
+		return "", fmt.Errorf("HEAD carries more than one version tag (%s): which release this is, and which of them the moving tags should follow, is not a question this pipeline can answer", strings.Join(versions, ", "))
 	}
 
-	tags, err := versionTags(versions[0])
-	if err != nil {
-		return releasePlan{}, err
+	// An OCI tag is [A-Za-z0-9_.-], which has no `+` in it. Refusing is the only
+	// honest answer: mangling the metadata away would publish `v0.2.0` and
+	// `v0.2.0+build.5` as the same tag, and this project's contract says a
+	// published version tag is never repointed. The archetype refuses it as well;
+	// refusing it here is what keeps the answer the same for a commit nobody was
+	// ever going to publish.
+	if v, _ := parseVersion(versions[0]); v.build != "" {
+		return "", fmt.Errorf("version tag %q carries build metadata, which cannot be spelled in an OCI tag: release it under a version without one", versions[0])
 	}
-	return releasePlan{version: versions[0], tags: tags}, nil
+	return versions[0], nil
 }
 
 // version is a parsed canonical version tag.
@@ -373,272 +328,90 @@ func parseVersion(tag string) (version, bool) {
 	}, true
 }
 
-// versionTags is docs/container/SPEC.md's tag table, as a function.
-//
-// A release publishes the full version tag, which never moves, and the three
-// that do: the minor tag, the major tag and the rolling tag. A prerelease
-// publishes its own tag and nothing else — the moving tags are what a derived
-// Dockerfile pins to pick up fixes without an edit, and a release candidate is
-// not a fix anybody consented to be given.
-func versionTags(tag string) ([]string, error) {
-	v, ok := parseVersion(tag)
-	if !ok {
-		return nil, fmt.Errorf("%q is not a canonical version tag", tag)
-	}
-	// An OCI tag is [A-Za-z0-9_.-], which has no `+` in it. Refusing is the only
-	// honest answer: mangling the metadata away would publish `v0.2.0` and
-	// `v0.2.0+build.5` as the same tag, and this project's contract says a
-	// published version tag is never repointed.
-	if v.build != "" {
-		return nil, fmt.Errorf("version tag %q carries build metadata, which cannot be spelled in an OCI tag: release it under a version without one", tag)
-	}
-	if v.prerelease != "" {
-		return []string{tag}, nil
-	}
-	return []string{
-		tag,
-		"v" + v.major + "." + v.minor,
-		"v" + v.major,
-		rollingTag,
-	}, nil
-}
-
-// releaseImage is one image a release publishes: where it goes, how it is
-// pushed, and which executables it ships — the last being what the SBOMs
-// describe.
+// releaseImage is one image a release publishes: the repository it goes to and
+// the application that is pushed there.
 type releaseImage struct {
-	repository  string
-	executables []string
-	publish     func(ctx context.Context, address string) (string, error)
+	repository string
+	app        *dagger.Z5LabsApp
+	// generator is the built-in this image carries, or the empty string for the
+	// base. It is what tells releaseContract which listing to hold the image to,
+	// and it is a name rather than a listing so that the check reads the same
+	// table GeneratorImageContract reads.
+	generator string
 }
 
-// releaseImages is every image a release publishes, derived from the base
-// image's repository.
+// releaseImages is every image a release publishes, derived from the base image's
+// repository.
 //
 // The generator repositories are `<base>-gen-<name>`, which is the naming
-// docs/container/SPEC.md uses throughout — `avroc-gen-go` beside `avroc`. The
-// set of generators comes from builtinGenerators, so a fourth one is published
-// by being added there and nowhere else.
+// docs/container/SPEC.md uses throughout — `avroc-gen-go` beside `avroc`. The set
+// of generators comes from builtinGenerators, so a fourth one is published by
+// being added there and nowhere else.
 //
-// Each entry pushes through Publish or PublishGenerator rather than through a
-// path of its own. Those two are what a person calls to put an image on a test
-// registry, and a release that pushed by some other route would be exercising
-// something nobody can reproduce by hand.
-func (m *Avroc) releaseImages(repository, username string, password *dagger.Secret) []releaseImage {
+// Every entry is an App built at the release's version, and every one of them is
+// built exactly as the check stages build theirs — the version is the only
+// difference, which is what makes `dagger call image-contract` on a pull request a
+// statement about the image that release will push.
+//
+// The bundle is deliberately absent, as it always was: it is a convenience for
+// checking that three generators compose, and docs/container/SPEC.md publishes one
+// image per generator.
+func (m *Avroc) releaseImages(repository, version string) []releaseImage {
 	images := []releaseImage{{
-		repository:  repository,
-		executables: baseImageExecutables(),
-		publish: func(ctx context.Context, address string) (string, error) {
-			return m.Publish(ctx, address, username, password)
-		},
+		repository: repository,
+		app:        m.baseApp(version),
 	}}
 	for _, name := range builtinGenerators() {
 		images = append(images, releaseImage{
-			repository:  repository + "-gen-" + name,
-			executables: append(baseImageExecutables(), generatorExecutable(name)),
-			publish: func(ctx context.Context, address string) (string, error) {
-				return m.PublishGenerator(ctx, name, address, username, password)
-			},
+			repository: repository + "-gen-" + name,
+			app:        m.generatorImageApp(name, version),
+			generator:  name,
 		})
 	}
 	return images
 }
 
-// publishTags pushes one image under every tag the release carries, and returns
-// the digest they all point at.
+// releaseContract holds every image a release is about to publish to
+// docs/container/SPEC.md, on every platform, before anything is pushed.
 //
-// Every tag is a separate push of the same content, so the registry stores one
-// manifest and the tags are names for it. The digests are required to agree,
-// which is the machine-checkable form of the promise the tag table makes: `v0.2`
-// and `v0.2.0` are the same image, or one of them is lying.
-func publishTags(ctx context.Context, image releaseImage, tags []string) (string, error) {
-	var digest string
-	for _, tag := range tags {
-		ref, err := image.publish(ctx, image.repository+":"+tag)
-		if err != nil {
-			return "", fmt.Errorf("publishing %s:%s: %w", image.repository, tag, err)
-		}
-		_, pushed, ok := strings.Cut(ref, "@")
-		if !ok {
-			return "", fmt.Errorf("publishing %s:%s returned %q, which is not digest-qualified", image.repository, tag, ref)
-		}
-		switch {
-		case digest == "":
-			digest = pushed
-		case pushed != digest:
-			return "", fmt.Errorf("%s:%s published as %s but %s:%s published as %s: every tag of one release names one image", image.repository, tag, pushed, image.repository, tags[0], digest)
-		}
-	}
-	return digest, nil
-}
+// It is the same assertions ImageContract and GeneratorImageContract make, over
+// the containers these Apps carry rather than over a second build of them — see
+// this file's comment. Every image and every platform is checked and every failure
+// collected: a release that is wrong is wrong on both architectures, and one run
+// should say so once for each.
+func (m *Avroc) releaseContract(ctx context.Context, images []releaseImage) error {
+	var errs []error
+	for _, image := range images {
+		for _, platform := range imagePlatforms() {
+			container := image.app.Container(platform)
 
-// cosign is the container every signature and attestation is produced in.
-//
-// The binary is built by the shared Go module at a pinned version rather than
-// pulled as a tool image, for the reason this file's comment gives. It is
-// installed into a container that has certificate authorities and a shell — the
-// signing flow talks to a public CA, a transparency log and the registry — and
-// which is emphatically not the published image, since that one deliberately has
-// none of those things.
-//
-// COSIGN_YES is what makes the flow non-interactive: without it cosign asks for
-// confirmation before writing to the public transparency log, and a release
-// would hang waiting for a person who is not there.
-func (m *Avroc) cosign(
-	idTokenRequestUrl string,
-	idTokenRequestToken *dagger.Secret,
-	host, username string,
-	password *dagger.Secret,
-	startedOn time.Time,
-) *dagger.Container {
-	return dag.Go().
-		Container(dag.Directory()).
-		WithFile("/usr/local/bin/cosign", dag.Go().Install(cosignPackage), dagger.ContainerWithFileOpts{
-			Permissions: executableMode,
-		}).
-		// The instant this release started, in the environment so that every
-		// signing command below is a different command on every run. Signing is
-		// side-effecting — it writes to a registry and to a public transparency
-		// log — and an exec whose arguments are identical to a previous one is
-		// one Dagger is entitled to skip. A release that silently skipped its
-		// own signatures would report success having signed nothing.
-		WithEnvVariable("AVROC_RELEASE_STARTED_ON", startedOn.Format(time.RFC3339Nano)).
-		WithEnvVariable("COSIGN_YES", "true").
-		// The two halves of the workload identity exchange, in the environment
-		// cosign's GitHub Actions provider reads them from. The token is a
-		// secret variable rather than a plain one because it mints identity
-		// tokens for this repository.
-		WithEnvVariable("ACTIONS_ID_TOKEN_REQUEST_URL", idTokenRequestUrl).
-		WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN", idTokenRequestToken).
-		WithSecretVariable("REGISTRY_PASSWORD", password).
-		// Through stdin rather than on the command line: an argument is visible
-		// to anything that can list processes in the container, and a token that
-		// can write packages is worth the extra line.
-		WithExec([]string{
-			"sh", "-c",
-			`printf '%s' "$REGISTRY_PASSWORD" | cosign login "$1" --username "$2" --password-stdin`,
-			"sh", host, username,
-		})
-}
+			contents := baseImageExecutables()
+			if image.generator != "" {
+				contents = append(contents, generatorExecutable(image.generator))
+			}
 
-// attest signs one published digest and attaches its provenance and SBOMs.
-//
-// The signature comes first: it is the claim the other two are read under, and a
-// digest carrying attestations nobody signed is worse than one carrying none,
-// because it looks verified from a distance.
-//
-// Everything names the digest rather than a tag, and the digest is the one
-// publishTags resolved — so what is signed is what was pushed, not whatever the
-// tag has come to mean by the time cosign resolves it.
-//
-// The signature reaches further than the attestations do, and deliberately:
-// signing is recursive over the index's per-platform manifests, while the
-// attestations go on the index digest alone. An attestation is a statement about
-// the release, and the release is the index; docs/container/SPEC.md says so
-// explicitly, so that nobody goes looking for a provenance statement on the
-// manifest their runtime happened to pull.
-func (m *Avroc) attest(
-	ctx context.Context,
-	signer *dagger.Container,
-	image releaseImage,
-	digest string,
-	predicate *dagger.File,
-) error {
-	const predicateAt = "/attestations/predicate.json"
+			for _, err := range m.checkImageConfig(ctx, container) {
+				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
+			}
+			for _, err := range m.checkImageFilesystem(ctx, container, contents) {
+				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
+			}
 
-	ref := image.repository + "@" + digest
-
-	// --recursive because what is published is an index over two platforms, and
-	// signing the index alone leaves the manifest a consumer's runtime actually
-	// pulls unsigned. `cosign verify` against the tag would still pass, which is
-	// the shape of gap worth closing rather than documenting.
-	c := signer.
-		WithExec([]string{"cosign", "sign", "--recursive", ref}).
-		WithFile(predicateAt, predicate).
-		WithExec([]string{"cosign", "attest", "--type", provenancePredicate, "--predicate", predicateAt, ref})
-
-	// One SBOM per executable per platform. Each document is tied to the
-	// SHA-256 of the binary it describes, so a single document for an image
-	// holding two executables on two platforms would name one of the four and
-	// be wrong about the other three.
-	for _, platform := range imagePlatforms() {
-		binaries := m.binaries(platform)
-		for _, executable := range image.executables {
-			at := fmt.Sprintf("/attestations/%s-%s.spdx.json", executable, strings.ReplaceAll(string(platform), "/", "-"))
-			c = c.
-				WithFile(at, dag.Go().Spdx(binaries.File(executable), m.Source)).
-				WithExec([]string{"cosign", "attest", "--type", sbomPredicate, "--predicate", at, ref})
+			if image.generator == "" {
+				if err := m.checkImageIsTheCLI(ctx, container); err != nil {
+					errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
+				}
+				if err := m.checkAMissingWorkingDirectoryIsLegible(ctx, container); err != nil {
+					errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
+				}
+				continue
+			}
+			if err := m.checkGeneratorRuns(ctx, container, image.generator); err != nil {
+				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
+			}
 		}
 	}
-
-	if _, err := c.Sync(ctx); err != nil {
-		return fmt.Errorf("signing and attesting %s: %w", ref, err)
-	}
-	return nil
-}
-
-// provenanceFacts is everything the provenance predicate says, gathered before
-// anything is rendered so that one release's four statements agree about the
-// commit, the ref and the run that produced them.
-type provenanceFacts struct {
-	Repository string
-	Version    string
-	Tags       []string
-	Source     string
-	Commit     string
-	Builder    string
-	Invocation string
-	StartedOn  time.Time
-}
-
-// provenanceStatement renders the SLSA v1 provenance predicate for one image.
-//
-// It is the predicate alone rather than a whole in-toto statement: cosign builds
-// the statement and fills in the subject from the digest it is signing, which is
-// the one field that must not be taken on this side's word.
-//
-// What it claims is deliberately narrow. Every field is something read from the
-// repository or handed in by the run — the commit, the ref, the workflow — and
-// nothing is asserted about hermeticity or reproducibility that this pipeline
-// does not check. A predicate that claimed more than it knew would be worse than
-// none, because a consumer would act on it.
-func provenanceStatement(facts provenanceFacts) (*dagger.File, error) {
-	platforms := make([]string, 0, len(imagePlatforms()))
-	for _, p := range imagePlatforms() {
-		platforms = append(platforms, string(p))
-	}
-
-	predicate := map[string]any{
-		"buildDefinition": map[string]any{
-			"buildType": buildType,
-			"externalParameters": map[string]any{
-				"repository": facts.Repository,
-				"version":    facts.Version,
-				"tags":       facts.Tags,
-				"platforms":  platforms,
-			},
-			"internalParameters": map[string]any{},
-			"resolvedDependencies": []any{
-				map[string]any{
-					"uri":    "git+" + facts.Source + "@refs/tags/" + facts.Version,
-					"digest": map[string]any{"gitCommit": facts.Commit},
-				},
-			},
-		},
-		"runDetails": map[string]any{
-			"builder": map[string]any{"id": facts.Builder},
-			"metadata": map[string]any{
-				"invocationId": facts.Invocation,
-				"startedOn":    facts.StartedOn.Format(time.RFC3339),
-			},
-		},
-	}
-
-	body, err := json.MarshalIndent(predicate, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("rendering the provenance predicate for %s: %w", facts.Repository, err)
-	}
-	return dag.Directory().WithNewFile("predicate.json", string(body)+"\n").File("predicate.json"), nil
+	return errors.Join(errs...)
 }
 
 // headRefs is every ref pointing at HEAD, as git reports them.
@@ -659,35 +432,6 @@ func headRefs(ctx context.Context, source, gitDir *dagger.Directory) ([]string, 
 	return refs, nil
 }
 
-// headCommit is the full SHA at HEAD, which is what the provenance names as the
-// source it was built from. Full rather than abbreviated: an abbreviation is a
-// prefix somebody has to resolve against a repository they may not have.
-func headCommit(ctx context.Context, source, gitDir *dagger.Directory) (string, error) {
-	out, err := gitContainer(source, gitDir).
-		WithExec([]string{"git", "rev-parse", "HEAD"}).
-		Stdout(ctx)
-	if err != nil {
-		return "", fmt.Errorf("reading the commit at HEAD: %w", err)
-	}
-	return strings.TrimSpace(out), nil
-}
-
-// sourceURI is where the source came from, as the provenance's resolved
-// dependency. It is read from the checkout rather than passed in, so it names
-// the repository that was actually built and not the one somebody meant.
-func sourceURI(ctx context.Context, source, gitDir *dagger.Directory) (string, error) {
-	out, err := gitContainer(source, gitDir).
-		WithExec([]string{"git", "config", "--get", "remote.origin.url"}).
-		Stdout(ctx)
-	if err != nil {
-		return "", fmt.Errorf("reading the source repository's origin: %w", err)
-	}
-	// The `.git` suffix is how a clone URL is written and not part of the
-	// repository's identity; dropping it is what makes the provenance's URI the
-	// one a person would recognise.
-	return strings.TrimSuffix(strings.TrimSpace(out), ".git"), nil
-}
-
 // gitContainer is a container holding the source with its git metadata grafted
 // back on.
 //
@@ -696,14 +440,12 @@ func sourceURI(ctx context.Context, source, gitDir *dagger.Directory) (string, e
 // all of them. A release does read it, so it arrives here as its own argument
 // and is mounted rather than folded into the source — which keeps the release's
 // need from costing every other stage its cache.
+//
+// It is the only place in this file that runs git. The commit, its committer time
+// and the origin remote used to be read here too, for the provenance predicate
+// this module rendered; the archetype reads them itself now, out of appSource, and
+// its provenance takes every identifying field from the exchanged OIDC token's
+// claims rather than from anything a caller could have stated.
 func gitContainer(source, gitDir *dagger.Directory) *dagger.Container {
 	return dag.Go().Container(source).WithMountedDirectory("/src/.git", gitDir)
-}
-
-// registryHost is the host part of a repository reference, which is what cosign
-// authenticates against. `ghcr.io/z5labs/avroc` is a repository on `ghcr.io`;
-// everything after the first slash is a path within it.
-func registryHost(repository string) string {
-	host, _, _ := strings.Cut(repository, "/")
-	return host
 }

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -101,16 +101,20 @@ import (
 // here and why there is no `dagger call publish` beside this one — the only caller
 // with a token to exchange is the workflow.
 //
-// It returns a report naming every reference published, which is one line per tag
-// per repository, each pinned to the digest it resolved to.
+// The git metadata is New's, not an argument here. It used to be one, because the
+// release was the only thing in this module that read git; since #217 every image
+// build reads it too, so New binds it once and this reads m.GitDir. Two independent
+// inputs for one fact is what that avoids, and the way it would have gone wrong is
+// specific: `dagger call --git-dir=A release --git-dir=B` was accepted, and would
+// have taken the release *decision* from one tree while the archetype stamped and
+// annotated the images from the other.
+//
+// It returns a report naming every reference published, grouped by repository, each
+// pinned to the digest it resolved to.
 //
 // +cache="never"
 func (m *Avroc) Release(
 	ctx context.Context,
-	// The repository's git metadata. The refs at HEAD are what decides whether
-	// this commit is a release, so a checkout without tags publishes nothing.
-	// +defaultPath="/.git"
-	gitDir *dagger.Directory,
 	// The registry to publish to, without a repository path — `ghcr.io`.
 	registry string,
 	// The base image's repository within that registry, without a tag —
@@ -131,7 +135,7 @@ func (m *Avroc) Release(
 	// The refs are read before the arguments are checked, because "this commit is
 	// not a release" is the common answer and reaching it should not depend on a
 	// credential nobody is going to use.
-	refs, err := headRefs(ctx, m.Source, gitDir)
+	refs, err := headRefs(ctx, m.Source, m.GitDir)
 	if err != nil {
 		return "", err
 	}
@@ -170,15 +174,24 @@ func (m *Avroc) Release(
 
 	var report strings.Builder
 	for _, image := range images {
-		refs, err := image.app.
+		published, err := image.app.
 			WithRegistry(registry, username, password).
 			WithOidc(idTokenRequestUrl, idTokenRequestToken).
 			Publish(ctx, []string{image.repository})
 		if err != nil {
 			return report.String(), fmt.Errorf("publishing %s/%s: %w", registry, image.repository, err)
 		}
-		for _, ref := range refs {
-			fmt.Fprintf(&report, "%s\n", ref)
+
+		// Grouped by repository, one reference per line beneath it. Publish returns
+		// its references repository-major in tag-family order and this passes one
+		// repository per call, so the grouping is this loop's rather than an
+		// assumption about that ordering — which matters, because the archetype's
+		// own documentation calls the grouping a thing it may yet give a structured
+		// return type. A flat list of `<ref>@<digest>` lines is what a person reads
+		// this for, and the repository heading is what makes four of them legible.
+		fmt.Fprintf(&report, "%s/%s\n", registry, image.repository)
+		for _, ref := range published {
+			fmt.Fprintf(&report, "  %s\n", ref)
 		}
 	}
 	return report.String(), nil
@@ -279,13 +292,25 @@ func planRelease(refs []string) (string, error) {
 		return "", fmt.Errorf("HEAD carries more than one version tag (%s): which release this is, and which of them the moving tags should follow, is not a question this pipeline can answer", strings.Join(versions, ", "))
 	}
 
+	// Parsed a second time rather than carried out of the loop, and the `ok` is
+	// checked rather than discarded. It cannot be false today — the loop above only
+	// kept refs parseVersion already accepted — and that is exactly why it is worth
+	// a branch: `versionTags` used to be the thing that refused an unparseable tag,
+	// and without this the day the filter above admits something looser is the day a
+	// zero `version` passes the build-metadata check and an unrecognised tag reaches
+	// App.Publish as the release's version.
+	v, ok := parseVersion(versions[0])
+	if !ok {
+		return "", fmt.Errorf("%q reached the release plan without being a canonical version tag, which is a bug in this function", versions[0])
+	}
+
 	// An OCI tag is [A-Za-z0-9_.-], which has no `+` in it. Refusing is the only
 	// honest answer: mangling the metadata away would publish `v0.2.0` and
 	// `v0.2.0+build.5` as the same tag, and this project's contract says a
 	// published version tag is never repointed. The archetype refuses it as well;
 	// refusing it here is what keeps the answer the same for a commit nobody was
 	// ever going to publish.
-	if v, _ := parseVersion(versions[0]); v.build != "" {
+	if v.build != "" {
 		return "", fmt.Errorf("version tag %q carries build metadata, which cannot be spelled in an OCI tag: release it under a version without one", versions[0])
 	}
 	return versions[0], nil
@@ -374,39 +399,30 @@ func (m *Avroc) releaseImages(repository, version string) []releaseImage {
 // releaseContract holds every image a release is about to publish to
 // docs/container/SPEC.md, on every platform, before anything is pushed.
 //
-// It is the same assertions ImageContract and GeneratorImageContract make, over
-// the containers these Apps carry rather than over a second build of them — see
-// this file's comment. Every image and every platform is checked and every failure
-// collected: a release that is wrong is wrong on both architectures, and one run
-// should say so once for each.
+// It runs `checkBaseImage` and `checkGeneratorImage` — the *same* functions
+// ImageContract and GeneratorImageContract run, not a list assembled here — over
+// the containers these Apps carry rather than over a second build of them. That is
+// the whole point, and it is a mechanism rather than an intention: a check added to
+// either of those two is a check this gate acquires, where a hand-copied sequence
+// would have let one be added and the release stop short of it. It was a
+// hand-copied sequence in the first draft of #217, and a reviewer caught it.
+//
+// Every image and every platform is checked and every failure collected: a release
+// that is wrong is wrong on both architectures, and one run should say so once for
+// each.
 func (m *Avroc) releaseContract(ctx context.Context, images []releaseImage) error {
 	var errs []error
 	for _, image := range images {
 		for _, platform := range imagePlatforms() {
 			container := image.app.Container(platform)
 
-			contents := baseImageExecutables()
-			if image.generator != "" {
-				contents = append(contents, generatorExecutable(image.generator))
-			}
-
-			for _, err := range m.checkImageConfig(ctx, container) {
-				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
-			}
-			for _, err := range m.checkImageFilesystem(ctx, container, contents) {
-				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
-			}
-
+			var found []error
 			if image.generator == "" {
-				if err := m.checkImageIsTheCLI(ctx, container); err != nil {
-					errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
-				}
-				if err := m.checkAMissingWorkingDirectoryIsLegible(ctx, container); err != nil {
-					errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
-				}
-				continue
+				found = m.checkBaseImage(ctx, container)
+			} else {
+				found = m.checkGeneratorImage(ctx, container, image.generator)
 			}
-			if err := m.checkGeneratorRuns(ctx, container, image.generator); err != nil {
+			for _, err := range found {
 				errs = append(errs, fmt.Errorf("%s on %s: %w", image.repository, platform, err))
 			}
 		}

--- a/.dagger/tls_egress.go
+++ b/.dagger/tls_egress.go
@@ -153,7 +153,7 @@ func (m *Avroc) TlsEgress(
 		name  string
 		image *dagger.Container
 	}{
-		{"the base image", m.image(p)},
+		{"the base image", m.baseImage(p)},
 		{"the bundle image", m.generatorBundleImage(p)},
 	}
 

--- a/.dagger/trace_propagation.go
+++ b/.dagger/trace_propagation.go
@@ -362,7 +362,14 @@ func (m *Avroc) tracedGeneration(platform dagger.Platform, collector *dagger.Ser
 			"-endpoint", fmt.Sprintf("http://%s:%d", collectorHostname, collectorOtlpHTTPPort),
 			"-record", traceparentRecord,
 			"--",
-			pluginDir + "/" + cliExecutable, "generate",
+			// cliPath rather than the plugin directory: since #217 the archetype
+			// puts an application's own binary in its own directory and names it
+			// absolutely in the entrypoint, and the plugin directory is for what an
+			// extension adds. The launcher execs avroc by path rather than through
+			// the entrypoint because it *is* the entrypoint's replacement — it sets
+			// one environment variable and re-execs — so it has to name what the
+			// entrypoint would have run.
+			cliPath(), "generate",
 		})
 }
 
@@ -431,7 +438,15 @@ func (m *Avroc) propagationRemoved(ctx context.Context) (*Avroc, error) {
 			inject, path)
 	}
 
-	return &Avroc{Source: m.Source.WithNewFile(path, edited), LintConfig: m.LintConfig}, nil
+	// A copy of the receiver with one file replaced, rather than a fresh Avroc
+	// naming the fields it wants. Naming them is how this broke once: #217 added
+	// GitDir, a literal listing Source and LintConfig kept compiling, and the
+	// control's first call panicked on a nil directory a long way from here. The
+	// control differs from the committed tree in exactly one file, so saying that
+	// and nothing else is both shorter and the thing that stays true.
+	broken := *m
+	broken.Source = m.Source.WithNewFile(path, edited)
+	return &broken, nil
 }
 
 // traceparent is the W3C trace context the Dagger exec handed the container:

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -110,7 +110,7 @@ func (m *Avroc) WorkedExampleImage(
 	if err != nil {
 		return nil, err
 	}
-	return example.image(m.image(p), p), nil
+	return example.image(m.baseImage(p), p), nil
 }
 
 // WorkedExample is the worked example executed rather than read (#129): it
@@ -163,7 +163,7 @@ func (m *Avroc) WorkedExample(ctx context.Context) error {
 		return err
 	}
 
-	image := example.image(m.image(platform), platform)
+	image := example.image(m.baseImage(platform), platform)
 
 	var errs []error
 	if err := example.rules(); err != nil {
@@ -494,7 +494,13 @@ func (e *workedExample) contents() (map[string]imageEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	contents := imageContents(baseImageExecutables())
+	// The copied file is named as a plugin-directory executable so that the
+	// directory itself gets a row: since #217 the base image carries no
+	// /usr/local/bin, and this example's COPY is what creates it — which is
+	// exactly the sentence docs/container/SPEC.md now makes about a derived image.
+	// The entry is then overwritten with what the document actually asked for,
+	// which is the whole point of reading it rather than assuming it.
+	contents := imageContents([]string{path.Base(e.copy.dst)})
 	contents[e.copy.dst] = entry
 	return contents, nil
 }

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -494,13 +494,24 @@ func (e *workedExample) contents() (map[string]imageEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The copied file is named as a plugin-directory executable so that the
-	// directory itself gets a row: since #217 the base image carries no
-	// /usr/local/bin, and this example's COPY is what creates it — which is
-	// exactly the sentence docs/container/SPEC.md now makes about a derived image.
-	// The entry is then overwritten with what the document actually asked for,
-	// which is the whole point of reading it rather than assuming it.
-	contents := imageContents([]string{path.Base(e.copy.dst)})
+	// The plugin directory gets a row of its own, because since #217 the base image
+	// carries no /usr/local/bin and this example's COPY is what creates it — which
+	// is exactly the sentence docs/container/SPEC.md now makes about a derived
+	// image.
+	//
+	// It is keyed off the destination the document wrote rather than off a name
+	// round-tripped through path.Base: `dst` is already known to be a file directly
+	// inside pluginDir, because dockerfileCopy refuses anything else and says so
+	// naming the path, and asking path.Dir here rather than assuming it is what
+	// keeps this from quietly expecting `/usr/local/bin/bin` the day the document
+	// writes a directory destination. The entry itself is the document's own, which
+	// is the whole point of reading the COPY rather than assuming it; the directory
+	// is the builder's, and that its owner and mode are the base listing's rather
+	// than the COPY's `--chown` is something the stage passing is the evidence for.
+	contents := imageContents(nil)
+	if path.Dir(e.copy.dst) == pluginDir {
+		contents[pluginDir] = imageEntry{0, 0, 0o755}
+	}
 	contents[e.copy.dst] = entry
 	return contents, nil
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,11 +98,13 @@ jobs:
       # that does not change when a commit is made — full history costs this job a
       # slower checkout and costs those four stages nothing.
       #
-      # Tags are not fetched. The refs at HEAD decide whether a commit is a
-      # release, and that decision is release.yaml's; a pull request has no
-      # release in it, and `fetch-tags: true` here would only make `dagger call
-      # tag-scheme` look as though it were reading this commit, which it is not —
-      # it runs the derivation over a literal table.
+      # `fetch-depth: 0` brings tag refs with it, and that is fine rather than
+      # intended — do not read this as a checkout with no tags in it. Nothing here
+      # looks at them: `dagger call tag-scheme` runs the release derivation over a
+      # literal table and reads no repository at all, and the decision that a commit
+      # *is* a release belongs to release.yaml, which does its own checkout. A tag
+      # that happens to point at a pull request's HEAD therefore changes nothing
+      # this workflow does.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,14 +84,29 @@ jobs:
     env:
       DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     steps:
-      # A shallow checkout on purpose. The module excludes .git from the source
-      # directory it checks, because none of fmt, vet, lint or test reads git
-      # metadata, so there is nothing here for the extra history to feed. That
-      # changes with the archetype: a GoApp stamps binaries from the refs at
-      # HEAD and needs real metadata, so `fetch-depth: 0` comes back in the same
-      # change that drops .git from the module's ignore list.
+      # Full history, because this job builds images (#217). The checkout was
+      # shallow while nothing here read git metadata; the archetype the pipeline
+      # now builds on stamps every binary with the short HEAD SHA and annotates
+      # every image with the commit, its committer time and the origin remote, so
+      # a checkout with no real .git fails at the first image the contract checks
+      # ask for.
+      #
+      # It does *not* come with `.git` moving into the module's source directory,
+      # which is what the comment here used to predict. The module binds it as its
+      # own argument and folds it in on the one path that builds an App
+      # (.dagger/main.go's appSource), so fmt, vet, lint and test still see a tree
+      # that does not change when a commit is made — full history costs this job a
+      # slower checkout and costs those four stages nothing.
+      #
+      # Tags are not fetched. The refs at HEAD decide whether a commit is a
+      # release, and that decision is release.yaml's; a pull request has no
+      # release in it, and `fetch-tags: true` here would only make `dagger call
+      # tag-scheme` look as though it were reading this commit, which it is not —
+      # it runs the derivation over a literal table.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
 
       # Pinned to the engineVersion the module itself declares, read out of
       # dagger.json rather than repeated here. The CLI provisions an engine of

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,14 +127,14 @@ jobs:
       # this is the only job that pushes or signs anything, and a grant held in
       # advance is one nothing accounts for. `id-token: write` arrives in the
       # same change as the signing step that needs it: it is what lets the run
-      # ask GitHub for the workload identity token cosign exchanges for a
+      # ask GitHub for the workload identity token the publish exchanges for a
       # short-lived certificate, and it is also what puts
       # ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN in the
       # step environment below.
       contents: read
       packages: write
       id-token: write
-    # The three `dagger call`s below publish their traces, for the reason the
+    # The `dagger call` below publishes its trace, for the reason the
     # job above gives and with the same one-time setup — the account of what
     # this secret is and where an operator gets one is on that job, a screen up
     # in this file. It is repeated per job rather than hoisted to the workflow
@@ -178,19 +178,18 @@ jobs:
           this release publishes no trace. See the comment on this job for where an \
           operator gets one."
 
-      # The same contract check CI runs on every pull request, run once more
-      # against the tag before anything is pushed. A tag is published once and
-      # never repointed, so this is the last moment at which a broken promise
-      # costs nothing.
-      - name: Check the base image against its contract
-        run: dagger call image-contract
-
-      # And the images built FROM it, for the same reason: a tag is published
-      # once and never repointed, so this is the last moment at which a generator
-      # image that had stopped inheriting the entrypoint costs nothing.
-      - name: Check the generator images against the contract
-        run: dagger call generator-image-contract
-
+      # The contract check used to be two steps here, run against the tag before
+      # anything was pushed. It is a gate *inside* `dagger call release` now
+      # (#217), and the reason is the seam the archetype gives: the guarantee that
+      # the container a check read is the very container that will be pushed holds
+      # only within one chained call, so two separate `dagger call`s were a
+      # second, cache-identical build that merely agreed with the first. A
+      # published version tag is never repointed here, so "it was checked, and
+      # then an identical one was pushed" is not a property worth resting a
+      # release on. `dagger call image-contract` and
+      # `dagger call generator-image-contract` stay in build.yaml, where a pull
+      # request has no release to gate.
+      #
       # One call publishes all four images — the base and one per built-in
       # generator — as multi-platform indexes covering linux/amd64 and
       # linux/arm64, under every tag docs/container/SPEC.md's tag table gives
@@ -201,14 +200,23 @@ jobs:
       # generators come from the module, because that is where the set is
       # defined; a `for name in go json pcf` in this file would be forgotten
       # exactly once, at the release where a fourth generator silently did not
-      # get published. The tags come from the refs at HEAD, for the reason this
-      # job's comment gives. What this step supplies is the base repository —
-      # the generator repositories derive from it as `<base>-gen-<name>`, the
-      # naming that document already uses — and the credentials.
+      # get published. The tags come from the refs at HEAD by way of the shared
+      # archetype's tag family, for the reason this job's comment gives. What this
+      # step supplies is *where* — the registry and the base repository, the
+      # generator repositories deriving from it as `<base>-gen-<name>`, the naming
+      # docs/container/SPEC.md already uses — and the credentials.
+      #
+      # The registry and the repository are two arguments rather than one
+      # reference (#217), because the archetype separates them so that a mirror or
+      # an internal registry serves the same release by changing one of the two.
+      # `--builder` and `--invocation` are gone with the provenance predicate this
+      # module used to render: every identifying field now comes out of the
+      # exchanged OIDC token's claims, on the grounds that anything a caller could
+      # have supplied attests to nothing.
       #
       # The two ACTIONS_ID_TOKEN_REQUEST_* variables are put in the environment
-      # by `id-token: write` above. They are the workload identity exchange:
-      # cosign trades a token minted from them for a short-lived sigstore
+      # by `id-token: write` above. They are the workload identity exchange: the
+      # publish trades a token minted from them for a short-lived sigstore
       # certificate, so the signature says which workflow at which ref produced
       # the image rather than which key somebody is holding. The token is passed
       # as a secret because it mints identity tokens for this repository.
@@ -217,10 +225,9 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           dagger call release \
-            --repository "ghcr.io/${{ github.repository }}" \
+            --registry ghcr.io \
+            --repository "${{ github.repository }}" \
             --username "${{ github.actor }}" \
             --password env://REGISTRY_PASSWORD \
             --id-token-request-url "$ACTIONS_ID_TOKEN_REQUEST_URL" \
-            --id-token-request-token env://ACTIONS_ID_TOKEN_REQUEST_TOKEN \
-            --builder "${{ github.server_url }}/${{ github.workflow_ref }}" \
-            --invocation "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --id-token-request-token env://ACTIONS_ID_TOKEN_REQUEST_TOKEN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,15 +523,63 @@ grows a timestamp uses it rather than inventing its own.
 
 ### The published images
 
-`.dagger/image.go` builds the base image `docs/container/SPEC.md` describes, and
-that document is normative: `/usr/local/bin` on `PATH` holding the CLI **and no
-generator**, the CLI as `Entrypoint` with an empty `Cmd`, **no `WorkingDir` at
-all**, UID and GID 65532 owning the plugin directory and running the process,
-the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a `scratch`
-base — no shell, no libc, no package manager, so extension is `COPY`-only. The
-filesystem is now exactly the files that document names and nothing else: a 1777
-`/tmp` used to be grafted on for the descriptor, and #218 removed the reason for
-it rather than the mount that carried it (see "Where the descriptor is written").
+**Nothing here builds an image any more** (#217). `.dagger/` used to, and roughly
+1,900 of its lines existed for that reason; the refactored devex `z5labs` module is
+a chainable `Go` -> `App` -> `Publish` API and every promise avroc needed is the
+archetype's own, so `image.go`'s `image()`, `publishIndex`, `Publish`,
+`generator_image.go`'s `generatorImage`/`generatorBundleImage`/`PublishGenerator`
+and `release.go`'s `versionTags`/`publishTags`/`cosign`/`attest`/
+`provenanceStatement` are all deleted rather than wrapped. What is left in those
+files is avroc's two contributions, the composition, the release *decision* and the
+contract checks.
+
+`.dagger/image.go`'s `baseApp` is the base image `docs/container/SPEC.md` describes,
+and that document is normative: `/usr/local/bin` on `PATH` and **no executable in
+it** — no generator, and since #217 not the CLI either, whose path that document
+always called implementation detail — the CLI as `Entrypoint` with an empty `Cmd`,
+**no `WorkingDir` at all**, UID and GID 65532 running the process and owning every
+file, the IR `FileDescriptorSet` at `/usr/local/share/avroc/ir.binpb`, and a
+`scratch` base — no shell, no libc, no package manager, so extension is `COPY`-only.
+A 1777 `/tmp` used to be grafted on for the descriptor, and #218 removed the reason
+for it rather than the mount that carried it (see "Where the descriptor is
+written").
+
+Two lines are avroc's: the package the archetype compiles (`cliPackage`) and the
+`FileDescriptorSet`, which arrives as a **contribution carrying a document** —
+`Z5Labs.FileDocument` with an explicit `MIT` and no invented version, because a
+protobuf descriptor set has no ecosystem able to produce one, and because a publish
+assembles the image's SPDX and CycloneDX pair out of one document per thing that
+entered it. Everything else falls out of the archetype, `Publish` asserting the whole
+image configuration before it pushes.
+
+**A generator image is composition, not `FROM` plus `COPY`.** Each generator is its
+own `App` — through the *generic* `Z5Labs.App` constructor rather than the Go chain,
+because the chain names a binary after `go.mod`'s module path and avroc's four
+commands share one module, so all four would be called `avroc` — and
+`App.WithApp` lands its entry in the plugin directory under its own name, matched
+platform by platform, with its document joining the base's, its version recorded,
+and its entry exec'd in every variant before the first byte is pushed. The bundle is
+the same base with all three composed in. `builtinGenerators` survives, because the
+set of generators is this repository's.
+
+**Four consumer-visible breaks ship with the adoption**, and `docs/container/SPEC.md`
+requires the next *minor* release's notes to name every one: attestation discovery
+becomes referrers-only (`cosign verify-attestation` finds nothing; `oras discover`
+does), the SBOM's subject moves from the executable to the whole image, the plugin
+directory is no longer present-and-empty in the base (a contribution to any directory
+on `PATH` is refused, and composition would mean shipping a generator in the base),
+and no directory is 65532-owned any more. The first two were anticipated by #217; the
+last two were found by re-deriving the unexpressible promises against the *landed*
+API, which is what that story asked for.
+
+**`.git` is bound apart from the source.** The archetype stamps the short HEAD SHA
+into every binary and annotates every image with the commit, its committer time and
+the origin, so an `App` needs real git metadata — and `New`'s ignore list keeps it out
+of `Source` so that fmt, vet, lint and test do not miss their cache on every commit.
+`New` takes a `gitDir` argument (`+defaultPath="/.git"`) and `appSource` is the one
+place the two are put back together; `build.yaml` fetches full history because a pull
+request builds images. The cost is that a git *worktree* has a `.git` file rather than
+a directory, so the image stages do not run from one — already true of `Release`.
 
 **The image sets no working directory, and that is a decision** (#219,
 `docs/container/SPEC.md`'s "The working directory"). `WorkingDir` was `/work` and
@@ -546,7 +594,7 @@ directory is mode `0555` and a `/work` that is not writable is not one a
 generation can write into. What made it affordable is that `-w /work` is a path
 the invocation already contains, where #218's `--tmpfs /tmp:mode=1777` was a fact
 an adopter had no way to possess. It is a **break**, deliberately, and the SPEC
-requires the next minor release's notes to name it beside #217's two rather than
+requires the next minor release's notes to name it beside #217's four rather than
 claiming they already do.
 
 Every check that reached `avroc.json` through the image's working directory now
@@ -588,37 +636,46 @@ of them exist because **an absence is the easiest thing to leave unchecked**.
   block three ways and requires each to be refused, because the failure path of an
   extractor nobody has broken is a check nobody knows the state of.
 
-`.dagger/generator_image.go` builds the three images that carry avroc's own
+`.dagger/generator_image.go` composes the three images that carry avroc's own
 generators, each of them the base plus one executable in the plugin directory
-(#127). The generators are deliberately not in the base: a built-in on `PATH`
+(#127, #217). The generators are deliberately not in the base: a built-in on `PATH`
 because the pipeline put it there is not a consumer of the extension mechanism,
 and the first person to discover that the mechanism needs a path the contract
 does not promise would otherwise have been a stranger at their own
-`docker build`. `dagger call generator-image --name go`, `... publish-generator`
-and `... generator-bundle-image` — the last being all three combined by copying
-each executable out of the image that publishes it, which is what an adopter
-writes as `COPY --from`.
+`docker build`. `dagger call generator-image --name go` and
+`... generator-bundle-image` are the accessors; there is no `publish-generator` any
+more, because the archetype's publish is signed and attested by construction and the
+only caller with an OIDC token to exchange is the release workflow.
 
-It is built here rather than by the devex `GoApp` archetype, whose image half
-produces one scratch image per binary with `/app/<binaryName>` as entrypoint and
-nothing else set; `image.go`'s package comment records why that was the choice
-over extending `GoApp` upstream or accepting a non-scratch base (#126). The
-check stages still route through the Z5Labs standard, so there is still one
-definition of what "checked" means.
+The bundle used to be all three combined by copying each executable *out of the
+image that publishes it*, which is what an adopter writes as `COPY --from`; it is
+three `WithApp` calls onto one base now. What was lost is that the old shape
+incidentally demonstrated a derived image of a derived image; the archetype states
+that composition is transitive, so nothing rests on having shown it. What was gained
+is that each generator arrives with its own document and version, collisions are
+refused rather than layered over, and every composed entry is exec'd in the finished
+image before it is pushed.
 
 `dagger call image-contract` is the compatibility guarantees table executed
 rather than read — the OCI configuration, an *exact* listing of every path in
 the image with its owner and mode, and `help` through the entrypoint, which is
-all a base holding no generator can be asked to do.
+all a base holding no generator can be asked to do. Since #217 the same
+assertions are also a **gate inside `Release`** (`releaseContract`), and
+`release.yaml` no longer calls the two contract stages as steps of its own: the
+archetype's guarantee that the container a check read is *the very container that
+will be pushed* holds only within one chained call, so two separate `dagger call`s
+were a second, cache-identical build that merely agreed. The standalone calls stay
+for pull requests, which have no release to gate.
 `dagger call generator-image-contract` is the other half: each generator image's
 configuration inherited unchanged, its filesystem exhaustively equal to the
 base's plus one executable (which is how "only `COPY` ran" becomes an assertion),
 each image generating with its own generator through the inherited entrypoint,
 and the combined image reproducing the committed `example/` byte for byte as 65532
-and as an overridden UID. CI runs both on every pull request;
-`dagger call publish --address <ref>` and `dagger call publish-generator --name
-<name> --address <ref>` push one multi-platform index to the reference they are
-given, and are what a person calls to put an image on a test registry.
+and as an overridden UID. CI runs both on every pull request. There is no
+`dagger call publish` for a person to put an image on a test registry: the
+archetype's publish is signed and attested by construction and refuses a run it
+cannot produce provenance for, so `dagger call image export --path ./avroc.tar` plus
+`docker load` is what looking at one costs now.
 
 **The image carries no CA certificate bundle, and that is a decision** (#198,
 `docs/container/SPEC.md`'s "No certificate authorities"). A scratch image has no
@@ -736,12 +793,13 @@ only until the next regeneration lowered it again, so the exclusion removes a
 hazard rather than a protection, and `osvVulnerabilityAlerts` no longer reaching
 them is the intended outcome and not its cost. `engineVersion` is the lever that
 moves those requires, and the `pin` SHAs beside it are the lever that moves the
-devex dependencies; neither is Renovate-managed today. The rule names the
-generated files rather than the directories holding them, because
-`.dagger/release.go` carries a custom regex manager — the cosign module version —
-that a directory-wide `ignorePaths` entry would silently switch off, and it is
-last in `packageRules` because the `indirect` rule above it would otherwise
-re-enable exactly the requires it excludes.
+devex dependencies; neither is Renovate-managed today. The rule still names the
+generated files rather than the directories holding them, even though the thing that
+forced it is gone: `.dagger/release.go` carried a custom regex manager for the cosign
+module version until #217 deleted the pin with the signing code, and the rule that a
+directory-wide `ignorePaths` entry silently switches off whatever gets added to that
+directory outlives its first instance. It is last in `packageRules` because the
+`indirect` rule above it would otherwise re-enable exactly the requires it excludes.
 
 ### Releasing the images
 
@@ -756,16 +814,28 @@ the others; two version tags is an error. `dagger call tag-scheme` runs that
 derivation over a table of cases on every pull request, with every expected tag
 written as a literal so the check cannot move with the constant it is checking.
 
-Each published digest is then signed with `cosign`, keyless: the identity is the
-release workflow, certified per run by the public sigstore CA from the OIDC token
-`id-token: write` lets the run mint, so there is no avroc key for anybody to hold
-or trust. Signing is recursive, so the published index and every per-platform
-manifest under it are signed; the attestations — a SLSA v1 provenance statement
-and one SPDX SBOM per executable per platform — go on the **index digest** and
-only there. Nothing is ever attached to a tag.
-The verifying commands are `docs/container/SPEC.md`'s "Verifying a signature",
-and cosign itself is built by `dag.Go().Install` at a module version pinned in
-`release.go`, so there is no tool image here to keep in step with an upstream tag.
+**The tag family, the signature and the attestations are the archetype's** (#217).
+`planRelease` answers "is this a release, and which version" and stops there;
+`App.Publish` derives `v0.2.0` -> `v0.2` -> `v0` -> `latest` from that version, pushes
+one manifest list per repository with every tag pointing at the one digest, signs the
+index and every per-platform manifest under it, and attaches a signed SLSA v1
+provenance statement plus an SPDX and a CycloneDX document per platform. `versionTags`,
+`publishTags`, `cosign`, `attest`, `provenanceStatement` and the `cosignPackage` pin are
+gone, and so are `Release`'s `--builder` and `--invocation`: every identifying field in
+the provenance comes out of the exchanged OIDC token's claims, because anything a
+caller could have supplied attests to nothing. `--repository` split into `--registry`
+plus `--repository` for the same reason the archetype splits them — a mirror serves the
+same release by changing one of the two.
+
+Signing is still keyless with no avroc key for anybody to hold, and nothing is ever
+attached to a tag. Two things a consumer runs did change and are named in
+`docs/container/SPEC.md`'s "Verifying a signature": the attestations are OCI
+**referrers and nothing else**, so `cosign verify-attestation` reports none and
+`oras discover` is what finds them, and each SBOM describes the **whole image**
+rather than one executable. `cosign verify` is untouched.
+
+`TagScheme` shrank to the half avroc still decides, and its table lost the `tags`
+column with `versionTags`. Every expected value is still a literal.
 
 ### Key Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,16 @@ rather than read: the plugin directory and its place on `PATH`, the entrypoint,
 the empty `Cmd`, the *absence* of a working directory, the pinned non-root UID,
 the absence of a shell, and the `FileDescriptorSet`'s path.
 
-The base ships the CLI and **no generator**. avroc's own three are images built
-`FROM` it, one `COPY` each, exactly as a stranger's generator image is
-(`generator-image --name go|json|pcf`), and `generator-image-contract` checks
-them: the configuration inherited unchanged, a filesystem that is the base's plus
-exactly one executable, each image generating with its own generator through the
-inherited entrypoint, and the combined image reproducing the committed
+The base ships **no generator**, and since #217 the CLI is not in the plugin
+directory either — the shared archetype puts an application's own binary in its own
+directory and names it absolutely in the entrypoint, and
+[`docs/container/SPEC.md`](docs/container/SPEC.md) had always said the CLI's own
+path was implementation detail. avroc's own three generators are the base image
+with one generator composed into it (`generator-image --name go|json|pcf`), which
+is what a stranger's `COPY` is, and `generator-image-contract` checks them: the
+configuration inherited unchanged, a filesystem that is the base's plus exactly one
+executable, each image generating with its own generator through the inherited
+entrypoint, and the combined image reproducing the committed
 [`example/`](example/) as itself and as an overridden UID.
 
 It is a check because every one of those promises is depended on from a
@@ -90,9 +94,12 @@ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/example:/work" -w /work \
   <image> generate
 ```
 
-`dagger call publish --address …` and `dagger call publish-generator --name …
---address …` push one multi-platform index to the reference you give them, which
-is how to put an image on a registry of your own.
+There is no `dagger call publish`. Publishing is `dagger call release`'s, and only
+the release workflow can run it: every published digest is signed and carries
+provenance whose identity comes from an OIDC token exchange, and a publish the
+pipeline cannot produce provenance for fails rather than publishing without it. To
+look at an image, export the tarball above; to try one on a registry of your own,
+`docker load` it and `docker push` it under a name you own.
 
 ### The companion Dagger module
 
@@ -161,11 +168,16 @@ so it is a stage of its own:
 dagger call tag-scheme
 ```
 
-Each published digest is signed with `cosign` keyless, with a SLSA provenance
-statement and an SPDX SBOM per executable per platform attached beside it. There
-is no avroc signing key: the identity is the release workflow, certified per run
-from the OIDC token GitHub mints for it. `docs/container/SPEC.md`'s [Verifying a
-signature](docs/container/SPEC.md#verifying-a-signature) is the consumer's half.
+Each published digest is signed keyless, with a SLSA provenance statement and an
+SPDX and a CycloneDX document per platform describing the whole image attached
+beside it as OCI referrers. There is no avroc signing key: the identity is the
+release workflow, certified per run from the OIDC token GitHub mints for it, and a
+publish that cannot produce provenance fails rather than publishing without it.
+`docs/container/SPEC.md`'s [Verifying a
+signature](docs/container/SPEC.md#verifying-a-signature) is the consumer's half, and
+it is where the two things #217 changed for a consumer are written down —
+`cosign verify-attestation` no longer finds anything, and the SBOM's subject is the
+image.
 
 ### Getting the tools
 
@@ -247,7 +259,7 @@ it is the root module calling the companion one.
 
 `ci` does not implement the four stages. It hands the source to
 [`github.com/z5labs/devex/daggerverse/z5labs`](https://github.com/z5labs/devex/tree/main/daggerverse/z5labs)
-and lets that module's `GoLib` archetype run them — the same standard every other
+and lets that module's `Go` chain run them — the same standard every other
 Z5Labs repository runs.
 
 Reimplementing them here would be a second definition of what "checked" means in
@@ -258,32 +270,33 @@ wrote down. Wrapping costs one dependency and makes that impossible. The full
 reasoning, including why the stage functions are not a fork of it, is in
 [`.dagger/main.go`](.dagger/main.go)'s package comment.
 
-Both dependencies in [`dagger.json`](dagger.json) are pinned to one `devex`
+All four `devex` dependencies in [`dagger.json`](dagger.json) are pinned to one
 commit, so a bump has to move them together — otherwise a stage run on its own
 stops being the stage `ci` runs.
 
-### `GoLib`, even though avroc has four commands
+### The images are the archetype's too, since #217
 
-`GoLib` is not a claim that avroc is a library. There are four `package main`
-binaries under [`cmd/`](cmd/), so the usual reason to call `GoLib` — no main
-package for the image half of the standard to act on — does not apply here. Two
-reasons that do:
+This module used to build avroc's published images itself, and about 1,900 of its
+lines existed for that reason: the standard pipeline's image half produced one
+`scratch` image per binary with `/app/<binaryName>` as entrypoint and nothing else —
+no `PATH`, no `USER`, no plugin directory — and avroc's image is a public contract
+that has to promise all three.
 
-- **The check stages are identical either way.** `GoApp` and `GoLib` route fmt,
-  vet, lint and `go test -race` through the same shared check, so the choice
-  costs this pipeline nothing in coverage.
-- **`GoApp`'s image half is not the image avroc needs.** It builds a `scratch`
-  image per binary with `/app/<binaryName>` as entrypoint and nothing else: no
-  `PATH`, no `USER`, no plugin directory. avroc's published image is a documented
-  public contract that has to promise all three, because generator images are
-  built `FROM` it and avroc discovers generators on `PATH`.
+The refactored `z5labs` module makes every one of those the standard's own, so
+`image`, `generator-image`, `generator-bundle-image` and `release` are now thin
+things over its `Go` → `App` → `Publish` chain. What stayed here is the part that is
+about *this* project: the contract checks, the decision about whether a commit is a
+release, and the list of generators avroc ships.
 
-So this module takes the checks, and the base-image work owns how images get
-built — whether by extending `GoApp` upstream in `devex`, building the image
-here, or using a non-`scratch` base. Moving to `GoApp` is a change to which
-factory `New` calls, plus dropping `.git` from its ignore list and restoring
-`fetch-depth: 0` in the workflow, because a `GoApp` stamps binaries from the refs
-at HEAD and does read git metadata.
+One consequence a contributor meets immediately: **the stages that build an image
+need real git metadata**, because the archetype stamps every binary with the short
+HEAD SHA and annotates every image with the commit and the origin. `New` binds
+`.git` as its own argument and folds it in only on the path that builds an App, so
+`fmt`, `vet`, `lint` and `test` keep the cache-stable tree they always had — but a
+git *worktree* has a `.git` file rather than a directory, so `image-contract`,
+`generator-image-contract`, `worked-example`, `companion-module`, `tls-egress` and
+`trace-propagation` do not run from one. Run them from an ordinary clone. That was
+already true of `release`.
 
 ## Linting
 

--- a/dagger.json
+++ b/dagger.json
@@ -11,23 +11,23 @@
     },
     {
       "name": "go",
-      "source": "github.com/z5labs/devex/daggerverse/go@47e25f065653c481a6d1567537307f2565bfa316",
-      "pin": "47e25f065653c481a6d1567537307f2565bfa316"
+      "source": "github.com/z5labs/devex/daggerverse/go@c10a12007999eb807f68cd9af9000fbaeab159cb",
+      "pin": "c10a12007999eb807f68cd9af9000fbaeab159cb"
     },
     {
       "name": "grafana-stack",
-      "source": "github.com/z5labs/devex/daggerverse/grafana-stack@47e25f065653c481a6d1567537307f2565bfa316",
-      "pin": "47e25f065653c481a6d1567537307f2565bfa316"
+      "source": "github.com/z5labs/devex/daggerverse/grafana-stack@c10a12007999eb807f68cd9af9000fbaeab159cb",
+      "pin": "c10a12007999eb807f68cd9af9000fbaeab159cb"
     },
     {
       "name": "otel",
-      "source": "github.com/z5labs/devex/daggerverse/otel@47e25f065653c481a6d1567537307f2565bfa316",
-      "pin": "47e25f065653c481a6d1567537307f2565bfa316"
+      "source": "github.com/z5labs/devex/daggerverse/otel@c10a12007999eb807f68cd9af9000fbaeab159cb",
+      "pin": "c10a12007999eb807f68cd9af9000fbaeab159cb"
     },
     {
       "name": "z5labs",
-      "source": "github.com/z5labs/devex/daggerverse/z5labs@47e25f065653c481a6d1567537307f2565bfa316",
-      "pin": "47e25f065653c481a6d1567537307f2565bfa316"
+      "source": "github.com/z5labs/devex/daggerverse/z5labs@c10a12007999eb807f68cd9af9000fbaeab159cb",
+      "pin": "c10a12007999eb807f68cd9af9000fbaeab159cb"
     }
   ],
   "source": ".dagger",

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -88,11 +88,11 @@ stating what each half of it buys. The path is what a `COPY` line writes; the
 manifest asks for. Either one alone is useless, which is why they are one
 requirement here rather than two facts in different sections.
 
-The image **MUST** set `Env` such that `PATH` contains `/usr/local/bin`, and the
-directory **MUST** exist in the base image even when it is empty, so that a
-`COPY` into it never depends on the builder creating it. The base image holds one
-executable in it — the avroc CLI — and **no generator**: avroc's own three are
-images built `FROM` the base, exactly as a stranger's is, and
+The image **MUST** set `Env` such that `PATH` contains `/usr/local/bin`. The base
+image holds **no executable** in it — not a generator, and since #217 not the
+avroc CLI either, whose own path is [implementation
+detail](#the-clis-own-path-is-not-part-of-the-contract). avroc's own three
+generators are images built `FROM` the base, exactly as a stranger's is, and
 [avroc's own generators](#avrocs-own-generators) is where they are described
 (#127). A derived image
 **MUST NOT** remove the directory from `PATH` or shadow it with an earlier entry
@@ -100,6 +100,24 @@ containing an executable of the same name; the plugin contract's rule that
 [the earliest `PATH` match
 wins](../plugin/SPEC.md#discovery) is exactly what makes that a way to silently
 substitute a generator.
+
+**The directory does not exist in the base image until something is copied into
+it**, and a `COPY` is what creates it (#217). This document required its presence
+when empty, on the grounds that a `COPY` should not depend on the builder creating
+its destination; that requirement is **withdrawn**, because the shared pipeline
+avroc's images are now built by refuses to put content in any directory the
+image's `PATH` resolves against — content with no architecture that something
+could find by name is how an `arm64` image comes to run an `amd64` executable —
+and the sanctioned way in is to compose a whole application, which for the base
+would mean shipping a generator in it.
+
+Nothing a derived image does changes: every OCI builder creates a `COPY`'s
+destination directory, `--chown` and `--chmod` on that `COPY` apply to it, and the
+[worked example](#worked-example-adding-a-generator) is built and run by the
+pipeline on every pull request with no instruction added. What is lost is only the
+belt-and-braces promise, and it is called out in the release notes of the release
+that withdraws it rather than left to be discovered — see [how a covered thing
+would change](#how-a-covered-thing-would-change).
 
 An executable copied there **MUST** be executable by the [image's
 user](#the-user) and **MUST** be a statically linked native executable for the
@@ -215,12 +233,12 @@ a path that exists to be mounted over, and [No shell](#no-shell)'s "the base is
 `scratch` plus the files this document names" is a better guarantee without it.
 
 There is a second reason, and it is deliberately *not* stated as a property of
-this image: the shared pipeline this project is moving its build onto sets no
+this image: the shared pipeline this project's build has since moved onto sets no
 working directory and states that as a decision rather than an omission (#217).
 How the image is built is [out of
 scope](#how-the-image-is-built-and-published) here, so that is not a reason a
-consumer can check and it is not offered as one — it is why the promise is being
-spent now, while it can still be, rather than why it was not worth keeping.
+consumer can check and it is not offered as one — it is why the promise was spent
+then, while it still could be, rather than why it was not worth keeping.
 
 > **Breaking change.** This is one. Every `docker run` in this document, in
 > [`README.md`](../../README.md) and in [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
@@ -228,10 +246,13 @@ spent now, while it can still be, rather than why it was not worth keeping.
 >
 > Two things follow, and they are requirements on the release rather than
 > descriptions of one already made. It **MUST NOT** ship in a patch release; it
-> ships in the next minor, beside the other breaks #217 carries — attestation
-> discovery becoming referrers-only, and the SBOM's subject moving from the
-> executable to the image. And that release's notes **MUST** name it, with the
-> invocation a caller has to write instead, which is what [How a covered thing
+> ships in the next minor, beside the other four breaks #217 carries — attestation
+> discovery becoming referrers-only, the SBOM's subject moving from the executable
+> to the image, the [plugin directory](#the-plugin-directory) no longer being
+> present-and-empty in the base, and [no directory being
+> 65532-owned](#what-it-means-for-ownership). And that release's notes **MUST** name
+> every one of them, this one with the invocation a caller has to write instead,
+> which is what [How a covered thing
 > would change](#how-a-covered-thing-would-change) requires of a guarantee that is
 > withdrawn rather than moved.
 >
@@ -267,13 +288,22 @@ the number other people's tooling already expects.
 
 ### What it means for ownership
 
-The [plugin directory](#the-plugin-directory) is owned by 65532:65532 in the base
-image, and is the only directory in it that is: there is no [working
-directory](#the-working-directory) in the image to own. A
-derived image copying a plugin in **SHOULD** use `--chown=65532:65532` and
-**MUST** ensure the result is readable and executable by that user; a
-world-readable, world-executable file satisfies this without the `--chown`,
-which is what makes the omission a latent bug rather than an immediate one.
+**No directory in the image is owned by 65532:65532**, and none needs to be: the
+[plugin directory](#the-plugin-directory) is not in the base image at all until a
+`COPY` creates it, there is no [working directory](#the-working-directory) in the
+image to own, and every directory the image does carry is root-owned and
+world-traversable, which is what an executable inside one needs in order to be
+reachable (#217). The plugin directory was 65532-owned before that; nothing
+depended on it, because a `COPY` in a derived image runs as root in the builder.
+
+What a consumer does depend on is the **executable**. A derived image copying a
+plugin in **SHOULD** use `--chown=65532:65532` and **MUST** ensure the result is
+readable and executable by that user; a world-readable, world-executable file
+satisfies this without the `--chown`, which is what makes the omission a latent bug
+rather than an immediate one. Every file avroc's own images ship is world-readable
+and every executable in them is world-executable, so an
+[overridden UID](#writing-files-a-caller-can-read) runs the same image the same
+way.
 
 Files avroc writes are created by the process, so they are owned by whatever UID
 the container is actually running as — 65532 by default.
@@ -564,10 +594,31 @@ about which of the two things a signature is on (#128):
   under it, so the manifest a consumer's runtime actually pulls is signed too,
   not only the one their tag named.
 - **Attestations** — a [SLSA v1](https://slsa.dev/spec/v1.0/provenance)
-  provenance statement, and an SPDX SBOM per executable per platform — are
-  attached to the **published index digest**, and to that alone. They are
-  statements about the release, and the release is the index; a per-platform
-  manifest carries none of its own, and looking for one there finds nothing.
+  provenance statement, and an **SPDX and a CycloneDX document per platform
+  describing the whole image** — are attached to the **published index digest**,
+  and to that alone. They are statements about the release, and the release is
+  the index; a per-platform manifest carries none of its own, and looking for one
+  there finds nothing.
+
+Two things about the attestations changed in the release that adopted the shared
+publishing pipeline (#217), and both are visible to somebody running a command
+this document used to print:
+
+- **The SBOM's subject is the image, not an executable.** It was one SPDX document
+  per executable per platform, each tied to that binary's SHA-256. It is now one
+  SPDX document and one CycloneDX document per platform, each describing every byte
+  in that platform's image — the executables and the
+  [`FileDescriptorSet`](#the-ir-filedescriptorset) alike — assembled from one
+  document per thing that entered the image. That is a strictly larger claim about
+  a strictly larger subject, and a consumer reading an SBOM to find out what is in
+  the image now gets an answer about the image.
+- **They are discoverable as OCI referrers and by no other route.** They were
+  attached under cosign's tag convention as well, which is what let
+  `cosign verify-attestation` find them. They are not any more, so that command
+  reports `no matching attestations` even though the documents are there —
+  cosign looks under the tag convention and they are not under it. The signature
+  is unaffected: it is still in cosign's own layout, and `cosign verify` is
+  unchanged.
 
 Signing is **keyless**: there is no
 avroc public key to obtain or trust. The signing identity is the release workflow
@@ -600,21 +651,36 @@ $ cosign verify \
     ghcr.io/z5labs/avroc:v0
 ```
 
-The same two flags verify the attestations, with the predicate type naming which
-one is wanted — `slsaprovenance1` for the provenance and `spdxjson` for the
-SBOMs:
+`cosign verify-attestation` **does not find the attestations**, and this is worth
+stating rather than leaving a reader to conclude the release did not produce any.
+This document printed a `cosign verify-attestation --type slsaprovenance1` example
+until #217; that command now exits non-zero with `no matching attestations`,
+because it looks for them under cosign's tag convention and they are attached as
+[OCI
+referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)
+alone.
+
+What finds them is a client that speaks referrers, including the fallback tag
+scheme that registries with no referrers API — `ghcr.io` among them — are read
+through:
 
 ```console
-$ cosign verify-attestation --type slsaprovenance1 \
-    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-    --certificate-identity 'https://github.com/z5labs/avroc/.github/workflows/release.yaml@refs/tags/v0.2.0' \
-    ghcr.io/z5labs/avroc:v0.2.0
+$ oras discover ghcr.io/z5labs/avroc:v0.2.0
 ```
 
-Every one of these works identically against a [generator
-image](#avrocs-own-generators) — substitute `ghcr.io/z5labs/avroc-gen-go` — and
-against a digest, which is the reference to verify when the answer has to stay
-true afterwards.
+That lists one referrer per document, each with an artifact type saying which it
+is: `application/vnd.in-toto+json` for the provenance,
+`application/spdx+json` and `application/vnd.cyclonedx+json` for the two SBOMs
+per platform. Each referrer manifest holds one layer, whose
+`org.opencontainers.image.title` annotation names the platform it describes —
+`avroc-linux-amd64.spdx.json` — which is how the right one of several is chosen.
+Pull one by digest with `oras pull`, and anchor it to a digest `cosign verify` has
+already checked rather than to a tag, because a tag moves.
+
+`cosign verify` above and `oras discover` here work identically against a
+[generator image](#avrocs-own-generators) — substitute
+`ghcr.io/z5labs/avroc-gen-go` — and against a digest, which is the reference to use
+when the answer has to stay true afterwards.
 
 Nothing is attached to a **tag**, only ever to a digest. An attestation about a
 name that moves would say nothing, and this is why verifying a moving tag is
@@ -881,7 +947,7 @@ to any of them is a breaking change:
 
 | Guarantee | Value |
 | --- | --- |
-| [The plugin directory](#the-plugin-directory) | `/usr/local/bin`, on `PATH` |
+| [The plugin directory](#the-plugin-directory) | `/usr/local/bin`, on `PATH`; created by the `COPY` that fills it |
 | [The entrypoint](#the-entrypoint) | Is the avroc CLI, and takes its arguments |
 | [The working directory](#the-working-directory) | None: `WorkingDir` is empty, and the caller points it at the mount |
 | [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
@@ -889,16 +955,17 @@ to any of them is a breaking change:
 | [No certificate authorities](#no-certificate-authorities) | Absent; TLS egress verifies against nothing, and plaintext to a collector on the local network is the supported shape |
 | [The `FileDescriptorSet`](#the-ir-filedescriptorset) | `/usr/local/share/avroc/ir.binpb` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
-| [Signatures](#verifying-a-signature) | The published index and each manifest under it are signed; the index digest carries provenance and an SBOM |
+| [Signatures](#verifying-a-signature) | The published index and each manifest under it are signed; the index digest carries provenance and an SBOM per platform, discoverable as OCI referrers |
 | [avroc's own generators](#avrocs-own-generators) | One image each, `FROM` the base, adding one executable and changing nothing else |
 
 Not covered, and explicitly implementation detail. Depending on any of it is
 depending on something that may change in a patch release, with no notice:
 
 - The base image and everything in the filesystem other than the files named
-  above — their existence, their contents and their paths.
+  above — their existence, their contents and their paths. `HOME`'s directory is
+  one of them, and so is the directory the CLI lives in.
 - The path of the `avroc` executable itself, and the literal value of
-  `Entrypoint`.
+  `Entrypoint`. It moved out of the plugin directory in #217 and may move again.
 - The value of `PATH` beyond its containing `/usr/local/bin`, and the value of
   any other environment variable.
 - Layer count, layer ordering, image size, build timestamps and every other
@@ -930,6 +997,22 @@ patch release. What replaces the overlap is that the new invocation works agains
 both the old image and the new one — a `docker run` carrying `-w /work` behaves
 identically on an image that already set it — so a consumer can make the change
 before taking the release rather than after.
+
+Three more withdrawals ship on those terms in #217, and each is here rather than
+only in its own section because a withdrawal is the change a reader of this table
+is most likely to miss. None of them is a path or a value a `FROM` line resolves,
+which is why none takes a new major version:
+
+- The [plugin directory](#the-plugin-directory) is no longer present-and-empty in
+  the base image. Nothing a derived image writes changes, because a `COPY` creates
+  its destination.
+- No directory is [owned by 65532:65532](#what-it-means-for-ownership) any more.
+  Nothing depended on it, and every executable's own ownership and mode are
+  unchanged in substance.
+- `cosign verify-attestation` [no longer finds the
+  attestations](#verifying-a-signature), which is the one of the three a consumer
+  may have automated. `oras discover` is what replaces it, and the *signature*
+  verification this document leans on is untouched.
 
 ## Out of Scope
 
@@ -997,19 +1080,19 @@ found there and what happens to it.
 | --- | --- |
 | _Document shape and stub_ | [#103](https://github.com/z5labs/avroc/issues/103) |
 | _This document_ | [#107](https://github.com/z5labs/avroc/issues/107) |
-| [The plugin directory](#the-plugin-directory) | [#126](https://github.com/z5labs/avroc/issues/126) |
+| [The plugin directory](#the-plugin-directory) | [#126](https://github.com/z5labs/avroc/issues/126), [#217](https://github.com/z5labs/avroc/issues/217) |
 | [The entrypoint](#the-entrypoint) | [#126](https://github.com/z5labs/avroc/issues/126), [#127](https://github.com/z5labs/avroc/issues/127) |
 | [The working directory](#the-working-directory) | [#126](https://github.com/z5labs/avroc/issues/126), [#219](https://github.com/z5labs/avroc/issues/219) |
-| [The user](#the-user) | [#126](https://github.com/z5labs/avroc/issues/126) |
+| [The user](#the-user) | [#126](https://github.com/z5labs/avroc/issues/126), [#217](https://github.com/z5labs/avroc/issues/217) |
 | [No shell](#no-shell) | [#126](https://github.com/z5labs/avroc/issues/126) |
 | [No certificate authorities](#no-certificate-authorities) | [#198](https://github.com/z5labs/avroc/issues/198) |
 | [The IR `FileDescriptorSet`](#the-ir-filedescriptorset) | [#113](https://github.com/z5labs/avroc/issues/113), [#126](https://github.com/z5labs/avroc/issues/126) |
-| [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | [#128](https://github.com/z5labs/avroc/issues/128) |
-| [Verifying a signature](#verifying-a-signature) | [#128](https://github.com/z5labs/avroc/issues/128) |
+| [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | [#128](https://github.com/z5labs/avroc/issues/128), [#217](https://github.com/z5labs/avroc/issues/217) |
+| [Verifying a signature](#verifying-a-signature) | [#128](https://github.com/z5labs/avroc/issues/128), [#217](https://github.com/z5labs/avroc/issues/217) |
 | [avroc's own generators](#avrocs-own-generators) | [#127](https://github.com/z5labs/avroc/issues/127) |
 | [Worked example: adding a generator](#worked-example-adding-a-generator) | [#129](https://github.com/z5labs/avroc/issues/129) |
-| [Compatibility guarantees](#compatibility-guarantees) | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128) |
-| Multi-platform build and publishing — out of scope, see above | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128) |
+| [Compatibility guarantees](#compatibility-guarantees) | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128), [#217](https://github.com/z5labs/avroc/issues/217) |
+| Multi-platform build and publishing — out of scope, see above | [#126](https://github.com/z5labs/avroc/issues/126), [#128](https://github.com/z5labs/avroc/issues/128), [#217](https://github.com/z5labs/avroc/issues/217) |
 | A convenience over this contract, with no spec of its own | [#130](https://github.com/z5labs/avroc/issues/130) |
 | The plugin contract this one is the deployment half of | [#106](https://github.com/z5labs/avroc/issues/106) |
 | Conventions this document follows | [#103](https://github.com/z5labs/avroc/issues/103) |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -544,6 +544,16 @@ digest is the fifth way to name the image:
 | Rolling tag | `latest` | On each release |
 | Digest | `@sha256:…` | Never, by construction |
 
+The family is derived and published by the shared pipeline avroc's images are
+built by, not by this repository, and that is where it is checked — this document's
+table is the requirement and the check that a version implies exactly these four
+tags lives with the code that derives them (#217). What avroc still decides, and
+still checks on every pull request, is whether a commit is a release at all and
+under which version: one canonical version tag at HEAD, no tag or a tag that is not
+a canonical version publishing nothing, two version tags an error, and `+build`
+metadata refused. A reader should not conclude from that split that the table below
+is unenforced, nor that avroc enforces it.
+
 A published full-version tag **MUST NOT** be repointed at a different manifest
 after it is published — not for a rebuild, not for a base-image refresh, not to
 correct a broken release. A release that has to be corrected gets a new version

--- a/internal/tools/trace-propagation/main.go
+++ b/internal/tools/trace-propagation/main.go
@@ -16,7 +16,7 @@
 // by two call sites agreeing.
 //
 //	go run ./internal/tools/trace-propagation -launch \
-//	    -endpoint http://collector:4318 -record /traceparent -- /usr/local/bin/avroc generate
+//	    -endpoint http://collector:4318 -record /traceparent -- /app/avroc generate
 //	go run ./internal/tools/trace-propagation -fetch -tempo http://tempo:3200 -trace <hex>
 //
 // # Why there is a launcher at all

--- a/internal/tools/trace-propagation/main_test.go
+++ b/internal/tools/trace-propagation/main_test.go
@@ -174,7 +174,7 @@ func TestTheModesAreNotInterchangeable(t *testing.T) {
 		"both modes":             {"-launch", "-fetch"},
 		"launch with no command": {"-launch", "-endpoint", "http://collector:4318"},
 		"launch with no endpoint": {
-			"-launch", "--", "/usr/local/bin/avroc", "generate",
+			"-launch", "--", "/app/avroc", "generate",
 		},
 		"fetch with no tempo": {"-fetch", "-trace", "abc123"},
 		"fetch with no trace": {"-fetch", "-tempo", "http://tempo:3200"},

--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,6 @@
         "config:best-practices"
     ],
     "ignorePaths": ["docs/**"],
-    "customManagers": [
-        {
-            "description": "The signing tool the release pipeline installs is pinned as a Go module version in a string literal, which no built-in manager reads",
-            "customType": "regex",
-            "managerFilePatterns": [".dagger/release.go"],
-            "matchStrings": [
-                "//\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>\\S+)[^\"]*\"[^\"]+@(?<currentValue>v[^\"]+)\""
-            ]
-        }
-    ],
     "osvVulnerabilityAlerts": true,
     "schedule": [
         "before 4am"
@@ -82,7 +72,7 @@
             ]
         },
         {
-            "description": "The dagger modules' go.mod files are codegen output, not dependency declarations: `dagger develop` rewrites them wholesale from the Go SDK's template for dagger.json's engineVersion, so anything Renovate raises here is lowered again by the next regeneration. The engine version is the lever that actually moves these requires. Scoped to the generated go.mod files by name, not to the directories holding them, so the custom regex manager on .dagger/release.go keeps running.",
+            "description": "The dagger modules' go.mod files are codegen output, not dependency declarations: `dagger develop` rewrites them wholesale from the Go SDK's template for dagger.json's engineVersion, so anything Renovate raises here is lowered again by the next regeneration. The engine version is the lever that actually moves these requires. Scoped to the generated go.mod files by name, not to the directories holding them: nothing else in .dagger is Renovate-managed today, but a rule that names a directory is one that silently switches off whatever gets added to it, and the custom regex manager this exclusion had to leave running until #217 is the precedent.",
             "matchFileNames": [
                 ".dagger/go.mod",
                 "daggerverse/**/go.mod"


### PR DESCRIPTION
Closes #217

`.dagger/` used to build avroc's published images itself, and roughly 1,900 of its
lines existed for one reason: the Z5Labs standard pipeline's image half produced one
`scratch` image per binary with `/app/<binaryName>` as entrypoint and nothing else,
and avroc's image is a base other people build `FROM` that has to promise a plugin
directory, a `PATH` and a user. The refactored `z5labs` module removes that premise,
so this adopts it and deletes what it was standing in for.

## What moved

| avroc before | now |
| --- | --- |
| `Ci` -> `Z5Labs().GoLib(...)` | `Z5Labs().Go(source).WithLint(...).WithTest(true).Ci` |
| `image.go`'s `image()`, `binaries()` feeding it, `Publish`, `publishIndex` | `Go.App(version, pkg, platforms)` + one `WithFile`; `App.Publish` |
| `WithFile(descriptorSetPath, ...)` | `App.WithFile` with a `Z5Labs.FileDocument` describing it |
| `imageUID`/`imageGID`/`imageUser` + `WithUser` | the archetype's pinned `65532:65532` |
| `WithEnvVariable("PATH", pluginDir)` | the archetype's standardized `PATH` |
| `generatorImage`, `generatorBundleImage`, `PublishGenerator` | `App.WithApp` composition |
| `versionTags`, `publishTags`, `cosign`, `attest`, `provenanceStatement`, `cosignPackage` | `App.Publish`'s tag family, recursive signature and attestations |

`planRelease`, `parseVersion` and the ref reading stayed: whether a commit is a
release is a fact about *this* repository's process, not about publishing.

## Acceptance criteria

- [x] **`Ci` routes through `Z5labs.Go(...).Ci`, `GoLib` gone.** `Fmt`/`Vet`/`Lint`/`Test` still drive the shared `go` module's `Ci` builder unchanged.
- [x] **The base image is a `Go.App` plus its contributions.** `image()`, `publishIndex` and `Publish` deleted; `baseApp` is two calls.
- [x] **The three generator images and the bundle are composition onto the base `App`.** `generatorImage`/`generatorBundleImage`/`PublishGenerator` deleted; `builtinGenerators` survives.
- [x] **`release.go` keeps `planRelease`, `parseVersion` and the ref reading**, loses the other six plus the `cosignPackage` pin. `Release` hands `App.Publish` a version and repositories.
- [x] **`TagScheme` still runs on every pull request**, over the four cases avroc still decides, every expected value a literal.
- [x] **`ImageContract`/`GeneratorImageContract` pass**, and every row that changed is a row `docs/container/SPEC.md` changed too (see below).
- [x] **`regeneration`, `worked-example`, `companion-module`, `tls-egress`, `trace-propagation`, `ir-descriptor-set` all pass** on both platforms, and `example/` comes back byte for byte.
- [x] **Decided where the contract check runs**: a gate *inside* `Release` (`releaseContract`), because devex#393's guarantee that the container a check read is the one that will be pushed holds only within one chained call. `release.yaml`'s two standalone steps are gone; the standalone calls stay for pull requests.
- [x] **`.git` reaches what derives `commit` and not the check stages' source.** `New` takes a `gitDir` (`+defaultPath="/.git"`); `appSource` is the only place it is folded in. `build.yaml` fetches full history.
- [x] **`docs/container/SPEC.md` updated** for the four guarantees that changed and nothing that did not.
- [x] **Breaks called out**, with the SPEC requiring the next *minor* release's notes to name all four.
- [x] **The unexpressible promises re-derived against the landed API.** Nothing filed on devex, nothing worked around in `.dagger/`. Two new ones found — see below.
- [x] **`ir.binpb`'s document is `Z5Labs.FileDocument`**, explicit `MIT`, no invented version.
- [x] **All four devex deps moved to one commit** (`c10a120`). `.dagger/go.mod` untouched by hand and still Renovate-excluded.
- [x] **`main.go`'s and `image.go`'s package comments rewritten** rather than left arguing a case that is now history.
- [x] **`CONTRIBUTING.md` updated** for every `dagger call` that changed.

## Judgment calls

**Generators go through the *generic* `Z5labs.App`, not the Go chain.** `GoChain.App`
names the binary it builds after `go.mod`'s module path, so all four of avroc's
commands would be called `avroc` and three would collide in the plugin directory.
`Z5labs.App(version).WithVariant(platform, binary, doc, name)` is the seam devex#410
exists for and the one the story's own table cites. Cost, stated rather than hidden: a
prebuilt variant is not stamped with `main.version`/`main.commit` and its own image
carries no revision annotation. Neither matters here — avroc's generators declare no
version vars, and the generator *images* are composed onto the base App, whose
annotations are the chain's.

**`Image`, `GeneratorImage` and `GeneratorBundleImage` survive as one-line accessors
onto `App.Container`.** The criterion says delete `Image`. Dagger refuses a function
returning an object type from a dependency module, so an `app` entrypoint threading
the chain out to the CLI is not expressible, and deleting these outright would delete
`dagger call image export --path ./avroc.tar` with no replacement. What the criterion
is about — the hand-rolled `Container` chain, the `binaries()` that fed it, the
credential plumbing and the index assembly — is deleted. `Publish` and
`PublishGenerator` genuinely are gone: the archetype's publish is signed and attested
by construction, and the only caller with an OIDC token is the release workflow.

**`binaries()` survives, re-commented.** It no longer builds anything that goes into
the base image; two callers need a loose executable rather than an image — the
generator Apps above, and `CompanionModule`, which hands executables to the companion
module the way an adopter with no generator image would.

## Two more unexpressible promises, found by re-deriving

Criterion 11 asked for the list to be checked against code rather than taken as
checked once. Two showed up that the story did not anticipate, and both are handled
the way it handles a covered guarantee that changed — in the SPEC, with a
release-notes requirement — rather than worked around in `.dagger/`:

1. **`/usr/local/bin` is no longer present-and-empty in the base image.** The SPEC
   required it, so that a `COPY` into it never depended on the builder creating it.
   `validateContributionPath` refuses any path at, under or over a directory the
   image's `PATH` resolves against — content with no architecture that something can
   find by name is how an arm64 image runs an amd64 binary — and the sanctioned route
   is composition, which for the base would mean shipping a generator in it. So the
   requirement is withdrawn. Nothing a derived image writes changes: every OCI builder
   creates a `COPY`'s destination, and `worked-example` builds and runs the document's
   Dockerfile against the new base with no instruction added.
2. **No directory is owned by `65532:65532` any more.** The plugin directory was, in a
   derived image it is root-owned `0755`. Nothing depended on it — a `COPY` runs as
   root in the builder and `0755` is traversable by every UID — and the *executable's*
   ownership and mode are unchanged in substance.

Neither is a path or value a `FROM` line resolves, so neither takes a new major
version. Both are in the SPEC's withdrawal list beside the two the story already
named (attestation discovery becoming referrers-only, and the SBOM's subject moving
from the executable to the image), and the next minor release's notes must name all
four.

## How it was verified

Every `verify` command from `.claude/backlog.json` passes, and `golangci-lint run`
passes in `.dagger/` too. The Dagger stages cannot run from a git worktree — a
worktree's `.git` is a file, and the archetype needs a real one — so they were run
from a clone of this branch:

| stage | result |
| --- | --- |
| `ci` | pass |
| `regeneration` | pass |
| `image-contract` | pass (both platforms) |
| `generator-image-contract` | pass (both platforms) |
| `tls-egress` | pass |
| `trace-propagation` | pass, negative control included |
| `worked-example` | pass |
| `companion-module` | pass |
| `tag-scheme` | pass |
| `ir-descriptor-set` | pass |

`Release` was exercised both ways without pushing: with no version tag at HEAD it
reports `nothing published`, and with one it runs `releaseContract` to completion over
all four images on both platforms and then fails at the OIDC exchange against a
deliberately dead endpoint — which is the gate passing and the publish refusing a
credential, in that order.

Two bugs the run found and fixed, both worth naming because each would have been
silent:

- `propagationRemoved` built its negative-control `Avroc` from a struct literal
  naming `Source` and `LintConfig`. Adding `GitDir` kept compiling and the control
  panicked on a nil directory a long way from the literal. It copies the receiver now.
- `workedExample.contents()` did not expect a `/usr/local/bin` row, because until now
  the base always had one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
